### PR TITLE
Drop workspace from registry

### DIFF
--- a/src/RegistryClient.js
+++ b/src/RegistryClient.js
@@ -40,7 +40,7 @@ export default class RegistryClient extends Client {
    * @param files An array of {path, contents}, where contents can be a String, a Buffer or a ReadableStream.
    * @return Promise
    */
-  publishApp (account: string, workspace: string, files: Array<File>, isDevelopment?: boolean = false) {
+  publishApp (account: string, workspace: string, files: Array<File>, tag?: string) {
     if (!(files[0] && files[0].path && files[0].contents)) {
       throw new Error('Argument files must be an array of {path, contents}, where contents can be a String, a Buffer or a ReadableStream.')
     }
@@ -63,7 +63,7 @@ export default class RegistryClient extends Client {
       method: 'POST',
       url: routes.Registry(account, workspace),
       data: multipart.pipe(gz),
-      params: {isDevelopment},
+      params: tag ? {tag} : {},
       headers: {
         'Content-Encoding': 'gzip',
         'Content-Type': `multipart/mixed; boundary=${boundary}`,

--- a/src/RegistryClient.js
+++ b/src/RegistryClient.js
@@ -16,16 +16,16 @@ type File = {
 const CURRENT_MAJOR_VND = 'application/vnd.vtex.sppa.v4+json'
 
 const routes = {
-  Registry: (account: string, workspace: string) =>
-    `/${account}/${workspace}/registry`,
+  Registry: (account: string) =>
+    `/${account}/master/registry`,
 
-  Vendor: (account: string, workspace: string, vendor: string) =>
-    `${routes.Registry(account, workspace)}/${vendor}/apps`,
+  Vendor: (account: string, vendor: string) =>
+    `${routes.Registry(account)}/${vendor}/apps`,
 
-  App: (account: string, workspace: string, vendor: string, name: string, version?: string) =>
+  App: (account: string, vendor: string, name: string, version?: string) =>
     version
-    ? `${routes.Vendor(account, workspace, vendor)}/${name}/${version}`
-    : `${routes.Vendor(account, workspace, vendor)}/${name}`,
+    ? `${routes.Vendor(account, vendor)}/${name}/${version}`
+    : `${routes.Vendor(account, vendor)}/${name}`,
 }
 
 export default class RegistryClient extends Client {
@@ -36,11 +36,10 @@ export default class RegistryClient extends Client {
   /**
    * Sends an app as a streaming, gzipped multipart/mixed HTTP POST request.
    * @param account
-   * @param workspace
    * @param files An array of {path, contents}, where contents can be a String, a Buffer or a ReadableStream.
    * @return Promise
    */
-  publishApp (account: string, workspace: string, files: Array<File>, tag?: string) {
+  publishApp (account: string, files: Array<File>, tag?: string) {
     if (!(files[0] && files[0].path && files[0].contents)) {
       throw new Error('Argument files must be an array of {path, contents}, where contents can be a String, a Buffer or a ReadableStream.')
     }
@@ -61,7 +60,7 @@ export default class RegistryClient extends Client {
     const gz = createGzip()
     return this.http({
       method: 'POST',
-      url: routes.Registry(account, workspace),
+      url: routes.Registry(account),
       data: multipart.pipe(gz),
       params: tag ? {tag} : {},
       headers: {
@@ -71,7 +70,7 @@ export default class RegistryClient extends Client {
     })
   }
 
-  publishAppPatch (account: string, workspace: string, vendor: string, name: string, version: string, changes: any) {
+  publishAppPatch (account: string, vendor: string, name: string, version: string, changes: any) {
     const gz = createGzip()
     const stream = new Stream.Readable()
     stream.push(JSON.stringify(changes))
@@ -79,7 +78,7 @@ export default class RegistryClient extends Client {
     return this.http({
       method: 'PATCH',
       data: stream.pipe(gz),
-      url: routes.App(account, workspace, vendor, name, version),
+      url: routes.App(account, vendor, name, version),
       headers: {
         'Content-Encoding': 'gzip',
         'Content-Type': 'application/json',
@@ -87,23 +86,23 @@ export default class RegistryClient extends Client {
     })
   }
 
-  listVendors (account: string, workspace: string) {
-    return this.http(routes.Registry(account, workspace))
+  listVendors (account: string) {
+    return this.http(routes.Registry(account))
   }
 
-  listAppsByVendor (account: string, workspace: string, vendor: string) {
-    return this.http(routes.Vendor(account, workspace, vendor))
+  listAppsByVendor (account: string, vendor: string) {
+    return this.http(routes.Vendor(account, vendor))
   }
 
-  listVersionsByApp (account: string, workspace: string, vendor: string, name: string) {
-    return this.http(routes.App(account, workspace, vendor, name))
+  listVersionsByApp (account: string, vendor: string, name: string) {
+    return this.http(routes.App(account, vendor, name))
   }
 
-  getAppManifest (account: string, workspace: string, vendor: string, name: string, version: string) {
-    return this.http(routes.App(account, workspace, vendor, name, version))
+  getAppManifest (account: string, vendor: string, name: string, version: string) {
+    return this.http(routes.App(account, vendor, name, version))
   }
 
-  unpublishApp (account: string, workspace: string, vendor: string, name: string, version: string) {
-    return this.http.delete(routes.App(account, workspace, vendor, name, version))
+  unpublishApp (account: string, vendor: string, name: string, version: string) {
+    return this.http.delete(routes.App(account, vendor, name, version))
   }
 }

--- a/src/RegistryClient.test.js
+++ b/src/RegistryClient.test.js
@@ -39,7 +39,7 @@ test('publishApp streams a multipart/mixed request', async t => {
   t.plan(5)
   const requestHandler = (req, res) => {
     t.true(req.headers['content-type'].startsWith('multipart/mixed'))
-    t.is(req.url, '/account/workspace/registry?isDevelopment=false')
+    t.is(req.url, '/account/workspace/registry')
     t.is(req.headers['content-encoding'], 'gzip')
     t.is(req.headers['transfer-encoding'], 'chunked')
     let data = ''

--- a/src/RegistryClient.test.js
+++ b/src/RegistryClient.test.js
@@ -39,7 +39,7 @@ test('publishApp streams a multipart/mixed request', async t => {
   t.plan(5)
   const requestHandler = (req, res) => {
     t.true(req.headers['content-type'].startsWith('multipart/mixed'))
-    t.is(req.url, '/account/workspace/registry')
+    t.is(req.url, '/account/master/registry')
     t.is(req.headers['content-encoding'], 'gzip')
     t.is(req.headers['transfer-encoding'], 'chunked')
     let data = ''
@@ -60,7 +60,7 @@ test('publishApp streams a multipart/mixed request', async t => {
   const client = new RegistryClient('http://localhost:13377', options)
   const server = createServer(requestHandler)
   server.listen(13377)
-  await client.publishApp('account', 'workspace', [jsFile, manifest], false)
+  await client.publishApp('account', [jsFile, manifest], false)
   server.close()
 })
 
@@ -78,7 +78,7 @@ test('publishAppPatch sends changes array', async t => {
     t.is(req.headers['content-type'], 'application/json')
     t.is(req.headers['content-encoding'], 'gzip')
     t.is(req.headers['transfer-encoding'], 'chunked')
-    t.is(req.url, '/account/workspace/registry/vtex/apps/app/version')
+    t.is(req.url, '/account/master/registry/vtex/apps/app/version')
     let data = ''
     const gz = createGunzip()
     req.pipe(gz)
@@ -96,6 +96,6 @@ test('publishAppPatch sends changes array', async t => {
   const client = new RegistryClient('http://localhost:13378', options)
   const server = createServer(requestHandler)
   server.listen(13378)
-  await client.publishAppPatch('account', 'workspace', 'vtex', 'app', 'version', changes)
+  await client.publishAppPatch('account', 'vtex', 'app', 'version', changes)
   server.close()
 })


### PR DESCRIPTION
The apps server changed the registry to only support `master` workspace. This change also introduced support to version tags.

**Breaking changes:**
* Publish app method had `isDevelopment: bool` parameter replaced with `tag: string`.
* Registry operations have one less parameter, `workspace`.