### PR TITLE
Fix billing client to use correct endpoint for metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.4.4-beta] - 2019-04-19
 ### Changed
 - Fixed host reference for Billing metrics sending
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.4.4] - 2019-04-22
+
 ## [3.4.4-beta] - 2019-04-19
 ### Changed
 - Fixed host reference for Billing metrics sending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fixed host reference for Billing metrics sending
 
 ## [3.4.3] - 2019-04-18
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.4.3",
+  "version": "3.4.4-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.4.4-beta",
+  "version": "3.4.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Billing.ts
+++ b/src/clients/Billing.ts
@@ -7,7 +7,7 @@ const routes = {
   contractStatus: '/_v/contractStatus',
 }
 
-export class BillingService {
+export class Billing {
   private contracts: Contracts
   private metrics: Metrics
 

--- a/src/clients/Billing.ts
+++ b/src/clients/Billing.ts
@@ -1,48 +1,15 @@
-import { InstanceOptions } from '../HttpClient'
 import { forWorkspace, IODataSource } from '../IODataSource'
-import { IOContext } from '../service/typings'
-
-const metricRoute = `/metrics`
-
-const routes = {
-  contractStatus: '/_v/contractStatus',
-}
 
 export class Billing extends IODataSource {
   protected service = 'billing.vtex'
   protected httpClientFactory = forWorkspace
-  protected metrics: Metrics
-
-  constructor (context?: IOContext, options: InstanceOptions = {}) {
-    super(context, options)
-    this.metrics = new Metrics(context, options)
-  }
 
   public status = () =>
-    this.http.get<ContractStatus>(routes.contractStatus)
-
-  public sendMetric = (metric: BillingMetric) =>
-    this.metrics.sendMetric(metric)
-}
-
-// tslint:disable-next-line:max-classes-per-file
-class Metrics extends IODataSource {
-  protected service = 'colossus'
-  protected httpClientFactory = forWorkspace
-
-  public sendMetric = (metric: BillingMetric) =>
-    this.http.post<BillingMetric>(metricRoute, metric)
+    this.http.get<ContractStatus>('/_v/contractStatus')
 }
 
 export enum ContractStatus {
   ACTIVE = 'active_contract',
   INACTIVE = 'inactive_contract',
   NO_CONTRACT = 'no_contract',
-}
-
-export interface BillingMetric {
-  value: number,
-  unit: string,
-  metricId: string,
-  timestamp?: number,
 }

--- a/src/clients/Billing.ts
+++ b/src/clients/Billing.ts
@@ -1,4 +1,5 @@
-import {forWorkspace, IODataSource} from '../IODataSource'
+import { InstanceOptions, IOContext } from './HttpClient'
+import { forWorkspace, IODataSource } from './IODataSource'
 
 const metricRoute = `/metrics`
 
@@ -6,17 +7,38 @@ const routes = {
   contractStatus: '/_v/contractStatus',
 }
 
-export class Billing extends IODataSource {
+export class BillingService {
+  private contracts: Contracts
+  private metrics: Metrics
+
+  constructor(context: IOContext, options: InstanceOptions) {
+    this.contracts = new Contracts(context, options)
+    this.metrics = new Metrics(context, options)
+  }
+
+  public status = () =>
+    this.contracts.status()
+
+  public sendMetric = (metric: BillingMetric) =>
+    this.metrics.sendMetric(metric)
+}
+
+// tslint:disable-next-line:max-classes-per-file
+class Contracts extends IODataSource {
   protected service = 'billing.vtex'
   protected httpClientFactory = forWorkspace
 
-  public contractStatus = () => {
-    return this.http.get<ContractStatus>(routes.contractStatus)
-  }
+  public status = () =>
+    this.http.get<ContractStatus>(routes.contractStatus)
+}
 
-  public sendMetric = (metric: BillingMetric) => {
-    return this.http.post(metricRoute, metric)
-  }
+// tslint:disable-next-line:max-classes-per-file
+class Metrics extends IODataSource {
+  protected service = 'colossus'
+  protected httpClientFactory = forWorkspace
+
+  public sendMetric = (metric: BillingMetric) =>
+    this.http.post<BillingMetric>(metricRoute, metric)
 }
 
 export enum ContractStatus {

--- a/src/clients/Billing.ts
+++ b/src/clients/Billing.ts
@@ -1,5 +1,6 @@
-import { InstanceOptions, IOContext } from './HttpClient'
-import { forWorkspace, IODataSource } from './IODataSource'
+import { InstanceOptions } from '../HttpClient'
+import { forWorkspace, IODataSource } from '../IODataSource'
+import { IOContext } from '../service/typings'
 
 const metricRoute = `/metrics`
 
@@ -7,29 +8,21 @@ const routes = {
   contractStatus: '/_v/contractStatus',
 }
 
-export class Billing {
-  private contracts: Contracts
-  private metrics: Metrics
+export class Billing extends IODataSource {
+  protected service = 'billing.vtex'
+  protected httpClientFactory = forWorkspace
+  protected metrics: Metrics
 
-  constructor(context: IOContext, options: InstanceOptions) {
-    this.contracts = new Contracts(context, options)
+  constructor (context?: IOContext, options: InstanceOptions = {}) {
+    super(context, options)
     this.metrics = new Metrics(context, options)
   }
 
   public status = () =>
-    this.contracts.status()
+    this.http.get<ContractStatus>(routes.contractStatus)
 
   public sendMetric = (metric: BillingMetric) =>
     this.metrics.sendMetric(metric)
-}
-
-// tslint:disable-next-line:max-classes-per-file
-class Contracts extends IODataSource {
-  protected service = 'billing.vtex'
-  protected httpClientFactory = forWorkspace
-
-  public status = () =>
-    this.http.get<ContractStatus>(routes.contractStatus)
 }
 
 // tslint:disable-next-line:max-classes-per-file

--- a/src/clients/BillingMetrics.ts
+++ b/src/clients/BillingMetrics.ts
@@ -1,0 +1,16 @@
+import { forWorkspace, IODataSource } from '../IODataSource'
+
+export class BillingMetrics extends IODataSource {
+  protected service = 'colossus'
+  protected httpClientFactory = forWorkspace
+
+  public sendMetric = (metric: BillingMetric) =>
+    this.http.post<BillingMetric>('/metrics', metric)
+}
+
+export interface BillingMetric {
+  value: number
+  unit: string
+  metricId: string
+  timestamp?: number
+}

--- a/src/clients/IOClients.ts
+++ b/src/clients/IOClients.ts
@@ -2,7 +2,7 @@ import { pickAll } from 'ramda'
 import { InstanceOptions } from '../HttpClient'
 import { IODataSource } from '../IODataSource'
 import { ClientContext, ClientDependencies, ClientInstanceOptions, IOContext } from '../service/typings'
-import { Apps, Billing, Builder, Events, ID, Logger, Messages, Metadata, Registry, Router, Segment, VBase, Workspaces } from './index'
+import { Apps, Billing, BillingMetrics, Builder, Events, ID, Logger, Messages, Metadata, Registry, Router, Segment, VBase, Workspaces } from './index'
 
 export type IOClient = new (context: ClientContext, options: InstanceOptions) => IODataSource | Builder | ID | Router
 
@@ -29,6 +29,10 @@ export class IOClients {
 
   public get billing() {
     return this.getOrSet('billing', Billing)
+  }
+
+  public get billingMetrics() {
+    return this.getOrSet('billingMetrics', BillingMetrics)
   }
 
   public get builder() {

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,5 +1,6 @@
 export * from './Apps'
 export * from './Billing'
+export * from './BillingMetrics'
 export * from './Builder'
 export * from './Events'
 export * from './ID'


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change Billing client so that it uses the correct Colossus endpoint for metrics registering

#### What problem is this solving?
Recent changes to VTEX node client made the billing metrics method point to the wrong host (billing app instead of Colossus)

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
