### PR TITLE
Support app settings

### DIFF
--- a/src/AppsClient.js
+++ b/src/AppsClient.js
@@ -33,13 +33,31 @@ class AppsClient {
     return this.http.delete(url).thenJson()
   }
 
-  updateAppSettings (account, workspace, app, settings) {
-    checkRequiredParameters({account, workspace, app, settings})
-    const url = `${this.endpointUrl}${this.routes.App(account, workspace, app)}`
+  getAppSettings (account, workspace, app, {context = []} = {}) {
+    checkRequiredParameters({account, workspace, app})
+    const url = `${this.endpointUrl}${this.routes.Settings(account, workspace, app)}`
 
-    return this.http.put(url).send({
-      settings,
+    return this.http.get(url).query({
+      context: contextQuery(context),
     }).thenJson()
+  }
+
+  updateAppSettings (account, workspace, app, settings, {context = []} = {}) {
+    checkRequiredParameters({account, workspace, app, settings})
+    const url = `${this.endpointUrl}${this.routes.Settings(account, workspace, app)}`
+
+    return this.http.put(url).query({
+      context: contextQuery(context),
+    }).send(settings).thenJson()
+  }
+
+  patchAppSettings (account, workspace, app, settings, {context = []} = {}) {
+    checkRequiredParameters({account, workspace, app, settings})
+    const url = `${this.endpointUrl}${this.routes.Settings(account, workspace, app)}`
+
+    return this.http.patch(url).query({
+      context: contextQuery(context),
+    }).send(settings).thenJson()
   }
 
   updateAppTtl (account, workspace, app) {
@@ -108,6 +126,10 @@ AppsClient.prototype.routes = {
 
   App (account, workspace, app) {
     return `${this.Apps(account, workspace)}/${app}`
+  },
+
+  Settings (account, workspace, app) {
+    return `${this.App(account, workspace, app)}/settings`
   },
 
   Files (account, workspace, app) {

--- a/src/RegistryClient.js
+++ b/src/RegistryClient.js
@@ -3,7 +3,7 @@ import Promise from 'any-promise'
 import qs from 'querystring'
 import {createReadStream} from 'fs'
 import request, {successful} from './http'
-import getEndpointUrl from './utils/appsEndpoints.js'
+import getEndpointUrl from './utils/apiEndpoints.js'
 import checkRequiredParameters from './utils/required.js'
 
 class RegistryClient {

--- a/src/http.js
+++ b/src/http.js
@@ -55,3 +55,15 @@ Request.prototype.thenJson = function () {
 Request.prototype.thenText = function () {
   return this.then(res => res.text())
 }
+
+Request.prototype.baseQuery = Request.prototype.query
+Request.prototype.query = function (options) {
+  let query = {}
+  for (let key of Object.keys(options)) {
+    let value = options[key]
+    if (value !== undefined && value !== '') {
+      query[key] = value
+    }
+  }
+  return this.baseQuery(query)
+}

--- a/src/http.js
+++ b/src/http.js
@@ -56,7 +56,7 @@ Request.prototype.thenText = function () {
   return this.then(res => res.text())
 }
 
-Request.prototype.baseQuery = Request.prototype.query
+const baseQuery = Request.prototype.query
 Request.prototype.query = function (options) {
   let query = {}
   for (let key of Object.keys(options)) {
@@ -65,5 +65,5 @@ Request.prototype.query = function (options) {
       query[key] = value
     }
   }
-  return this.baseQuery(query)
+  return baseQuery.apply(this, [query])
 }


### PR DESCRIPTION
This implements two new operations: get and patch settings. The patch API is implemented according to the [RFC 7396 - JSON Merge Patch](https://tools.ietf.org/html/rfc7396) specification.

The `PUT` settings operation has also been updated to use its canonical endpoint (`:account/:workspace/apps/:app/settings`).

Furthermore, query string parameters are now only being passed when they are not empty or undefined.