### PR TITLE
Remove unnecessary console.log

### DIFF
--- a/src/HttpClient/axios.ts
+++ b/src/HttpClient/axios.ts
@@ -12,7 +12,6 @@ export const createInstance = (baseURL: string, headers: Record<string, string>,
   http.interceptors.response.use(response => response, (err: any) => {
     if (err.response && err.response.config) {
       const {url, method} = err.response.config
-      console.log(`Error calling ${method.toUpperCase()} ${url}`)
     }
     try {
       delete err.response.request


### PR DESCRIPTION
An API client library should not console.log errors. This is the reason behind these non user friendly messages on toobelt:

<img width="583" alt="screen shot 2017-09-14 at 13 08 17" src="https://user-images.githubusercontent.com/5302127/30440882-2ea99198-994e-11e7-8915-51d9b2c4a09f.png">
