### PR TITLE
LRUCache - revised metrics interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.45.3",
+  "version": "0.45.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.45.2",
+  "version": "0.45.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.45.0",
+  "version": "0.45.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/LRUCache.ts
+++ b/src/LRUCache.ts
@@ -31,8 +31,9 @@ export class LRUCache <K, V> {
 
   public getStats = () => {
     const stats = {
-      count: this.storage.itemCount,
-      disposed: this.disposed,
+      itemCount: this.storage.itemCount,
+      length: this.storage.length,
+      disposedItems: this.disposed,
       hitRate: this.total > 0 ? this.hits / this.total : undefined,
       hits: this.hits,
       max: this.storage.max,

--- a/src/LRUCache.ts
+++ b/src/LRUCache.ts
@@ -29,7 +29,7 @@ export class LRUCache <K, V> {
 
   public has = (key: K): boolean => this.storage.has(key)
 
-  public getStats = () => {
+  public getStats = (): Stats => {
     const stats = {
       itemCount: this.storage.itemCount,
       length: this.storage.length,
@@ -44,4 +44,14 @@ export class LRUCache <K, V> {
     this.disposed = 0
     return stats
   }
+}
+
+export type Stats = {
+  itemCount: number,
+  length: number,
+  disposedItems: number,
+  hitRate: number | undefined,
+  hits: number,
+  max: number,
+  total: number,
 }


### PR DESCRIPTION
Minor change in the metrics interface for a better compatibility with previous use cases of the npm package `lru-cache` at [render-server](https://github.com/vtex/render-server).