### PR TITLE
Updating dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.44.0",
+  "version": "0.46.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -23,11 +23,16 @@
         "@types/node": "*"
       }
     },
+    "@types/koa-compose": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.2.tgz",
+      "integrity": "sha1-3BBuAAu/kqOskA91bfRzRIh+6Ec=",
+      "dev": true
+    },
     "@types/lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-8mNEUG6diOrI6pMqOHrHPDBB1JsrpedeMK9AWGzVCQ7StRRribiT9BRvUmF8aUws9iBbVlgVekOT5Sgzc1MTKw==",
-      "dev": true
+      "integrity": "sha512-8mNEUG6diOrI6pMqOHrHPDBB1JsrpedeMK9AWGzVCQ7StRRribiT9BRvUmF8aUws9iBbVlgVekOT5Sgzc1MTKw=="
     },
     "@types/mime-types": {
       "version": "2.1.0",
@@ -861,6 +866,11 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
+    },
+    "koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
     },
     "latest-version": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -23,11 +23,12 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/lru-cache": "^4.1.1",
     "archiver": "^2.1.0",
     "axios": "^0.16.0",
     "axios-retry": "^1.2.0",
-    "lru-cache": "^4.1.3",
     "koa-compose": "^4.1.0",
+    "lru-cache": "^4.1.3",
     "mime-types": "^2.1.12",
     "multipart-stream": "^2.0.1",
     "qs": "^6.5.1",
@@ -35,7 +36,6 @@
   },
   "devDependencies": {
     "@types/archiver": "^2.0.1",
-    "@types/lru-cache": "^4.1.1",
     "@types/koa-compose": "^3.2.2",
     "@types/mime-types": "^2.1.0",
     "@types/node": "^8.0.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "0.46.1",
+  "version": "0.46.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
This PR removes the `@types/lru-cache`dependency from development and adds it as a normal dependency since the `LRU.Cache`type is exported.