### PR TITLE
Add cache with revalidation by etag

### DIFF
--- a/src/HttpClient/axios.ts
+++ b/src/HttpClient/axios.ts
@@ -1,0 +1,27 @@
+import axios, {AxiosInstance} from 'axios'
+import * as retry from 'axios-retry'
+
+export const createInstance = (baseURL: string, headers: Record<string, string>, timeout: number): AxiosInstance => {
+  const http = axios.create({
+    baseURL,
+    headers,
+    timeout,
+    validateStatus: status => (status >= 200 && status < 300) || status === 304,
+  })
+  retry(http)
+  http.interceptors.response.use(response => response, (err: any) => {
+    if (err.response && err.response.config) {
+      const {url, method} = err.response.config
+      console.log(`Error calling ${method.toUpperCase()} ${url}`)
+    }
+    try {
+      delete err.response.request
+      delete err.response.config
+      delete err.config.res
+      delete err.config.data
+    } catch (e) {}
+    return Promise.reject(err)
+  })
+
+  return http
+}

--- a/src/HttpClient/cache.ts
+++ b/src/HttpClient/cache.ts
@@ -1,0 +1,52 @@
+import {AxiosInstance, AxiosResponse, AxiosRequestConfig} from 'axios'
+
+const EMPTY = {}
+
+const successOrNotModified = (status: number): boolean =>
+  status >= 200 && status < 300 || status === 304
+
+export const addCacheInterceptors = (http: AxiosInstance, cacheStorage: CacheStorage) => {
+  http.interceptors.request.use((config: CacheableRequestConfig) => {
+    if (config.cacheable) {
+      const {etag, response} = cacheStorage.get(config.url) || EMPTY
+      if (etag) {
+        config.headers['if-none-match'] = etag
+        config.cached = response
+        config.validateStatus = successOrNotModified
+      }
+    }
+
+    return config
+  })
+
+  http.interceptors.response.use((response: CacheableResponse) => {
+    const {status, data, headers, config} = response
+    if (status === 304) {
+      return config.cached
+    }
+
+    if (headers.etag) {
+      cacheStorage.set(config.url, {
+        etag: headers.etag,
+        response: {data, headers},
+      })
+    }
+
+    return response
+  })
+}
+
+export interface CacheStorage {
+  get<T> (key: string): T
+  set (key: string, value: any): void
+}
+
+export type CacheableRequestConfig = AxiosRequestConfig & {
+  url: string,
+  cacheable: boolean,
+  cached?: any,
+}
+
+type CacheableResponse = AxiosResponse & {
+  config: CacheableRequestConfig,
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "compilerOptions": {
-    "types": [
-      "node"
-    ],
     "target": "es2015",
     "module": "commonjs",
     "strict": true,


### PR DESCRIPTION
The objective is not to implement full HTTP Cache specification as described in [RFC 7234](https://tools.ietf.org/html/rfc7234)

It is just an use case of HTTP Cache, and the only one that matters right now, as our infrastructure is based on cache revalidation.