### PR TITLE
Service runtime node types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.5.3] - 2019-01-11
 ### Fixed
 - IOContext types mismatch with service-runtime-node
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- IOContext types mismatch with service-runtime-node
 
 ## [1.5.2] - 2018-11-27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "multipart-stream": "^2.0.1",
     "p-queue": "^3.0.0",
     "qs": "^6.5.1",
+    "querystring": "^0.2.0",
     "ramda": "^0.25.0",
     "rwlock": "^5.0.0",
     "semver": "^5.5.1",

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -1,17 +1,17 @@
-import {AxiosResponse} from 'axios'
-import {IncomingMessage} from 'http'
-import {Context} from 'koa'
+import { AxiosResponse } from 'axios'
+import { IncomingMessage } from 'http'
+import { Context } from 'koa'
 import * as compose from 'koa-compose'
+import { ParsedUrlQuery } from 'querystring'
 
-import {MetricsAccumulator} from '../MetricsAccumulator'
-
-import {CacheLayer} from '../caches/CacheLayer'
-import {MiddlewareContext, RequestConfig} from './context'
-import {CacheableRequestConfig, Cached, cacheMiddleware} from './middlewares/cache'
-import {metricsMiddleware} from './middlewares/metrics'
-import {acceptNotFoundMiddleware, notFoundFallbackMiddleware} from './middlewares/notFound'
-import {Recorder, recorderMiddleware} from './middlewares/recorder'
-import {defaultsMiddleware, requestMiddleware} from './middlewares/request'
+import { CacheLayer } from '../caches/CacheLayer'
+import { MetricsAccumulator } from '../MetricsAccumulator'
+import { MiddlewareContext, RequestConfig } from './context'
+import { CacheableRequestConfig, Cached, cacheMiddleware } from './middlewares/cache'
+import { metricsMiddleware } from './middlewares/metrics'
+import { acceptNotFoundMiddleware, notFoundFallbackMiddleware } from './middlewares/notFound'
+import { Recorder, recorderMiddleware } from './middlewares/recorder'
+import { defaultsMiddleware, requestMiddleware } from './middlewares/request'
 
 const DEFAULT_TIMEOUT_MS = 10000
 const noTransforms = [(data: any) => data]
@@ -152,11 +152,9 @@ export interface IOContext {
   recorder?: Recorder,
   region: string,
   route: {
-    declarer: string
+    declarer?: string
     id: string
-    params: {
-      [param: string]: string,
-    },
+    params: ParsedUrlQuery,
   }
   userAgent: string,
   workspace: string,

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -155,8 +155,8 @@ export interface IOContext {
     declarer: string
     id: string
     params: {
-      [param: string]: string
-    }
+      [param: string]: string,
+    },
   }
   userAgent: string,
   workspace: string,

--- a/src/IODataSource.ts
+++ b/src/IODataSource.ts
@@ -17,7 +17,7 @@ export abstract class IODataSource extends DataSource<ServiceContext> {
 
   constructor (
     private context?: IOContext,
-    private options: InstanceOptions = {}
+    private options: InstanceOptions = {},
   ) {
     super()
   }

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -76,7 +76,7 @@ export interface ErrorLog {
   response?: {
     status: number
     data: string
-    headers: Record<string, string>
+    headers: Record<string, string>,
   }
   // You might add any other keys with extra information
   [key: string]: any

--- a/src/MetricsAccumulator.ts
+++ b/src/MetricsAccumulator.ts
@@ -20,7 +20,7 @@ interface AggregateMetric extends Metric {
 
 interface GetStats {
   getStats(): {
-    [key: string]: number | boolean | string | undefined
+    [key: string]: number | boolean | string | undefined,
   }
 }
 
@@ -128,7 +128,7 @@ export class MetricsAccumulator {
       {
         name: 'memory',
         ...process.memoryUsage(),
-      }
+      },
     ]
 
     const onFlushMetrics = flatten(map(getMetric => getMetric(), this.onFlushMetrics)) as Metric[]

--- a/src/caches/typings.ts
+++ b/src/caches/typings.ts
@@ -53,5 +53,5 @@ export type LRUDiskCacheOptions = {
    * return `undefined` when you try to get a stale entry,
    * as if it had already been deleted.
    */
-  stale?: boolean
+  stale?: boolean,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,6 +838,10 @@ qs@^6.5.1:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
 
+querystring@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
 ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Currently, there is a mismatch between the IOContext types described here and the types available through the context in provided by `service-runtime-node`.

#### What problem is this solving?
This PR solves the mismatch problem by making the `declarer` parameter optional, and the `params` parameter of type `ParsedUrlQuery`.

The declarer must be optional because for private routes, service node does not add a declarer in the route, as given in [here](https://github.com/vtex/service-runtime-node/blob/c39fbaacb7e0bf9294479a2d35a584d88ab86c77/src/setup/prepare.ts#L40)

The params parameter should be of type `ParsedUrlQuery`, because of [this line](https://github.com/vtex/service-runtime-node/blob/c39fbaacb7e0bf9294479a2d35a584d88ab86c77/src/setup/prepare.ts#L29) in service runtime

Also, this PR solves some lint problems 

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
