### PR TITLE
Fix no-store cache directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.3.6] - 2019-03-16
+
 ## [2.3.6-beta] - 2019-03-16
 
 ## [2.3.5] - 2019-03-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.3.6-beta] - 2019-03-16
+
 ## [2.3.5] - 2019-03-14
 
 ## [2.3.4] - 2019-03-14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "2.3.6-beta",
+  "version": "2.3.6",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "2.3.5",
+  "version": "2.3.6-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -102,17 +102,19 @@ export const cacheMiddleware = ({cacheStorage, segmentToken}: {cacheStorage: Cac
       }
     }
 
-    // Indicates this should NOT be cached, and this, cacheHit will not be considered
+    // Indicates this should NOT be cached and this request will not be considered a miss.
     if (noStore || (noCache && !etag)) {
       return
     }
 
+    const shouldCache = maxAge || etag
+
     // Add false to cacheHits to indicate this _should_ be cached but was as miss.
-    if (!ctx.cacheHit) {
+    if (!ctx.cacheHit && shouldCache) {
       ctx.cacheHit = false
     }
 
-    if (maxAge || etag) {
+    if (shouldCache) {
       const currentAge = revalidated ? 0 : age
       const varySegment = ctx.response.headers.vary.includes('x-vtex-segment')
       const setKey = varySegment ? keyWithSegment : key

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -102,12 +102,13 @@ export const cacheMiddleware = ({cacheStorage, segmentToken}: {cacheStorage: Cac
       }
     }
 
+    // Indicates this should NOT be cached, and this, cacheHit will not be considered
     if (noStore || (noCache && !etag)) {
       return
     }
 
     // Add false to cacheHits to indicate this _should_ be cached but was as miss.
-    if (!ctx.cacheHit && !noStore) {
+    if (!ctx.cacheHit) {
       ctx.cacheHit = false
     }
 

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -87,7 +87,7 @@ export const cacheMiddleware = ({cacheStorage, segmentToken}: {cacheStorage: Cac
     }
 
     const {data, headers, status} = ctx.response as AxiosResponse
-    const {age, etag, maxAge, noStore} = parseCacheHeaders(headers)
+    const {age, etag, maxAge, noStore, noCache} = parseCacheHeaders(headers)
 
     if (headers[ROUTER_CACHE_KEY] === ROUTER_CACHE_HIT) {
       if (ctx.cacheHit) {
@@ -102,7 +102,7 @@ export const cacheMiddleware = ({cacheStorage, segmentToken}: {cacheStorage: Cac
       }
     }
 
-    if (noStore && !etag) {
+    if (noStore || (noCache && !etag)) {
       return
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
According to this [link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Other), one should not cache when there is a no-store header. However, this was not the case for node-vtex-api, since we only respected this header when there was no etag available

To address this problem, we should respect `no-store` and `no-cache` headers, i.e. responses with no-store should never be cached, and responses with no-cache should only be cached if they have an etag for validation

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
