### PR TITLE
Fixing Unreleased Locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.1] - 2018-10-31
+
 ## [1.5.0] - 2018-10-31
 
 ## [1.4.0] - 2018-10-29

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
#### What problem is this solving?

A more careful approach is needed when promisifying the `rwlock` module. If an error is thrown inside the lock callback, we still need to release the corresponding key and also resolve the promise with a failure value in order to avoid a promise that is never resolved.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

In order to test this PR, a beta version can be installed by using the following command: yarn add @vtex/api@1.5.0-beta.1

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
