### PR TITLE
Add production info to workspace creation call

### DIFF
--- a/src/Workspaces.ts
+++ b/src/Workspaces.ts
@@ -23,8 +23,8 @@ export class Workspaces extends IODataSource {
     return this.http.put(routes.Workspace(account, workspace), metadata)
   }
 
-  public create = (account: string, workspace: string) => {
-    return this.http.post(routes.Account(account), {name: workspace})
+  public create = (account: string, workspace: string, production: boolean) => {
+    return this.http.post(routes.Account(account), {name: workspace, production})
   }
 
   public delete = (account: string, workspace: string) => {


### PR DESCRIPTION
We will no longer support changing the `production` flag of a workspace. This
means that we need to be able to create the workspace with `production` both set
to `true` or `false`, instead of always setting it to false.

According to the new guidelines we only allow links on workspaces that have
`production` set to `false` and we only allow workspaces with `production` set
to `true` to be promoted. This is going to be implemented in toolbelt, but first
we need to allow it to create both kinds of workspace.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
