### PR TITLE
Context should be protected in IODataSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.5.4] - 2019-01-17
 ### Added
 - protected context in favor of private one in IODataSource
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- protected context in favor of private one in IODataSource
 
 ## [1.5.3] - 2019-01-11
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/IODataSource.ts
+++ b/src/IODataSource.ts
@@ -16,7 +16,7 @@ export abstract class IODataSource extends DataSource<ServiceContext> {
   private initialized = false
 
   constructor (
-    private context?: IOContext,
+    protected context?: IOContext,
     private options: InstanceOptions = {},
   ) {
     super()


### PR DESCRIPTION
#### What is the purpose of this pull request?
The context in IODataSource should be protected so derived classes can use it

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
