### PR TITLE
Add functions to call new Apps API for dependency resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Functions that call new Apps API for dependency resolution.
 
 ## [1.8.3] - 2019-02-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.9.0] - 2019-02-25
 ### Added
 - Functions that call new Apps API for dependency resolution.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/Apps.ts
+++ b/src/Apps.ts
@@ -226,12 +226,12 @@ export class Apps extends IODataSource {
 
   public resolveDependencies = (apps: string[], registries: string[], filter: string = '') => {
     const params = {apps, registries, filter}
+    console.error(paramsSerializer(params))
     return this.http.get(routes.ResolveDependencies, {params, paramsSerializer})
   }
 
-  public resolveDependenciesWithManifest = (manifest: AppManifest, filter: string = '') => {
-    const params = {filter}
-    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest, {params, paramsSerializer})
+  public resolveDependenciesWithManifest = (manifest: AppManifest) => {
+    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest)
   }
     
 }

--- a/src/Apps.ts
+++ b/src/Apps.ts
@@ -19,6 +19,7 @@ const routes = {
   Link: (app: string) => `/v2/links/${app}`,
   Links: '/links',
   ResolveDependencies: 'dependencies/_resolve',
+  ResolveDependenciesWithManifest: '/v2/apps/_resolve',
   Settings: (app: string) => `${routes.App(app)}/settings`,
   Unlink: (app: string) => `${routes.Links}/${app}`,
 }
@@ -227,6 +228,11 @@ export class Apps extends IODataSource {
     const params = {apps, registries, filter}
     return this.http.get(routes.ResolveDependencies, {params, paramsSerializer})
   }
+
+  public resolveDependenciesWithManifest = (manifest: AppManifest) => {
+    return this.http.post(routes.ResolveDependenciesWithManifest, manifest)
+  }
+    
 }
 
 interface ZipOptions {

--- a/src/Apps.ts
+++ b/src/Apps.ts
@@ -230,8 +230,9 @@ export class Apps extends IODataSource {
     return this.http.get(routes.ResolveDependencies, {params, paramsSerializer})
   }
 
-  public resolveDependenciesWithManifest = (manifest: AppManifest) => {
-    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest)
+  public resolveDependenciesWithManifest = (manifest: AppManifest, filter: string = '') => {
+    const params = {filter}
+    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest, {params, paramsSerializer})
   }
     
 }

--- a/src/Apps.ts
+++ b/src/Apps.ts
@@ -229,8 +229,9 @@ export class Apps extends IODataSource {
     return this.http.get(routes.ResolveDependencies, {params, paramsSerializer})
   }
 
-  public resolveDependenciesWithManifest = (manifest: AppManifest) => {
-    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest)
+  public resolveDependenciesWithManifest = (manifest: AppManifest, filter: string = '') => {
+    const params = {filter}
+    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest, {params, paramsSerializer})
   }
     
 }

--- a/src/Apps.ts
+++ b/src/Apps.ts
@@ -230,7 +230,7 @@ export class Apps extends IODataSource {
   }
 
   public resolveDependenciesWithManifest = (manifest: AppManifest) => {
-    return this.http.post(routes.ResolveDependenciesWithManifest, manifest)
+    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest)
   }
     
 }

--- a/src/Apps.ts
+++ b/src/Apps.ts
@@ -226,7 +226,6 @@ export class Apps extends IODataSource {
 
   public resolveDependencies = (apps: string[], registries: string[], filter: string = '') => {
     const params = {apps, registries, filter}
-    console.error(paramsSerializer(params))
     return this.http.get(routes.ResolveDependencies, {params, paramsSerializer})
   }
 

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -45,7 +45,6 @@ export class HttpClient {
     const {authToken, userAgent, recorder, segmentToken, sessionToken} = context
     const {timeout, cacheStorage} = opts
     const baseURL = workspaceURL(service, context, opts)
-    console.error(`baseURL = ${baseURL}`)
     return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken})
   }
 

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -45,6 +45,7 @@ export class HttpClient {
     const {authToken, userAgent, recorder, segmentToken, sessionToken} = context
     const {timeout, cacheStorage} = opts
     const baseURL = workspaceURL(service, context, opts)
+    console.error(`baseURL = ${baseURL}`)
     return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken})
   }
 

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -19,6 +19,7 @@ const routes = {
   AppVersion: (app: string, version: string) => `${routes.App(app)}/${version}`,
   Publish: '/v2/registry',
   Registry: '/registry',
+  ResolveDependenciesWithManifest: '/v2/registry/_resolve',
 }
 
 const forWorkspaceMaster: HttpClientFactory = ({service, context, options}) => (service && context)
@@ -105,6 +106,10 @@ export class Registry extends IODataSource {
         .pipe(createGunzip())
         .pipe(extract(unpackPath)),
       )
+  }
+
+  public resolveDependenciesWithManifest = (manifest: AppManifest) => {
+    return this.http.post(routes.ResolveDependenciesWithManifest, manifest)
   }
 }
 

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -109,7 +109,7 @@ export class Registry extends IODataSource {
   }
 
   public resolveDependenciesWithManifest = (manifest: AppManifest) => {
-    return this.http.post(routes.ResolveDependenciesWithManifest, manifest)
+    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest)
   }
 }
 

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -1,5 +1,6 @@
 import * as archiver from 'archiver'
 import {IncomingMessage} from 'http'
+import {stringify} from 'qs'
 import {Readable, Writable} from 'stream'
 import {extract} from 'tar-fs'
 import {createGunzip, ZlibOptions} from 'zlib'
@@ -25,6 +26,10 @@ const routes = {
 const forWorkspaceMaster: HttpClientFactory = ({service, context, options}) => (service && context)
   ? HttpClient.forWorkspace(service, {...context, workspace: DEFAULT_WORKSPACE}, options || {})
   : undefined
+
+const paramsSerializer = (params: any) => {
+  return stringify(params, {arrayFormat: 'repeat'})
+}
 
 export class Registry extends IODataSource {
   protected httpClientFactory = forWorkspaceMaster
@@ -108,8 +113,9 @@ export class Registry extends IODataSource {
       )
   }
 
-  public resolveDependenciesWithManifest = (manifest: AppManifest) => {
-    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest)
+  public resolveDependenciesWithManifest = (manifest: AppManifest, filter: string = '') => {
+    const params = {filter}
+    return this.http.post<Record<string, string[]>>(routes.ResolveDependenciesWithManifest, manifest, {params, paramsSerializer})
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds functions to Apps and Registry that uses the new Apps API to resolve dependencies (see https://github.com/vtex/apps/pull/334).

#### What problem is this solving?
The old API has a bug that causes builds to fail depending on the dependency tree. The section below has an instance of such case.

#### How should this be manually tested?
This can be tested along with https://github.com/vtex/builder-hub/pull/385:
- Create three apps `A`, `B` and `C` (you can copy existing ones and just change their names). Make sure all apps are unpublished and at least one of them uses the GraphQL builder (say, app `A`).
- Add `B` as a dependency of `A`, and `C` as a dependency of `B`.
- Link `C`, `B` and `A`, in this order. If you're using a Builder-hub version prior to these changes, the build should fail for app `A` with message `vtex.B@0.1.0+build1550790911: vtex.C@0.x: Failed to list versions for vtex.C: No versions published for app vtex.C`. This should not reproduce after these changes.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
