### PR TITLE
Create IOClientContext and extend IOContext from it

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -2,7 +2,7 @@ import * as archiver from 'archiver'
 import {ZlibOptions} from 'zlib'
 
 import {Change} from './Apps'
-import {HttpClient, InstanceOptions, IOContext} from './HttpClient'
+import {HttpClient, InstanceOptions, IOClientContext} from './HttpClient'
 import {File} from './Registry'
 
 const EMPTY_OBJECT = {}
@@ -22,7 +22,7 @@ export class Builder {
   private http: HttpClient
   private stickyHost!: string
 
-  constructor (ioContext: IOContext, opts: InstanceOptions = {}) {
+  constructor (ioContext: IOClientContext, opts: InstanceOptions = {}) {
     this.http = HttpClient.forWorkspace('builder-hub.vtex', ioContext, opts)
     this.account = ioContext.account
     this.workspace = ioContext.workspace

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -16,7 +16,7 @@ import {defaultsMiddleware, requestMiddleware} from './middlewares/request'
 const DEFAULT_TIMEOUT_MS = 10000
 const noTransforms = [(data: any) => data]
 
-const rootURL = (service: string, {region}: IOContext, {endpoint}: InstanceOptions): string => {
+const rootURL = (service: string, {region}: IOClientContext, {endpoint}: InstanceOptions): string => {
   if (endpoint) {
     return 'http://' + endpoint
   }
@@ -28,7 +28,7 @@ const rootURL = (service: string, {region}: IOContext, {endpoint}: InstanceOptio
   throw new Error('Missing required: should specify either {region} or {endpoint}')
 }
 
-const workspaceURL = (service: string, context: IOContext, opts: InstanceOptions): string => {
+const workspaceURL = (service: string, context: IOClientContext, opts: InstanceOptions): string => {
   const {account, workspace} = context
   if (!account || !workspace) {
     throw new Error('Missing required arguments: {account, workspace}')
@@ -39,14 +39,14 @@ const workspaceURL = (service: string, context: IOContext, opts: InstanceOptions
 
 export class HttpClient {
 
-  public static forWorkspace (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
+  public static forWorkspace (service: string, context: IOClientContext, opts: InstanceOptions): HttpClient {
     const {authToken, userAgent, recorder} = context
     const {timeout, cacheStorage} = opts
     const baseURL = workspaceURL(service, context, opts)
     return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage})
   }
 
-  public static forRoot (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
+  public static forRoot (service: string, context: IOClientContext, opts: InstanceOptions): HttpClient {
     const {authToken, userAgent, recorder} = context
     const {timeout, cacheStorage} = opts
     const baseURL = rootURL(service, context, opts)
@@ -133,7 +133,7 @@ export class HttpClient {
   }
 }
 
-export const withoutRecorder = (ioContext: IOContext): IOContext => {
+export const withoutRecorder = (ioContext: IOClientContext): IOClientContext => {
   return {...ioContext, recorder: undefined}
 }
 
@@ -145,12 +145,17 @@ export interface ServiceContext extends Context {
   vtex: IOContext
 }
 
-export interface IOContext {
+export interface IOClientContext {
   account: string,
   authToken: string,
   production: boolean,
   recorder?: Recorder,
   region: string,
+  userAgent: string,
+  workspace: string,
+}
+
+export interface IOContext extends IOClientContext {
   route: {
     declarer: string
     id: string
@@ -158,8 +163,6 @@ export interface IOContext {
       [param: string]: string
     }
   }
-  userAgent: string,
-  workspace: string,
 }
 
 export interface InstanceOptions {

--- a/src/IODataSource.ts
+++ b/src/IODataSource.ts
@@ -1,9 +1,9 @@
 import {DataSource, DataSourceConfig} from 'apollo-datasource'
-import {HttpClient, InstanceOptions, IOContext, LegacyInstanceOptions, ServiceContext} from './HttpClient'
+import {HttpClient, InstanceOptions, IOClientContext, LegacyInstanceOptions, ServiceContext} from './HttpClient'
 
 interface HttpClientFactoryOptions {
   service: string | void
-  context: IOContext | void
+  context: IOClientContext | void
   options: InstanceOptions | LegacyInstanceOptions | void
 }
 
@@ -16,7 +16,7 @@ export abstract class IODataSource extends DataSource<ServiceContext> {
   private initialized = false
 
   constructor (
-    private context?: IOContext,
+    private context?: IOClientContext,
     private options: InstanceOptions = {}
   ) {
     super()


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create `IOClientContext` that encapsulates all data needed from `IOContext` to instantiate a client and extend `IOContext` from it.

#### What problem is this solving?
Clients are instantiated using `IOContext` in `node-vtex-api 1.x`. But it does have unnecessary information that clients (e.g. `toolbelt`) won't have. Creating `IOClientContext` allows us to keep

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
