### PR TITLE
[WIP] Allow passing build request parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.0.7] - 2019-03-28
 ### Added
 - tsErrorsAsWarnings parameter for the `linkApp` and `relinkApp` methods of the `Builder` class
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- tsErrorsAsWarnings parameter for the `link` and `relink` methods of the `Builder` class
+- tsErrorsAsWarnings parameter for the `linkApp` and `relinkApp` methods of the `Builder` class
 
 ## [3.0.6] - 2019-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- tsErrorsAsWarnings parameter for the `link` and `relink` methods of the `Builder` class
 
 ## [3.0.6] - 2019-03-28
 
@@ -128,7 +130,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.3.0-beta] - 2019-03-13
 
-### Changed 
+### Changed
 - Remove production from MetricsAccumulator methods and add cacheHits
 
 ## [2.2.0] - 2019-03-12

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Builder.ts
+++ b/src/clients/Builder.ts
@@ -55,24 +55,24 @@ export class Builder {
     return this.http.post<BuildResult>(routes.Clean(app), {headers, metric})
   }
 
-  public linkApp = (app: string, files: File[], zipOptions: ZipOptions = {sticky: true}) => {
-    return this.zipAndSend(routes.Link(app), app, files, zipOptions)
+  public linkApp = (app: string, files: File[], zipOptions: ZipOptions = {sticky: true}, params = {}) => {
+    return this.zipAndSend(routes.Link(app), app, files, zipOptions, params)
   }
 
   public publishApp = (app: string, files: File[], zipOptions: ZipOptions = {sticky: true}) => {
     return this.zipAndSend(routes.Publish(app), app, files, zipOptions)
   }
 
-  public relinkApp = (app: string, changes: Change[]) => {
+  public relinkApp = (app: string, changes: Change[], params = {}) => {
     const headers = {
       'Content-Type': 'application/json',
       ...this.stickyHost && {'x-vtex-sticky-host': this.stickyHost},
     }
     const metric = 'bh-relink'
-    return this.http.put<BuildResult>(routes.Relink(app), changes, {headers, metric})
+    return this.http.put<BuildResult>(routes.Relink(app), changes, {headers, metric, params})
   }
 
-  private zipAndSend = async (route: string, app: string, files: File[], {tag, sticky, stickyHint, zlib}: ZipOptions = {}) => {
+  private zipAndSend = async (route: string, app: string, files: File[], {tag, sticky, stickyHint, zlib}: ZipOptions = {}, requestParams = {}) => {
     if (!(files[0] && files[0].path && files[0].content)) {
       throw new Error('Argument files must be an array of {path, content}, where content can be a String, a Buffer or a ReadableStream.')
     }
@@ -87,13 +87,14 @@ export class Builder {
     })
     const hint = stickyHint || `request:${this.account}:${this.workspace}:${app}`
     const metric = 'bh-zip-send'
+    const params = tag ? {...requestParams, tag} : requestParams
     const request = this.http.postRaw<BuildResult>(route, zip, {
       headers: {
         'Content-Type': 'application/octet-stream',
         ...sticky && {'x-vtex-sticky-host': this.stickyHost || hint},
       },
       metric,
-      params: tag ? {tag} : EMPTY_OBJECT,
+      params,
     })
 
     files.forEach(({content, path}) => zip.append(content, {name: path}))

--- a/src/clients/Builder.ts
+++ b/src/clients/Builder.ts
@@ -55,7 +55,7 @@ export class Builder {
     return this.http.post<BuildResult>(routes.Clean(app), {headers, metric})
   }
 
-  public linkApp = (app: string, files: File[], zipOptions: ZipOptions = {sticky: true}, params = {}) => {
+  public linkApp = (app: string, files: File[], zipOptions: ZipOptions = {sticky: true}, params: RequestParams = {}) => {
     return this.zipAndSend(routes.Link(app), app, files, zipOptions, params)
   }
 
@@ -63,7 +63,7 @@ export class Builder {
     return this.zipAndSend(routes.Publish(app), app, files, zipOptions)
   }
 
-  public relinkApp = (app: string, changes: Change[], params = {}) => {
+  public relinkApp = (app: string, changes: Change[], params: RequestParams = {}) => {
     const headers = {
       'Content-Type': 'application/json',
       ...this.stickyHost && {'x-vtex-sticky-host': this.stickyHost},
@@ -72,7 +72,7 @@ export class Builder {
     return this.http.put<BuildResult>(routes.Relink(app), changes, {headers, metric, params})
   }
 
-  private zipAndSend = async (route: string, app: string, files: File[], {tag, sticky, stickyHint, zlib}: ZipOptions = {}, requestParams = {}) => {
+  private zipAndSend = async (route: string, app: string, files: File[], {tag, sticky, stickyHint, zlib}: ZipOptions = {}, requestParams: RequestParams = {}) => {
     if (!(files[0] && files[0].path && files[0].content)) {
       throw new Error('Argument files must be an array of {path, content}, where content can be a String, a Buffer or a ReadableStream.')
     }
@@ -105,6 +105,10 @@ export class Builder {
     this.stickyHost = host
     return data
   }
+}
+
+interface RequestParams {
+  tsErrorsAsWarnings?: boolean,
 }
 
 interface ZipOptions {


### PR DESCRIPTION
This PR makes it possible to pass a `tsErrorsAsWarnings` (boolean) parameter to the `linkApp` and `relinkApp` methods of the `Builder` class.

Setting this parameter to true makes `vtex.builder-hub` accept linking apps with typescript errors.

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
