### PR TITLE
Extend forLegacy factory method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.40.7-beta.0",
+  "version": "0.40.7-beta.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.40.6",
+  "version": "0.40.7-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.40.7-beta",
+  "version": "0.40.7-beta.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -34,7 +34,7 @@ export class HttpClient {
   private constructor (opts: ClientOptions) {
     const {baseURL, authToken, authType, cacheStorage, recorder, userAgent, timeout = DEFAULT_TIMEOUT_MS} = opts
 
-    const headers = authType === AuthType.outbound ? {
+    const headers = authType === AuthType.vtexIdclientAutCookie ? {
       'Proxy-Authorization': authToken,
       VtexIdclientAutCookie: authToken,
     } : {
@@ -67,14 +67,8 @@ export class HttpClient {
   }
 
   static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {
-    const {authToken, userAgent, timeout, cacheStorage} = opts
-    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage})
-  }
-
-  static forOutbound (endpoint: string, context: IOContext, opts: InstanceOptions): HttpClient {
-    const {authToken, userAgent, recorder} = context
-    const {timeout, cacheStorage} = opts
-    return new HttpClient({baseURL: endpoint, authType: AuthType.outbound, authToken, userAgent, timeout, cacheStorage})
+    const {authToken, userAgent, timeout, cacheStorage, authType} = opts
+    return new HttpClient({baseURL: endpoint, authType, authToken, userAgent, timeout, cacheStorage})
   }
 
   get = <T = any>(url: string, config: AxiosRequestConfig = {}): Promise<T> => {
@@ -144,6 +138,7 @@ export type InstanceOptions = {
 
 export type LegacyInstanceOptions = {
   authToken: string,
+  authType: AuthType,
   userAgent: string,
   timeout?: number,
   accept?: string,
@@ -156,10 +151,10 @@ export interface IOResponse<T> {
   status: number
 }
 
-enum AuthType {
+export enum AuthType {
   bearer = 'bearer',
   token = 'token',
-  outbound = 'outbound',
+  vtexIdclientAutCookie = 'vtexIdclientAutCookie',
 }
 
 type ClientOptions = {

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -65,7 +65,7 @@ export class HttpClient {
 
   static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {
     const {timeout, cacheStorage, headers} = opts
-    return new HttpClient({baseURL: endpoint, timeout, cacheStorage})
+    return new HttpClient({baseURL: endpoint, timeout, cacheStorage, headers})
   }
 
   get = <T = any>(url: string, config: AxiosRequestConfig = {}): Promise<T> => {

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -33,7 +33,11 @@ export class HttpClient {
 
   private constructor (opts: ClientOptions) {
     const {baseURL, authToken, authType, cacheStorage, recorder, userAgent, timeout = DEFAULT_TIMEOUT_MS} = opts
-    const headers = {
+
+    const headers = authType === AuthType.outbound ? {
+      'Proxy-Authorization': authToken,
+      VtexIdclientAutCookie: authToken,
+    } : {
       Authorization: `${authType} ${authToken}`,
       'User-Agent': userAgent,
     }
@@ -65,6 +69,12 @@ export class HttpClient {
   static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {
     const {authToken, userAgent, timeout, cacheStorage} = opts
     return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage})
+  }
+
+  static forOutbound (endpoint: string, context: IOContext, opts: InstanceOptions): HttpClient {
+    const {authToken, userAgent, recorder} = context
+    const {timeout, cacheStorage} = opts
+    return new HttpClient({baseURL: endpoint, authType: AuthType.outbound, authToken, userAgent, timeout, cacheStorage})
   }
 
   get = <T = any>(url: string, config: AxiosRequestConfig = {}): Promise<T> => {
@@ -149,6 +159,7 @@ export interface IOResponse<T> {
 enum AuthType {
   bearer = 'bearer',
   token = 'token',
+  outbound = 'outbound',
 }
 
 type ClientOptions = {

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -32,14 +32,11 @@ export class HttpClient {
   private http: AxiosInstance
 
   private constructor (opts: ClientOptions) {
-    const {baseURL, authToken, authType, cacheStorage, recorder, userAgent, timeout = DEFAULT_TIMEOUT_MS} = opts
+    const {baseURL, authToken, cacheStorage, recorder, userAgent, timeout = DEFAULT_TIMEOUT_MS} = opts
 
-    const headers = authType === AuthType.vtexIdclientAutCookie ? {
-      'Proxy-Authorization': authToken,
-      VtexIdclientAutCookie: authToken,
-    } : {
-      Authorization: `${authType} ${authToken}`,
-      'User-Agent': userAgent,
+    const headers = opts.headers || {
+      Authorization: `bearer ${authToken}`,
+      'User-Agent': `${userAgent}`,
     }
 
     this.http = createInstance(baseURL, headers, timeout)
@@ -56,19 +53,19 @@ export class HttpClient {
     const {authToken, userAgent, recorder} = context
     const {timeout, cacheStorage} = opts
     const baseURL = workspaceURL(service, context, opts)
-    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage})
+    return new HttpClient({baseURL, authToken, userAgent, timeout, recorder, cacheStorage})
   }
 
   static forRoot (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
     const {authToken, userAgent, recorder} = context
     const {timeout, cacheStorage} = opts
     const baseURL = rootURL(service, context, opts)
-    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage})
+    return new HttpClient({baseURL, authToken, userAgent, timeout, recorder, cacheStorage})
   }
 
   static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {
-    const {authToken, userAgent, timeout, cacheStorage, authType} = opts
-    return new HttpClient({baseURL: endpoint, authType, authToken, userAgent, timeout, cacheStorage})
+    const {timeout, cacheStorage, headers} = opts
+    return new HttpClient({baseURL: endpoint, timeout, cacheStorage})
   }
 
   get = <T = any>(url: string, config: AxiosRequestConfig = {}): Promise<T> => {
@@ -137,11 +134,8 @@ export type InstanceOptions = {
 }
 
 export type LegacyInstanceOptions = {
-  authToken: string,
-  authType: AuthType,
-  userAgent: string,
+  headers: Record<string, string>,
   timeout?: number,
-  accept?: string,
   cacheStorage?: CacheStorage,
 }
 
@@ -151,17 +145,11 @@ export interface IOResponse<T> {
   status: number
 }
 
-export enum AuthType {
-  bearer = 'bearer',
-  token = 'token',
-  vtexIdclientAutCookie = 'vtexIdclientAutCookie',
-}
-
 type ClientOptions = {
-  authType: AuthType,
-  authToken: string,
-  userAgent: string
+  authToken?: string,
+  userAgent?: string,
   baseURL: string,
+  headers?: Record<string, string>,
   timeout?: number,
   recorder?: Recorder,
   cacheStorage?: CacheStorage,

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -90,4 +90,3 @@ export type AppBundlePublished = AppBundleResponse & {
 export type AppBundleLinked = AppBundleResponse & {
   bundleSize?: number,
 }
-


### PR DESCRIPTION
Current implementation of `forLegacy` method of `HttpClient` only serves the ID client of this package. To make it extensible so it can be used by other clients implementations for different VTEX modules, this change adds flexibility for the user to define her own headers.