### PR TITLE
Update types for App Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.8.3] - 2019-02-22
 ### Changed
 - Updated App Manifest types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated App Manifest types
 
 ## [1.8.2] - 2019-02-22
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,5 +1,8 @@
 export interface Policy {
   name: string,
+  attrs?: {
+    [name: string]: string,
+  }
 }
 
 export interface AppManifest {
@@ -7,20 +10,24 @@ export interface AppManifest {
   vendor: string,
   name: string,
   version: string,
-  title: string,
-  description: string,
-  categories: string[],
-  dependencies: {
+  title?: string,
+  description?: string,
+  mustUpdateAt?: string,
+  builders: {
+    [name: string]: string,
+  }
+  categories?: string[],
+  dependencies?: {
     [name: string]: string,
   },
-  peerDependencies: {
+  peerDependencies?: {
     [name: string]: string,
   },
-  settingsSchema: any,
-  registries: string[],
-  credentialType: string,
-  policies: Policy[],
-  billingOptions: BillingOptions,
+  settingsSchema?: any,
+  registries?: string[],
+  credentialType?: string,
+  policies?: Policy[],
+  billingOptions?: BillingOptions,
   _resolvedDependencies?: {
     [name: string]: string[],
   },
@@ -41,13 +48,21 @@ export interface BucketMetadata {
   hash: string,
 }
 
-export interface BillingOptions {
-  version?: string,
-  free?: boolean,
-  policies?: BillingPolicy[],
-  deactivationRoute?: string,
-  termsURL: string,
+interface RootBillingOptions {
+  termsURL: string
+  support: Support
 }
+
+export interface Support {
+  url: string
+  email: string
+}
+
+export type BillingOptions = RootBillingOptions & ({
+  free: boolean,
+} | {
+  policies: BillingPolicy[],
+})
 
 export interface BillingPolicy {
   currency: string,
@@ -59,17 +74,19 @@ export interface BillingChargeElements {
   items: CalculationItem[],
 }
 
-export interface CalculationItem {
+export type CalculationItem = {
   itemCurrency: string,
+} & ({
   fixed: number,
+} | {
   calculatedByMetricUnit: CalculatedByMetricUnit,
-}
+})
 
 export interface CalculatedByMetricUnit {
   metricId: string,
   metricName: string,
   ranges: Range[],
-  route: string,
+  route?: string,
 }
 
 export interface Range {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update App Manifest types for better usage in app-store,  apps-admin, apps-graphql and billing projects

#### What problem is this solving?
These apps make extensive use of the app manifest types. The proposed change prevents generalized repetition and inconsistency.
