### PR TITLE
Simplify context and app parameters

### DIFF
--- a/src/AppsClient.js
+++ b/src/AppsClient.js
@@ -26,25 +26,25 @@ class AppsClient {
     return this.http.post(url).send(descriptor).thenJson()
   }
 
-  uninstallApp (account, workspace, vendor, name) {
-    checkRequiredParameters({account, workspace, vendor, name})
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name)}`
+  uninstallApp (account, workspace, app) {
+    checkRequiredParameters({account, workspace, app})
+    const url = `${this.endpointUrl}${this.routes.App(account, workspace, app)}`
 
     return this.http.delete(url).thenJson()
   }
 
-  updateAppSettings (account, workspace, vendor, name, version, settings) {
-    checkRequiredParameters({account, workspace, vendor, name, version, settings})
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
+  updateAppSettings (account, workspace, app, settings) {
+    checkRequiredParameters({account, workspace, app, settings})
+    const url = `${this.endpointUrl}${this.routes.App(account, workspace, app)}`
 
     return this.http.put(url).send({
       settings,
     }).thenJson()
   }
 
-  updateAppTtl (account, workspace, vendor, name, version) {
-    checkRequiredParameters({account, workspace, vendor, name, version})
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
+  updateAppTtl (account, workspace, app) {
+    checkRequiredParameters({account, workspace, app})
+    const url = `${this.endpointUrl}${this.routes.App(account, workspace, app)}`
 
     return this.http.patch(url).thenJson()
   }
@@ -62,9 +62,9 @@ class AppsClient {
     }).thenJson()
   }
 
-  listAppFiles (account, workspace, vendor, name, version, {prefix = '', context = '', nextMarker = ''}) {
-    checkRequiredParameters({account, workspace, vendor, name, version})
-    const url = `${this.endpointUrl}${this.routes.Files(account, workspace, vendor, name, version)}`
+  listAppFiles (account, workspace, app, {prefix = '', context = '', nextMarker = ''}) {
+    checkRequiredParameters({account, workspace, app})
+    const url = `${this.endpointUrl}${this.routes.Files(account, workspace, app)}`
 
     return this.http.get(url).query({
       prefix,
@@ -73,18 +73,18 @@ class AppsClient {
     }).thenJson()
   }
 
-  getAppFile (account, workspace, vendor, name, version, path, context = '') {
-    checkRequiredParameters({account, workspace, vendor, name, version, path})
-    const url = `${this.endpointUrl}${this.routes.File(account, workspace, vendor, name, version, path)}`
+  getAppFile (account, workspace, app, path, context = '') {
+    checkRequiredParameters({account, workspace, app, path})
+    const url = `${this.endpointUrl}${this.routes.File(account, workspace, app, path)}`
 
     return this.http.get(url).query({
       context,
     }).thenJson()
   }
 
-  getApp (account, workspace, vendor, name, version, context = '') {
-    checkRequiredParameters({account, workspace, vendor, name, version})
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, vendor, name, version)}`
+  getApp (account, workspace, app, context = '') {
+    checkRequiredParameters({account, workspace, app})
+    const url = `${this.endpointUrl}${this.routes.App(account, workspace, app)}`
 
     return this.http.get(url).query({
       context,
@@ -106,18 +106,16 @@ AppsClient.prototype.routes = {
     return `/${account}/${workspace}/apps`
   },
 
-  App (account, workspace, vendor, name, version) {
-    return version
-      ? `${this.Apps(account, workspace)}/${vendor}.${name}@${version}`
-      : `${this.Apps(account, workspace)}/${vendor}.${name}`
+  App (account, workspace, app) {
+    return `${this.Apps(account, workspace)}/${app}`
   },
 
-  Files (account, workspace, vendor, name, version) {
-    return `${this.App(account, workspace, vendor, name, version)}/files`
+  Files (account, workspace, app) {
+    return `${this.App(account, workspace, app)}/files`
   },
 
-  File (account, workspace, vendor, name, version, path) {
-    return `${this.Files(account, workspace, vendor, name, version)}/${path}`
+  File (account, workspace, app, path) {
+    return `${this.Files(account, workspace, app)}/${path}`
   },
 
   DependencyMap (account, workspace) {

--- a/src/AppsClient.js
+++ b/src/AppsClient.js
@@ -49,45 +49,45 @@ class AppsClient {
     return this.http.patch(url).thenJson()
   }
 
-  listApps (account, workspace, options = {oldVersion: '', context: '', since: '', service: ''}) {
+  listApps (account, workspace, options = {oldVersion: '', context: [], since: '', service: ''}) {
     checkRequiredParameters({account, workspace})
     const url = `${this.endpointUrl}${this.routes.Apps(account, workspace)}`
     const {oldVersion, context, since, service} = options
 
     return this.http.get(url).query({
       oldVersion,
-      context,
+      context: contextQuery(context),
       since,
       service,
     }).thenJson()
   }
 
-  listAppFiles (account, workspace, app, {prefix = '', context = '', nextMarker = ''}) {
+  listAppFiles (account, workspace, app, {prefix = '', context = [], nextMarker = ''}) {
     checkRequiredParameters({account, workspace, app})
     const url = `${this.endpointUrl}${this.routes.Files(account, workspace, app)}`
 
     return this.http.get(url).query({
       prefix,
-      context,
+      context: contextQuery(context),
       nextMarker,
     }).thenJson()
   }
 
-  getAppFile (account, workspace, app, path, context = '') {
+  getAppFile (account, workspace, app, path, context = []) {
     checkRequiredParameters({account, workspace, app, path})
     const url = `${this.endpointUrl}${this.routes.File(account, workspace, app, path)}`
 
     return this.http.get(url).query({
-      context,
+      context: contextQuery(context),
     }).thenJson()
   }
 
-  getApp (account, workspace, app, context = '') {
+  getApp (account, workspace, app, context = []) {
     checkRequiredParameters({account, workspace, app})
     const url = `${this.endpointUrl}${this.routes.App(account, workspace, app)}`
 
     return this.http.get(url).query({
-      context,
+      context: contextQuery(context),
     }).thenJson()
   }
 
@@ -122,5 +122,7 @@ AppsClient.prototype.routes = {
     return `/${account}/${workspace}/dependencyMap`
   },
 }
+
+const contextQuery = (context) => context ? context.join('/') : context
 
 export default AppsClient


### PR DESCRIPTION
1. The `app` segment of App routes was represented by three parameters (`vendor`, `name` and `version`), one of them optional. Many times all we have is an ID (`vendor.name@version`), which is **exactly** what the API route expects. So, I think that always accepting an ID, either with or without version, makes more sense and cuts one step in most cases, besides looking cleaner.

2. The `context` parameter used to be in the format `vendor.name/vendor.name/vendor.name`. This is how the API expects it, but not how it would be used programmatically. All a client knows about the context is a succession of apps, but not what joins them. Therefore, I believe that accepting an array of apps (`[ 'vendor.name', 'vendor.name', 'vendor.name' ]`) is easier to use.