### PR TITLE
Feature/builder availability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -55,8 +55,8 @@ export class Builder {
     return this.zipAndSend(routes.Link(app), app, files, zipOptions)
   }
 
-  public publishApp = (app: string, files: File[], tag?: string) => {
-    return this.zipAndSend(routes.Publish(app), app, files, {tag})
+  public publishApp = (app: string, files: File[], zipOptions: zipOptions = {sticky: true}) => {
+    return this.zipAndSend(routes.Publish(app), app, files, zipOptions)
   }
 
   public relinkApp = (app: string, changes: Change[]) => {

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -8,10 +8,11 @@ import {ZlibOptions} from 'zlib'
 const EMPTY_OBJECT = {}
 
 const routes = {
+  Availability: (app: string) => `${routes.Builder}/availability/${app}`,
   Builder: '/_v/builder/0',
   Clean: (app: string) => `${routes.Builder}/clean/${app}`,
-  Publish: (app: string) => `${routes.Builder}/publish/${app}`,
   Link: (app: string) => `${routes.Builder}/link/${app}`,
+  Publish: (app: string) => `${routes.Builder}/publish/${app}`,
   Relink: (app: string) => `${routes.Builder}/relink/${app}`,
 }
 
@@ -27,20 +28,19 @@ export class Builder {
     this.workspace = ioContext.workspace
   }
 
-  public publishApp = (app: string, files: File[], tag?: string) => {
-    return this.zipAndSend(routes.Publish(app), app, files, {tag})
-  }
-
-  public linkApp = (app: string, files: File[], zipOptions: zipOptions = {sticky: true}) => {
-    return this.zipAndSend(routes.Link(app), app, files, zipOptions)
-  }
-
-  public relinkApp = (app: string, changes: Change[]) => {
+  public availability = async (app: string, hintIndex: number) => {
+    const stickyHint = hintIndex === undefined || hintIndex === null ?
+      `request:${this.account}:${this.workspace}:${app}` :
+      `request:${this.account}:${this.workspace}:${app}:${hintIndex}`
     const headers = {
       'Content-Type': 'application/json',
-      ...this.stickyHost && {'x-vtex-sticky-host': this.stickyHost},
+      'x-vtex-sticky-host': stickyHint,
     }
-    return this.http.put<BuildResult>(routes.Relink(app), changes, {headers})
+    const {data: {availability},
+           headers: {'x-vtex-sticky-host': host},
+          } = await this.http.getRaw(routes.Availability(app), {headers})
+    const {hostname, score} = availability as AvailabilityResponse
+    return {host, hostname, score}
   }
 
   public clean = (app: string) => {
@@ -49,6 +49,22 @@ export class Builder {
       ...this.stickyHost && {'x-vtex-sticky-host': this.stickyHost},
     }
     return this.http.post<BuildResult>(routes.Clean(app), {headers})
+  }
+
+  public linkApp = (app: string, files: File[], zipOptions: zipOptions = {sticky: true}) => {
+    return this.zipAndSend(routes.Link(app), app, files, zipOptions)
+  }
+
+  public publishApp = (app: string, files: File[], tag?: string) => {
+    return this.zipAndSend(routes.Publish(app), app, files, {tag})
+  }
+
+  public relinkApp = (app: string, changes: Change[]) => {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...this.stickyHost && {'x-vtex-sticky-host': this.stickyHost},
+    }
+    return this.http.put<BuildResult>(routes.Relink(app), changes, {headers})
   }
 
   private zipAndSend = async (route: string, app: string, files: File[], {tag, sticky, stickyHint, zlib}: zipOptions = {}) => {
@@ -91,7 +107,14 @@ type zipOptions = {
 }
 
 export type BuildResult = {
+  availability?: AvailabilityResponse
   code?: string,
   message?: any,
   timeNano?: number,
+}
+
+export type AvailabilityResponse = {
+  host: string | undefined,
+  hostname: string | undefined,
+  score: number,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR should be reviewed along with [this one in `toolbelt`](https://github.com/vtex/toolbelt/pull/427) and [this one in `builder-hub`](https://github.com/vtex/builder-hub/pull/207). If this gets approved, we should first launch `builder-hub` (whose changes should not break anything) to further test `toolbelt`/`node-vtex-api`.

After last week's updates, we noticed that `builder-hub` still experienced some restarts from memory allocation issues. This PR attempts to address one of the potential causes: some pods handle several builds at once (with a higher risk of memory allocation issues), whilst other pods are idle.

#### The `availability` route

To address this issue:
- `builder-hub` has a new `availability` route that responds an availability score (a number) for a given `account`/`workspace`/`appId` (a higher score indicates the pod is 'more available' for incoming build requests; if the build is already taking place for a given `account`/`workspace`/`appId` at the pod, availability is at maximum).
- whenever a `link`/`publish` request takes place, `toolbelt` first asks for a certain number of `builder-hub` instances for their availability (using different hints for the `x-vtex-sticky-host` header).  It then picks the most available one to perform the `link`/`publish` request.

In order to ask different `builder-hub` pods for their availability, `toolbelt` will pass several `index` variables (integers `0`, `1`, ...) to `node-vtex-api` which, in turn, will set the `x-vtex-sticky-host` header to `request:<account>:<workspace>:<app>:<index>` in the `GET` request to the `availability` route.

#### Sticky-host in the `publish` route

Since the `publish` route does not use hints for sticky-host (unlike the `link` route), if a user performs two `publish` requests sequentially, they may end up at different `builder-hub` pods and finish (successfully) nearly simultaneously, resulting in two apps with the same `vendor`/`name`/`version` being published. In fact, this happened twice last weekend (see [here](https://vtex.slack.com/archives/C8H0Q555G/p1534702684000100)).

In order to fix this, we added the sticky-host options to the `publish` route in `toolbelt` and `node-vtex-api`.

#### Screenshots or example usage

After updating everything (`builder-hub`, `toolbelt` and `node-vtex-api`), this should be seen in `--verbose` mode:

```
16:00:22.739 - info:    Successfully copied eslint setup!
16:00:22.740 - info:    Linking app vtex.node-getting-started@0.4.1-beta.3
16:00:22.749 - debug:   Trying to retrieve builder-hub availability from 3 hosts
...
16:00:23.366 - debug:   Retrieved availability score 0 from host vtex-builder-hub-0-30-3-lnk-bot-lui-fcfa73b8e3d4009-694dff5xvkm
...
16:00:23.420 - debug:   Selected host vtex-builder-hub-0-30-3-lnk-bot-lui-fcfa73b8e3d4009-694dff5xvkm with availability score 0
```

Timeout is set at 1000ms by default. Should `builder-hub` be unable to respond within this timespan, `toolbelt` just moves on and displays:

```
14:45:55.402 - debug:   Request to host at position 0 timed out after 1000ms
```

If there are any other issues in this availability retrieval request (network errors, earlier version of `builder-hub` with no `availability` route), `toolbelt` will swallow the errors, display the messages below and proceed to use the default sticky-hint options.

```
15:57:02.107 - debug:   Trying to retrieve builder-hub availability from 3 hosts
...
15:57:02.697 - debug:   Unable to retrieve availability from host at position 2
15:57:02.733 - debug:   Unable to retrieve availability from host at position 1
15:57:02.938 - debug:   Unable to retrieve availability from host at position 0
15:57:02.939 - debug:   Unable to select host a priori, will use default options
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
