### PR TITLE
HttpClient with cache varying with segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.8.1] - 2019-02-13
+
 ## [1.8.1-beta] - 2019-02-12
 
 ## [1.8.0-beta] - 2019-02-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.8.1-beta] - 2019-02-12
+
 ## [1.8.0-beta] - 2019-02-12
 
 ## [1.7.0] - 2019-02-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.8.0-beta] - 2019-02-12
+
 ## [1.7.0] - 2019-02-12
 ### Added
 - segmentToken and sessionToken to IOContext type definition

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "1.8.1-beta",
+  "version": "1.8.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "1.7.0",
+  "version": "1.8.0-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "1.8.0-beta",
+  "version": "1.8.1-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -57,7 +57,7 @@ export class HttpClient {
 
   public static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {
     const {authToken, userAgent, timeout, cacheStorage} = opts
-    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage, segmentToken: '', sessionToken: ''})
+    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage})
   }
   private runMiddlewares: compose.ComposedMiddleware<MiddlewareContext>
 
@@ -76,7 +76,7 @@ export class HttpClient {
       defaultsMiddleware(baseURL, headers, timeout),
       ...recorder ? [recorderMiddleware(recorder)] : [],
       acceptNotFoundMiddleware,
-      ...cacheStorage ? [cacheMiddleware({cacheStorage, segmentToken})] : [],
+      ...cacheStorage ? [cacheMiddleware({cacheStorage, segmentToken: segmentToken || ''})] : [],
       notFoundFallbackMiddleware,
       ...metrics ? [metricsMiddleware(metrics)] : [],
       requestMiddleware,

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -57,12 +57,12 @@ export class HttpClient {
 
   public static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {
     const {authToken, userAgent, timeout, cacheStorage} = opts
-    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage})
+    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage, segmentToken: '', sessionToken: ''})
   }
   private runMiddlewares: compose.ComposedMiddleware<MiddlewareContext>
 
   public constructor (opts: ClientOptions) {
-    const {baseURL, authToken, authType, cacheStorage, metrics, recorder, userAgent, timeout = DEFAULT_TIMEOUT_MS} = opts
+    const {baseURL, authToken, authType, cacheStorage, metrics, recorder, userAgent, timeout = DEFAULT_TIMEOUT_MS, segmentToken} = opts
     const headers: Record<string, string> = {
       'Accept-Encoding': 'gzip',
       'User-Agent': userAgent,

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -42,14 +42,14 @@ const workspaceURL = (service: string, context: IOContext, opts: InstanceOptions
 export class HttpClient {
 
   public static forWorkspace (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
-    const {authToken, userAgent, recorder} = context
+    const {authToken, userAgent, recorder, segmentToken, sessionToken} = context
     const {timeout, cacheStorage} = opts
     const baseURL = workspaceURL(service, context, opts)
     return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken})
   }
 
   public static forRoot (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
-    const {authToken, userAgent, recorder} = context
+    const {authToken, userAgent, recorder, segmentToken, sessionToken} = context
     const {timeout, cacheStorage} = opts
     const baseURL = rootURL(service, context, opts)
     return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken})
@@ -57,7 +57,7 @@ export class HttpClient {
 
   public static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {
     const {authToken, userAgent, timeout, cacheStorage} = opts
-    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage, segmentToken, sessionToken})
+    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage})
   }
   private runMiddlewares: compose.ComposedMiddleware<MiddlewareContext>
 

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -45,19 +45,19 @@ export class HttpClient {
     const {authToken, userAgent, recorder} = context
     const {timeout, cacheStorage} = opts
     const baseURL = workspaceURL(service, context, opts)
-    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage})
+    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken})
   }
 
   public static forRoot (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
     const {authToken, userAgent, recorder} = context
     const {timeout, cacheStorage} = opts
     const baseURL = rootURL(service, context, opts)
-    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage})
+    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken})
   }
 
   public static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {
     const {authToken, userAgent, timeout, cacheStorage} = opts
-    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage})
+    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage, segmentToken, sessionToken})
   }
   private runMiddlewares: compose.ComposedMiddleware<MiddlewareContext>
 
@@ -76,7 +76,7 @@ export class HttpClient {
       defaultsMiddleware(baseURL, headers, timeout),
       ...recorder ? [recorderMiddleware(recorder)] : [],
       acceptNotFoundMiddleware,
-      ...cacheStorage ? [cacheMiddleware(cacheStorage)] : [],
+      ...cacheStorage ? [cacheMiddleware({cacheStorage, segmentToken})] : [],
       notFoundFallbackMiddleware,
       ...metrics ? [metricsMiddleware(metrics)] : [],
       requestMiddleware,
@@ -204,4 +204,6 @@ interface ClientOptions {
   recorder?: Recorder,
   metrics?: MetricsAccumulator,
   cacheStorage?: CacheLayer<string, Cached>,
+  segmentToken?: string
+  sessionToken?: string
 }

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -1,5 +1,5 @@
 import {AxiosRequestConfig, AxiosResponse} from 'axios'
-import {contains} from 'ramda'
+import {match} from 'ramda'
 import {URL, URLSearchParams} from 'url'
 import {CacheLayer} from '../../caches/CacheLayer'
 import {MiddlewareContext} from '../context'
@@ -82,7 +82,7 @@ export const cacheMiddleware = ({cacheStorage, segmentToken}: {cacheStorage: Cac
 
     if (maxAge || etag) {
       const currentAge = revalidated ? 0 : age
-      const varySegment = contains('x-vtex-segment', ctx.response.headers.get('vary'))
+      const varySegment = match('x-vtex-segment', ctx.response.headers.get('vary'))
       const setKey = varySegment ? keyWithSegment : key
       await cacheStorage.set(setKey, {
         etag,

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -81,7 +81,8 @@ export const cacheMiddleware = ({cacheStorage, segmentToken}: {cacheStorage: Cac
 
     if (maxAge || etag) {
       const currentAge = revalidated ? 0 : age
-      const varySegment = ctx.response.headers.get('vary').includes('x-vtex-segment')
+      debugger
+      const varySegment = ctx.response.headers.vary.includes('x-vtex-segment')
       const setKey = varySegment ? keyWithSegment : key
       await cacheStorage.set(setKey, {
         etag,

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -1,5 +1,4 @@
 import {AxiosRequestConfig, AxiosResponse} from 'axios'
-import {match} from 'ramda'
 import {URL, URLSearchParams} from 'url'
 import {CacheLayer} from '../../caches/CacheLayer'
 import {MiddlewareContext} from '../context'
@@ -82,7 +81,7 @@ export const cacheMiddleware = ({cacheStorage, segmentToken}: {cacheStorage: Cac
 
     if (maxAge || etag) {
       const currentAge = revalidated ? 0 : age
-      const varySegment = match('x-vtex-segment', ctx.response.headers.get('vary'))
+      const varySegment = ctx.response.headers.get('vary').includes('x-vtex-segment')
       const setKey = varySegment ? keyWithSegment : key
       await cacheStorage.set(setKey, {
         etag,

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -81,7 +81,6 @@ export const cacheMiddleware = ({cacheStorage, segmentToken}: {cacheStorage: Cac
 
     if (maxAge || etag) {
       const currentAge = revalidated ? 0 : age
-      debugger
       const varySegment = ctx.response.headers.vary.includes('x-vtex-segment')
       const setKey = varySegment ? keyWithSegment : key
       await cacheStorage.set(setKey, {


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR makes the HttpClient cache vary according to the segment (if the response varies)

#### What problem is this solving?
Responses that varies with the segment were being cached without the segment information, therefore when the segment changed the client returned the cached data, even though it was incorrect.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
