### PR TITLE
Add a colossus client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ### SublimeText ###
 *.sublime-workspace
 
+### VSCode ###
+.vscode
+
 ### OSX ###
 .DS_Store
 .AppleDouble

--- a/src/Colossus.js
+++ b/src/Colossus.js
@@ -1,0 +1,30 @@
+/* @flow */
+import {createClient, createWorkspaceURL} from './baseClient'
+import type {InstanceOptions} from './baseClient'
+
+const routes = {
+  Event: (sender: string, subject: string, route: string) =>
+    `/events/${sender}/${subject}/${route}`,
+
+  Log: (sender: string, subject: string, level: string) =>
+    `/logs/${sender}/${subject}/${level}`,
+}
+
+export type ColossusInstance = {
+  sendLog: (sender: string, subject: string, message: {}, level: string) => any,
+  sendEvent: (sender: string, subject: string, route: string, message: {}) => any,
+}
+
+export default function Colossus (opts: InstanceOptions): ColossusInstance {
+  const client = createClient({...opts, baseURL: createWorkspaceURL('colossus', opts)})
+
+  return {
+    sendLog: (sender: string, subject: string, message: {}, level: string) => {
+      return client.post(routes.Log(sender, subject, level), message)
+    },
+
+    sendEvent: (sender: string, subject: string, route: string, message: {}) => {
+      return client.post(routes.Event(sender, subject, route), message)
+    },
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import Router from './Router.js'
 import VBase from './VBase.js'
 import ID from './ID.js'
 import Workspaces from './Workspaces.js'
+import Colossus from './Colossus.js'
 
 module.exports = {
   Apps,
@@ -14,4 +15,5 @@ module.exports = {
   VBase,
   ID,
   Workspaces,
+  Colossus,
 }


### PR DESCRIPTION
`render-builder` currently contains code to access Colossus that is very similar to other clients here in `node-vtex-api`, as can be seen [here](https://github.com/vtex/render-builder/blob/master/service/colossus/index.ts).

I currently need to use the same code in another app (`masterdata-graphql`), so it's best to move that logic here and have it be shared with anyone that needs it too.

I've tested it by manually running the client in node's terminal and making `sendLog` and `sendEvent` requests. It all seems to be working as expected.