### PR TITLE
Automatic x-vtex-meta headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.38.0-beta.4",
+  "version": "0.38.0-beta.5",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.38.0-beta.3",
+  "version": "0.38.0-beta.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.37.1",
+  "version": "0.38.0-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.38.0-beta.2",
+  "version": "0.38.0-beta.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.38.0-beta.5",
+  "version": "0.38.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.38.0-beta",
+  "version": "0.38.0-beta.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.38.0-beta.0",
+  "version": "0.38.0-beta.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.38.0-beta.1",
+  "version": "0.38.0-beta.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/Apps.ts
+++ b/src/Apps.ts
@@ -4,7 +4,7 @@ import {IncomingMessage} from 'http'
 import {Readable, Writable} from 'stream'
 import {stringify} from 'qs'
 
-import {HttpClient, InstanceOptions} from './HttpClient'
+import {HttpClient, InstanceOptions, IOContext} from './HttpClient'
 import {AppManifest, AppFilesList} from './responses'
 
 const routes = {
@@ -48,8 +48,8 @@ const paramsSerializer = (params: any) => {
 export class Apps {
   private http: HttpClient
 
-  constructor (opts: InstanceOptions) {
-    this.http = HttpClient.forWorkspace('apps', opts)
+  constructor (ioContext: IOContext, opts: InstanceOptions = {}) {
+    this.http = HttpClient.forWorkspace('apps', ioContext, opts)
   }
 
   installApp = (descriptor: string, registry: string) => {

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -1,6 +1,6 @@
 import * as archiver from 'archiver'
 
-import {HttpClient, InstanceOptions} from './HttpClient'
+import {HttpClient, InstanceOptions, IOContext} from './HttpClient'
 import {File} from './Registry'
 import {Change} from './Apps'
 
@@ -18,8 +18,8 @@ export class Builder {
   private http: HttpClient
   private stickyHost!: string
 
-  constructor (opts: InstanceOptions) {
-    this.http = HttpClient.forWorkspace('builder-hub.vtex', opts)
+  constructor (ioContext: IOContext, opts: InstanceOptions = {}) {
+    this.http = HttpClient.forWorkspace('builder-hub.vtex', ioContext, opts)
   }
 
   public publishApp = (app: string, files: File[], tag?: string) => {

--- a/src/Colossus.ts
+++ b/src/Colossus.ts
@@ -1,4 +1,4 @@
-import {HttpClient, InstanceOptions} from './HttpClient'
+import {HttpClient, InstanceOptions, IOContext} from './HttpClient'
 
 const routes = {
   Event: (route: string) => `/events/${route}`,
@@ -8,8 +8,8 @@ const routes = {
 export class Colossus {
   private http: HttpClient
 
-  constructor (opts: InstanceOptions) {
-    this.http = HttpClient.forWorkspace('colossus', opts)
+  constructor (ioContext: IOContext, opts: InstanceOptions = {}) {
+    this.http = HttpClient.forWorkspace('colossus', ioContext, opts)
   }
 
   sendLog = (subject: string, message: any, level: string) => {

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -45,17 +45,17 @@ export class HttpClient {
   }
 
   static forWorkspace (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
-    const {authToken, userAgent} = context
+    const {authToken, userAgent, recorder} = context
     const {timeout, cacheStorage} = opts
     const baseURL = workspaceURL(service, context)
-    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, cacheStorage})
+    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage})
   }
 
   static forRoot (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
-    const {authToken, userAgent} = context
+    const {authToken, userAgent, recorder} = context
     const {timeout, cacheStorage} = opts
     const baseURL = rootURL(service, context)
-    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, cacheStorage})
+    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage})
   }
 
   static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -35,12 +35,12 @@ export class HttpClient {
     }
 
     this.http = createInstance(baseURL, headers, timeout)
-    if (cacheStorage) {
-      addCacheInterceptors(this.http, cacheStorage)
-    }
-
     if (recorder) {
       addRecorderInterceptors(this.http, recorder)
+    }
+
+    if (cacheStorage) {
+      addCacheInterceptors(this.http, cacheStorage)
     }
   }
 

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -1,37 +1,34 @@
 import {AxiosInstance, AxiosRequestConfig} from 'axios'
 import {createInstance} from './axios'
 import {addCacheInterceptors, CacheableRequestConfig, CacheStorage} from './cache'
+import {Recorder, addRecorderInterceptors} from './recorder'
 import {IncomingMessage} from 'http'
 
 const DEFAULT_TIMEOUT_MS = 10000
 const noTransforms = [(data: any) => data]
 
-const rootURL = (service: string, {region, endpoint}: InstanceOptions): string => {
-  if (endpoint) {
-    return 'http://' + endpoint
-  }
-
+const rootURL = (service: string, {region}: IOContext): string => {
   if (region) {
     return `http://${service}.${region}.vtex.io`
   }
 
-  throw new Error('Missing required: should specify either {region} or {endpoint}')
+  throw new Error('Region required')
 }
 
-const workspaceURL = (service: string, opts: InstanceOptions): string => {
-  const {account, workspace} = opts
+const workspaceURL = (service: string, context: IOContext): string => {
+  const {account, workspace} = context
   if (!account || !workspace) {
     throw new Error('Missing required arguments: {account, workspace}')
   }
 
-  return rootURL(service, opts) + `/${account}/${workspace}`
+  return rootURL(service, context) + `/${account}/${workspace}`
 }
 
 export class HttpClient {
   private http: AxiosInstance
 
   private constructor (opts: ClientOptions) {
-    const {baseURL, authToken, authType, cacheStorage, userAgent, timeout = DEFAULT_TIMEOUT_MS} = opts
+    const {baseURL, authToken, authType, cacheStorage, recorder, userAgent, timeout = DEFAULT_TIMEOUT_MS} = opts
     const headers = {
       Authorization: `${authType} ${authToken}`,
       'User-Agent': userAgent,
@@ -41,17 +38,23 @@ export class HttpClient {
     if (cacheStorage) {
       addCacheInterceptors(this.http, cacheStorage)
     }
+
+    if (recorder) {
+      addRecorderInterceptors(this.http, recorder)
+    }
   }
 
-  static forWorkspace (service: string, opts: InstanceOptions): HttpClient {
-    const {authToken, userAgent, timeout, cacheStorage} = opts
-    const baseURL = workspaceURL(service, opts)
+  static forWorkspace (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
+    const {authToken, userAgent} = context
+    const {timeout, cacheStorage} = opts
+    const baseURL = workspaceURL(service, context)
     return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, cacheStorage})
   }
 
-  static forRoot (service: string, opts: InstanceOptions): HttpClient {
-    const {authToken, userAgent, timeout, cacheStorage} = opts
-    const baseURL = rootURL(service, opts)
+  static forRoot (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
+    const {authToken, userAgent} = context
+    const {timeout, cacheStorage} = opts
+    const baseURL = rootURL(service, context)
     return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, cacheStorage})
   }
 
@@ -103,13 +106,18 @@ export class HttpClient {
 
 export type CacheStorage = CacheStorage
 
-export type InstanceOptions = {
+export type Recorder = Recorder
+
+export type IOContext = {
   authToken: string,
   userAgent: string,
   account: string,
   workspace: string,
-  region?: string,
-  endpoint?: string,
+  recorder?: Recorder,
+  region: string,
+}
+
+export type InstanceOptions = {
   timeout?: number,
   cacheStorage?: CacheStorage,
 }
@@ -139,5 +147,6 @@ type ClientOptions = {
   userAgent: string
   baseURL: string,
   timeout?: number,
+  recorder?: Recorder,
   cacheStorage?: CacheStorage,
 }

--- a/src/HttpClient/recorder.ts
+++ b/src/HttpClient/recorder.ts
@@ -4,6 +4,11 @@ export const addRecorderInterceptors = (http: AxiosInstance, recorder: Recorder)
   http.interceptors.response.use((response: AxiosResponse) => {
     recorder(response.headers)
     return response
+  }, (err: any) => {
+    if (err.response && err.response.headers && err.response.status === 404) {
+      recorder(err.response.headers)
+    }
+    return Promise.reject(err)
   })
 }
 

--- a/src/HttpClient/recorder.ts
+++ b/src/HttpClient/recorder.ts
@@ -2,7 +2,7 @@ import {AxiosInstance, AxiosResponse} from 'axios'
 
 export const addRecorderInterceptors = (http: AxiosInstance, recorder: Recorder) => {
   http.interceptors.response.use((response: AxiosResponse) => {
-    recorder(response)
+    recorder(response.headers)
     return response
   })
 }

--- a/src/HttpClient/recorder.ts
+++ b/src/HttpClient/recorder.ts
@@ -1,0 +1,12 @@
+import {AxiosInstance, AxiosResponse} from 'axios'
+
+export const addRecorderInterceptors = (http: AxiosInstance, recorder: Recorder) => {
+  http.interceptors.response.use((response: AxiosResponse) => {
+    recorder(response.headers)
+    return response
+  })
+}
+
+export interface Recorder {
+  (headers: any): void
+}

--- a/src/HttpClient/recorder.ts
+++ b/src/HttpClient/recorder.ts
@@ -2,7 +2,7 @@ import {AxiosInstance, AxiosResponse} from 'axios'
 
 export const addRecorderInterceptors = (http: AxiosInstance, recorder: Recorder) => {
   http.interceptors.response.use((response: AxiosResponse) => {
-    recorder(response.headers)
+    recorder(response)
     return response
   })
 }

--- a/src/Metadata.ts
+++ b/src/Metadata.ts
@@ -1,4 +1,4 @@
-import { HttpClient, InstanceOptions } from './HttpClient'
+import { HttpClient, InstanceOptions, IOContext } from './HttpClient'
 import { BucketMetadata } from './responses'
 
 const appId = process.env.VTEX_APP_ID
@@ -24,11 +24,11 @@ export type MetadataEntryList = {
 export class Metadata {
   private http: HttpClient
 
-  constructor (opts: InstanceOptions) {
+  constructor (ioContext: IOContext, opts: InstanceOptions = {}) {
     if (runningAppName === '') {
       throw new Error(`Invalid path to access Metadata. Variable VTEX_APP_ID is not available.`)
     }
-    this.http = HttpClient.forWorkspace('router', opts)
+    this.http = HttpClient.forWorkspace('router', ioContext, opts)
   }
 
   getBuckets = (bucket: string) => {

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -4,7 +4,7 @@ import {createGunzip} from 'zlib'
 import {Readable, Writable} from 'stream'
 import {IncomingMessage} from 'http'
 
-import {HttpClient, InstanceOptions} from './HttpClient'
+import {HttpClient, InstanceOptions, IOContext} from './HttpClient'
 import {DEFAULT_WORKSPACE} from './constants'
 import {AppManifest, AppFilesList} from './responses'
 
@@ -23,8 +23,8 @@ const routes = {
 export class Registry {
   private http: HttpClient
 
-  constructor (opts: InstanceOptions) {
-    this.http = HttpClient.forWorkspace('apps', {...opts, workspace: DEFAULT_WORKSPACE})
+  constructor (ioContext: IOContext, opts: InstanceOptions = {}) {
+    this.http = HttpClient.forWorkspace('apps', {...ioContext, workspace: DEFAULT_WORKSPACE}, opts)
   }
 
   publishApp = async (files: File[], tag?: string) => {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -1,4 +1,4 @@
-import {HttpClient, InstanceOptions} from './HttpClient'
+import {HttpClient, InstanceOptions, IOContext} from './HttpClient'
 
 const routes = {
   AvailableServices: '/_services',
@@ -14,10 +14,10 @@ export class Router {
   private account: string
   private workspace: string
 
-  constructor (opts: InstanceOptions) {
-    this.account = opts.account
-    this.workspace = opts.workspace
-    this.http = HttpClient.forRoot('router', opts)
+  constructor (ioContext: IOContext, opts: InstanceOptions) {
+    this.account = ioContext.account
+    this.workspace = ioContext.workspace
+    this.http = HttpClient.forRoot('router', ioContext, opts)
   }
 
   listAvailableIoVersions = () => {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -14,7 +14,7 @@ export class Router {
   private account: string
   private workspace: string
 
-  constructor (ioContext: IOContext, opts: InstanceOptions) {
+  constructor (ioContext: IOContext, opts: InstanceOptions = {}) {
     this.account = ioContext.account
     this.workspace = ioContext.workspace
     this.http = HttpClient.forRoot('router', ioContext, opts)

--- a/src/VBase.ts
+++ b/src/VBase.ts
@@ -23,7 +23,7 @@ const isVBaseOptions = (opts?: string | VBaseOptions): opts is VBaseOptions => {
 export class VBase {
   private http: HttpClient
 
-  constructor (ioContext: IOContext, opts: InstanceOptions) {
+  constructor (ioContext: IOContext, opts: InstanceOptions = {}) {
     if (runningAppName === '') {
       throw new Error(`Invalid path to access Vbase. Variable VTEX_APP_ID is not available.`)
     }

--- a/src/VBase.ts
+++ b/src/VBase.ts
@@ -4,7 +4,7 @@ import * as mime from 'mime-types'
 import { Readable } from 'stream'
 import { IncomingMessage } from 'http'
 
-import { HttpClient, InstanceOptions } from './HttpClient'
+import { HttpClient, InstanceOptions, IOContext } from './HttpClient'
 import { BucketMetadata, FileListItem } from './responses'
 
 const appId = process.env.VTEX_APP_ID
@@ -23,11 +23,11 @@ const isVBaseOptions = (opts?: string | VBaseOptions): opts is VBaseOptions => {
 export class VBase {
   private http: HttpClient
 
-  constructor (opts: InstanceOptions) {
+  constructor (ioContext: IOContext, opts: InstanceOptions) {
     if (runningAppName === '') {
       throw new Error(`Invalid path to access Vbase. Variable VTEX_APP_ID is not available.`)
     }
-    this.http = HttpClient.forWorkspace('vbase', opts)
+    this.http = HttpClient.forWorkspace('vbase', ioContext, opts)
   }
 
   getBucket = (bucket: string) => {

--- a/src/Workspaces.ts
+++ b/src/Workspaces.ts
@@ -1,4 +1,4 @@
-import {HttpClient, InstanceOptions} from './HttpClient'
+import {HttpClient, InstanceOptions, IOContext} from './HttpClient'
 import {DEFAULT_WORKSPACE} from './constants'
 
 const routes = {
@@ -10,8 +10,8 @@ const routes = {
 export class Workspaces {
   private http: HttpClient
 
-  constructor (opts: InstanceOptions) {
-    this.http = HttpClient.forRoot('router', opts)
+  constructor (ioContext: IOContext, opts: InstanceOptions) {
+    this.http = HttpClient.forRoot('router', ioContext, opts)
   }
 
   list = (account: string) => {

--- a/src/Workspaces.ts
+++ b/src/Workspaces.ts
@@ -10,7 +10,7 @@ const routes = {
 export class Workspaces {
   private http: HttpClient
 
-  constructor (ioContext: IOContext, opts: InstanceOptions) {
+  constructor (ioContext: IOContext, opts: InstanceOptions = {}) {
     this.http = HttpClient.forRoot('router', ioContext, opts)
   }
 


### PR DESCRIPTION
This PR creates a new way to construct clients, directly from `ctx.vtex`. It also adds an interceptor (`recorder`) that will receive response headers and do anything with that. It will be used to add `x-vtex-meta` headers to app response.

Related: https://github.com/vtex/service-runtime-node/pull/33