### PR TITLE
Add support for streaming files to VBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The three clients in this library are:
 - AppsClient
 - RegistryClient
 - VBaseClient
+- VTEXIDClient
 
 Usage:
 
@@ -26,3 +27,53 @@ const client = new AppsClient({
 ## Development
 
 Install the dependencies (`npm install`) and run `npm run build`.
+
+
+### Using VBaseClient.sendFile
+
+An example usage of the three supported method of sending a file to VBase:
+
+```
+import {VBaseClient} from '@vtex/api'
+import {createReadStream} from 'fs'
+
+const client = new VBaseClient({
+  authToken: 'test',
+  userAgent: 'test send',
+  endpointUrl: 'BETA',
+})
+
+const read = createReadStream('./test-send.txt')
+
+client.saveFile(
+  'account',
+  'workspace',
+  'bucket',
+  'test-send-stream-gzip.txt',
+  read,
+  {gzip: true}
+).then((res) => {
+  console.log('gz:', res)
+})
+
+client.saveFile(
+  'account',
+  'workspace',
+  'bucket',
+  'test-send-stream.txt',
+  read,
+  {gzip: false}
+).then((res) => {
+  console.log('stream:', res)
+})
+
+client.saveFile(
+  'account',
+  'workspace',
+  'bucket',
+  'test-send-file.txt',
+  './test-send.txt'
+).then((res) => {
+  console.log('file:', res)
+})
+```

--- a/README.md
+++ b/README.md
@@ -43,15 +43,13 @@ const client = new VBaseClient({
   endpointUrl: 'BETA',
 })
 
-const read = createReadStream('./test-send.txt')
-
 client.saveFile(
   'account',
   'workspace',
   'bucket',
   'test-send-stream-gzip.txt',
-  read,
-  {gzip: true}
+  createReadStream('./test-send.txt'),
+  {gzip: true, gzipOptions: {level: 9}}
 ).then((res) => {
   console.log('gz:', res)
 })
@@ -61,7 +59,7 @@ client.saveFile(
   'workspace',
   'bucket',
   'test-send-stream.txt',
-  read,
+  createReadStream('./test-send.txt'),
   {gzip: false}
 ).then((res) => {
   console.log('stream:', res)

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "license": "MIT",
   "dependencies": {
     "any-promise": "^1.3.0",
+    "destroy": "^1.0.4",
     "form-data": "^1.0.0-rc4",
-    "requisition": "^1.7.0"
+    "requisition": "^1.7.0",
+    "statuses": "^1.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/src/VBaseClient.js
+++ b/src/VBaseClient.js
@@ -1,6 +1,9 @@
 import request from './http'
+import Request from 'requisition/lib/request'
 import getEndpointUrl from './utils/vbaseEndpoints.js'
 import checkRequiredParameters from './utils/required.js'
+import {createGzip} from 'zlib'
+import {basename} from 'path'
 
 class VBaseClient {
   constructor ({authToken, userAgent, endpointUrl = getEndpointUrl('STABLE')}) {
@@ -68,11 +71,24 @@ class VBaseClient {
     return this.http.get(url).thenText()
   }
 
-  saveFile (account, workspace, bucket, path, filePath, unzip = false) {
-    checkRequiredParameters({account, workspace, bucket, path, filePath})
+  saveFile (account, workspace, bucket, path, streamOrPath, {unzip, gzip} = {}) {
+    checkRequiredParameters({account, workspace, bucket, path, streamOrPath})
     const url = `${this.endpointUrl}${this.routes.Files(account, workspace, bucket, path)}`
-
-    return this.http.put(url).query({unzip}).sendFile(filePath).thenJson()
+    let put = this.http.put(url)
+    if (streamOrPath.pipe && streamOrPath.on) {
+      put = put.type(basename(path))
+      if (gzip) {
+        const gz = createGzip()
+        return Request.prototype.thenJson.apply(
+          put.set('Content-Encoding', 'gzip').sendStream(streamOrPath.pipe(gz))
+        )
+      }
+      return Request.prototype.thenJson.apply(put.sendStream(streamOrPath))
+    }
+    if (typeof streamOrPath === 'string' || streamOrPath instanceof String) {
+      return put.query({unzip}).sendFile(streamOrPath).thenJson()
+    }
+    throw new Error('Argument streamOrPath must be a readable stream or the path to a file.')
   }
 
   deleteFile (account, workspace, bucket, path) {

--- a/src/http.js
+++ b/src/http.js
@@ -46,13 +46,15 @@ Request.prototype.then = function (resolve, reject) {
   }, reject)
 }
 
+export const handleJson = res => {
+  if (res.is('json')) {
+    return res.json()
+  }
+  return res
+}
+
 Request.prototype.thenJson = function () {
-  return this.then(res => {
-    if (res.is('json')) {
-      return res.json()
-    }
-    return res
-  })
+  return this.then(handleJson)
 }
 
 Request.prototype.thenText = function () {


### PR DESCRIPTION
Example included in the README file:

```
import {VBaseClient} from '@vtex/api'
import {createReadStream} from 'fs'

const client = new VBaseClient({
  authToken: 'test',
  userAgent: 'test send stream',
  endpointUrl: 'BETA',
})

const read = createReadStream('./test-send.txt')

client.saveFile(
  'pilateslovers',
  'guilherme',
  'render',
  'test-send-stream-gzip.txt',
  read,
  {gzip: true}
).then((res) => {
  console.log('gz:', res)
})

client.saveFile(
  'pilateslovers',
  'guilherme',
  'render',
  'test-send-stream.txt',
  read,
  {gzip: false}
).then((res) => {
  console.log('stream:', res)
})

client.saveFile(
  'pilateslovers',
  'guilherme',
  'render',
  'test-send-file.txt',
  './test-send.txt'
).then((res) => {
  console.log('file:', res)
})
```