### PR TITLE
Add metrics everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.0-beta] - 2019-03-11
+
 ### Changed
 - Only retry safe requests
 - Add metrics for proxy timeout and retries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.0-beta.0] - 2019-03-11
+
 ## [2.2.0-beta] - 2019-03-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Only retry safe requests
 - Add metrics for proxy timeout and retries
 - Add `metric` config to clients requests
+- Add `concurrency` option to HttpClient to limit amount of parallel requests
 
 ## [2.1.0] - 2019-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.0] - 2019-03-12
+
 ## [2.2.0-beta.0] - 2019-03-11
 
 ## [2.2.0-beta] - 2019-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Only retry safe requests
+- Add metrics for proxy timeout and retries
+- Add `metric` config to clients requests
+
 ## [2.1.0] - 2019-03-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "2.2.0-beta.0",
+  "version": "2.2.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "2.2.0-beta",
+  "version": "2.2.0-beta.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "2.1.0",
+  "version": "2.2.0-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lru-cache": "^4.1.3",
     "mime-types": "^2.1.12",
     "multipart-stream": "^2.0.1",
+    "p-limit": "^2.2.0",
     "p-queue": "^3.0.0",
     "qs": "^6.5.1",
     "querystring": "^0.2.0",

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -36,9 +36,10 @@ export class Builder {
       'Content-Type': 'application/json',
       'x-vtex-sticky-host': stickyHint,
     }
+    const metric = 'bh-availability'
     const {data: {availability},
            headers: {'x-vtex-sticky-host': host},
-          } = await this.http.getRaw(routes.Availability(app), {headers})
+          } = await this.http.getRaw(routes.Availability(app), {headers, metric})
     const {hostname, score} = availability as AvailabilityResponse
     return {host, hostname, score}
   }
@@ -48,7 +49,8 @@ export class Builder {
       'Content-Type': 'application/json',
       ...this.stickyHost && {'x-vtex-sticky-host': this.stickyHost},
     }
-    return this.http.post<BuildResult>(routes.Clean(app), {headers})
+    const metric = 'bh-clean'
+    return this.http.post<BuildResult>(routes.Clean(app), {headers, metric})
   }
 
   public linkApp = (app: string, files: File[], zipOptions: ZipOptions = {sticky: true}) => {
@@ -64,7 +66,8 @@ export class Builder {
       'Content-Type': 'application/json',
       ...this.stickyHost && {'x-vtex-sticky-host': this.stickyHost},
     }
-    return this.http.put<BuildResult>(routes.Relink(app), changes, {headers})
+    const metric = 'bh-relink'
+    return this.http.put<BuildResult>(routes.Relink(app), changes, {headers, metric})
   }
 
   private zipAndSend = async (route: string, app: string, files: File[], {tag, sticky, stickyHint, zlib}: ZipOptions = {}) => {
@@ -81,11 +84,13 @@ export class Builder {
       throw e
     })
     const hint = stickyHint || `request:${this.account}:${this.workspace}:${app}`
+    const metric = 'bh-zip-send'
     const request = this.http.postRaw<BuildResult>(route, zip, {
       headers: {
         'Content-Type': 'application/octet-stream',
         ...sticky && {'x-vtex-sticky-host': this.stickyHost || hint},
       },
+      metric,
       params: tag ? {tag} : EMPTY_OBJECT,
     })
 

--- a/src/Events.ts
+++ b/src/Events.ts
@@ -12,6 +12,6 @@ export class Events extends IODataSource {
   protected httpClientFactory = forWorkspaceWithoutRecorder
 
   public sendEvent = (subject: string, route: string, message?: any) => {
-    return this.http.put(eventRoute(route), message, {params: {subject}})
+    return this.http.put(eventRoute(route), message, {params: {subject}, metric: 'events-send'})
   }
 }

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -44,21 +44,21 @@ export class HttpClient {
 
   public static forWorkspace (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
     const {authToken, userAgent, recorder, segmentToken, sessionToken} = context
-    const {timeout, cacheStorage, retryConfig} = opts
+    const {timeout, cacheStorage, retryConfig, metrics} = opts
     const baseURL = workspaceURL(service, context, opts)
-    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken, retryConfig})
+    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken, retryConfig, metrics})
   }
 
   public static forRoot (service: string, context: IOContext, opts: InstanceOptions): HttpClient {
     const {authToken, userAgent, recorder, segmentToken, sessionToken} = context
-    const {timeout, cacheStorage, retryConfig} = opts
+    const {timeout, cacheStorage, retryConfig, metrics} = opts
     const baseURL = rootURL(service, context, opts)
-    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken, retryConfig})
+    return new HttpClient({baseURL, authType: AuthType.bearer, authToken, userAgent, timeout, recorder, cacheStorage, segmentToken, sessionToken, retryConfig, metrics})
   }
 
   public static forLegacy (endpoint: string, opts: LegacyInstanceOptions): HttpClient {
-    const {authToken, userAgent, timeout, cacheStorage, retryConfig} = opts
-    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage, retryConfig})
+    const {authToken, userAgent, timeout, cacheStorage, retryConfig, metrics} = opts
+    return new HttpClient({baseURL: endpoint, authType: AuthType.token, authToken, userAgent, timeout, cacheStorage, retryConfig, metrics})
   }
   private runMiddlewares: compose.ComposedMiddleware<MiddlewareContext>
 
@@ -176,6 +176,7 @@ export interface InstanceOptions {
   cacheStorage?: CacheLayer<string, Cached>,
   endpoint?: string,
   retryConfig?: IAxiosRetryConfig,
+  metrics?: MetricsAccumulator,
 }
 
 export interface LegacyInstanceOptions {
@@ -185,6 +186,7 @@ export interface LegacyInstanceOptions {
   accept?: string,
   cacheStorage?: CacheLayer<string, Cached>,
   retryConfig?: IAxiosRetryConfig,
+  metrics?: MetricsAccumulator,
 }
 
 export interface IOResponse<T> {

--- a/src/HttpClient/middlewares/request.ts
+++ b/src/HttpClient/middlewares/request.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import retry, {exponentialDelay, IAxiosRetryConfig, isNetworkOrIdempotentRequestError} from 'axios-retry'
 import {Agent} from 'http'
+import {Limit} from 'p-limit'
 
 import {MiddlewareContext} from '../context'
 
@@ -46,6 +47,6 @@ export const defaultsMiddleware = (baseURL: string | undefined, headers: Record<
   }
 }
 
-export const requestMiddleware = async (ctx: MiddlewareContext, next: () => Promise<void>) => {
-  ctx.response = await http.request(ctx.config)
+export const requestMiddleware = (limit?: Limit) => async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+  ctx.response = await (limit ? limit(() => http.request(ctx.config)) : http.request(ctx.config))
 }

--- a/src/HttpClient/middlewares/request.ts
+++ b/src/HttpClient/middlewares/request.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import retry, {exponentialDelay, IAxiosRetryConfig, isNetworkError} from 'axios-retry'
+import retry, {exponentialDelay, IAxiosRetryConfig, isNetworkOrIdempotentRequestError} from 'axios-retry'
 import {Agent} from 'http'
 
 import {MiddlewareContext} from '../context'
@@ -13,7 +13,7 @@ const http = axios.create({
 
 retry(http, {
   retries: 1,
-  retryCondition: isNetworkError,
+  retryCondition: isNetworkOrIdempotentRequestError,
   retryDelay: exponentialDelay,
 })
 

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -63,7 +63,7 @@ export class Logger extends IODataSource {
   }
 
   public sendLog = (subject: string, message: any, level: string) : Promise<void> => {
-    return queue.add(() => this.http.put(routes.Log(level), message, {params: {subject}}))
+    return queue.add(() => this.http.put(routes.Log(level), message, {params: {subject}, metric: 'logger-send'}))
   }
 }
 

--- a/src/Metadata.ts
+++ b/src/Metadata.ts
@@ -34,7 +34,7 @@ export class Metadata extends IODataSource{
   }
 
   public getBuckets = (bucket: string) => {
-    return this.http.get<BucketMetadata>(routes.Bucket(bucket))
+    return this.http.get<BucketMetadata>(routes.Bucket(bucket), {metric: 'meta-get-buckets'})
   }
 
   public list = (bucket: string, includeValue: boolean, limit?: number, nextMarker?: string) => {
@@ -45,32 +45,34 @@ export class Metadata extends IODataSource{
     if (nextMarker) {
       query._marker = nextMarker
     }
+    const metric = 'meta-list'
 
-    return this.http.get<MetadataEntryList>(routes.Metadata(bucket), {params: query})
+    return this.http.get<MetadataEntryList>(routes.Metadata(bucket), {params: query, metric})
   }
 
   public listAll = (bucket: string, includeValue: boolean) => {
     const query = {value: includeValue, _limit: 1000}
-    return this.http.get<MetadataEntryList>(routes.Metadata(bucket), {params: query})
+    const metric = 'meta-list-all'
+    return this.http.get<MetadataEntryList>(routes.Metadata(bucket), {params: query, metric})
   }
 
   public get = (bucket: string, key: string) => {
-    return this.http.get<any>(routes.MetadataKey(bucket, key))
+    return this.http.get<any>(routes.MetadataKey(bucket, key), {metric: 'meta-get'})
   }
 
   public save = (bucket: string, key: string, data: any) => {
-    return this.http.put(routes.MetadataKey(bucket, key), data)
+    return this.http.put(routes.MetadataKey(bucket, key), data, {metric: 'meta-save'})
   }
 
   public saveAll = (bucket: string, data: {[key: string]: any}) => {
-    return this.http.put(routes.Metadata(bucket), data)
+    return this.http.put(routes.Metadata(bucket), data, {metric: 'meta-save-all'})
   }
 
   public delete = (bucket: string, key: string) => {
-    return this.http.delete(routes.MetadataKey(bucket, key))
+    return this.http.delete(routes.MetadataKey(bucket, key), {metric: 'meta-delete'})
   }
 
   public deleteAll = (bucket: string) => {
-    return this.http.delete(routes.Metadata(bucket))
+    return this.http.delete(routes.Metadata(bucket), {metric: 'meta-delete-all'})
   }
 }

--- a/src/VBase.ts
+++ b/src/VBase.ts
@@ -34,11 +34,11 @@ export class VBase extends IODataSource {
   }
 
   public getBucket = (bucket: string) => {
-    return this.http.get<BucketMetadata>(routes.Bucket(bucket))
+    return this.http.get<BucketMetadata>(routes.Bucket(bucket), {metric: 'vbase-get-bucket'})
   }
 
   public resetBucket = (bucket: string) => {
-    return this.http.delete(routes.Files(bucket))
+    return this.http.delete(routes.Files(bucket), {metric: 'vbase-reset-bucket'})
   }
 
   public listFiles = (bucket: string, opts?: string | VBaseOptions) => {
@@ -48,19 +48,20 @@ export class VBase extends IODataSource {
     } else if (opts) {
       params = {prefix: opts}
     }
-    return this.http.get<BucketFileList>(routes.Files(bucket), {params})
+    const metric = 'vbase-list'
+    return this.http.get<BucketFileList>(routes.Files(bucket), {params, metric})
   }
 
   public getFile = (bucket: string, path: string) => {
-    return this.http.getBuffer(routes.File(bucket, path))
+    return this.http.getBuffer(routes.File(bucket, path), {metric: 'vbase-get-file'})
   }
 
   public getJSON = <T>(bucket: string, path: string, nullIfNotFound?: boolean) => {
-    return this.http.get<T>(routes.File(bucket, path), {nullIfNotFound} as IgnoreNotFoundRequestConfig)
+    return this.http.get<T>(routes.File(bucket, path), {nullIfNotFound, metric: 'vbase-get-json'} as IgnoreNotFoundRequestConfig)
   }
 
   public getFileStream = (bucket: string, path: string): Promise<IncomingMessage> => {
-    return this.http.getStream(routes.File(bucket, path))
+    return this.http.getStream(routes.File(bucket, path), {metric: 'vbase-get-file-s'})
   }
 
   public saveFile = (bucket: string, path: string, stream: Readable, gzip: boolean = true, ttl?: number) => {
@@ -69,7 +70,8 @@ export class VBase extends IODataSource {
 
   public saveJSON = <T>(bucket: string, path: string, data: T) => {
     const headers = {'Content-Type': 'application/json'}
-    return this.http.put(routes.File(bucket, path), data, {headers})
+    const metric = 'vbase-save-json'
+    return this.http.put(routes.File(bucket, path), data, {headers, metric})
   }
 
   public saveZippedContent = (bucket: string, path: string, stream: Readable) => {
@@ -77,7 +79,7 @@ export class VBase extends IODataSource {
   }
 
   public deleteFile = (bucket: string, path: string) => {
-    return this.http.delete(routes.File(bucket, path))
+    return this.http.delete(routes.File(bucket, path), {metric: 'vbase-delete-file'})
   }
 
   private saveContent = (bucket: string, path: string, stream: Readable, opts: VBaseSaveOptions = {}) => {
@@ -96,7 +98,8 @@ export class VBase extends IODataSource {
     if (opts.ttl && Number.isInteger(opts.ttl)) {
       headers['X-VTEX-TTL'] = opts.ttl
     }
-    return this.http.put(routes.File(bucket, path), finalStream, {headers, params})
+    const metric = 'vbase-save-blob'
+    return this.http.put(routes.File(bucket, path), finalStream, {headers, params, metric})
   }
 }
 

--- a/src/Workspaces.ts
+++ b/src/Workspaces.ts
@@ -12,32 +12,33 @@ export class Workspaces extends IODataSource {
   protected httpClientFactory = forRoot
 
   public list = (account: string) => {
-    return this.http.get<WorkspaceMetadata[]>(routes.Account(account))
+    return this.http.get<WorkspaceMetadata[]>(routes.Account(account), {metric: 'workspaces-list'})
   }
 
   public get = (account: string, workspace: string) => {
-    return this.http.get<WorkspaceMetadata>(routes.Workspace(account, workspace))
+    return this.http.get<WorkspaceMetadata>(routes.Workspace(account, workspace), {metric: 'workspaces-get'})
   }
 
   public set = (account: string, workspace: string, metadata: Partial<WorkspaceMetadata>) => {
-    return this.http.put(routes.Workspace(account, workspace), metadata)
+    return this.http.put(routes.Workspace(account, workspace), metadata, {metric: 'workspaces-set'})
   }
 
   public create = (account: string, workspace: string, production: boolean) => {
-    return this.http.post(routes.Account(account), {name: workspace, production})
+    return this.http.post(routes.Account(account), {name: workspace, production}, {metric: 'workspaces-create'})
   }
 
   public delete = (account: string, workspace: string) => {
-    return this.http.delete(routes.Workspace(account, workspace))
+    return this.http.delete(routes.Workspace(account, workspace), {metric: 'workspaces-delete'})
   }
 
   public reset = (account: string, workspace: string, metadata: Partial<WorkspaceMetadata> = {}) => {
     const params = {reset: true}
-    return this.http.put(routes.Workspace(account, workspace), metadata, {params})
+    const metric = 'workspaces-reset'
+    return this.http.put(routes.Workspace(account, workspace), metadata, {params, metric})
   }
 
   public promote = (account: string, workspace: string) => {
-    return this.http.put(routes.Promote(account), {workspace})
+    return this.http.put(routes.Promote(account), {workspace}, {metric: 'workspaces-promote'})
   }
 }
 

--- a/src/utils/Retry.ts
+++ b/src/utils/Retry.ts
@@ -1,14 +1,14 @@
-import {isNetworkError} from 'axios-retry'
+import {isNetworkOrIdempotentRequestError, isSafeRequestError} from 'axios-retry'
 
 const TIMEOUT_CODE = 'ProxyTimeout'
 
 export const isNetworkErrorOrRouterTimeout = (e: any) => {
-  if (isNetworkError(e)) {
+  if (isNetworkOrIdempotentRequestError(e)) {
     console.warn('Retry from network error', e.message)
     return true
   }
 
-  if (e && e.response && e.response.data && e.response.data.code === TIMEOUT_CODE) {
+  if (e && isSafeRequestError(e) && e.response && e.response.data && e.response.data.code === TIMEOUT_CODE) {
     console.warn('Retry from timeout', e.message)
     return true
   }

--- a/src/utils/Retry.ts
+++ b/src/utils/Retry.ts
@@ -1,6 +1,6 @@
 import {isNetworkOrIdempotentRequestError, isSafeRequestError} from 'axios-retry'
 
-const TIMEOUT_CODE = 'ProxyTimeout'
+export const TIMEOUT_CODE = 'ProxyTimeout'
 
 export const isNetworkErrorOrRouterTimeout = (e: any) => {
   if (isNetworkOrIdempotentRequestError(e)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,9 +828,21 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+p-limit@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-queue@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-3.0.0.tgz#0ef247082f0dd5a21b66e2cfe8fb7b06db13fb52"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
+  integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
 
 parse-json@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add automatic metrics to all our native clients and better support for custom metrics on `HttpClient`

#### What problem is this solving?

Lack of visibility around what the heck is erroring/timeout/aborting.

#### How should this be manually tested?
Create your clients passing `metrics` (your global MetricsAccumulator instance) as an instance option. Tada, everything else just works. All your requests' metrics will be recorded.

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
