### PR TITLE
Improve service metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.8-beta] - 2019-03-28
+
 ## [3.0.7-beta.0] - 2019-03-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.7-beta.0] - 2019-03-28
+
 ### Changed
 - Conflate 2xx and 5xx status labels to success and error respectively.
 - Moves metrics status from name to dimension (`http-handler-2xx-render` becomes `http-handler-render` with `2xx` count)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - tsErrorsAsWarnings parameter for the `linkApp` and `relinkApp` methods of the `Builder` class
 ## [3.0.7-beta] - 2019-03-28
 
+### Changed
+- Moves metrics status from name to dimension (`http-handler-2xx-render` becomes `http-handler-render` with `2xx` count)
+- Adds `graphql-operation` metric that considers if _any_ resolver had errors, with two dimensions: success and error
+- Adds success and error dimensions to individual resolver metrics
+- Logs each resolver error individually and add request information
+- Stop logging successful route handlers
+- Add single hardcoded retry for sending error logs
+- Prepare for `graphql` route id (deprecating `__graphql`)
+- Disallow declaration of `graphql` as http route handler
+
 ## [3.0.6] - 2019-03-28
 
 ## [3.0.5] - 2019-03-27
@@ -19,6 +29,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.0.4] - 2019-03-27
 
 ## [3.0.3] - 2019-03-27
+
+### Added
+- Implement new Service() wrapper and port graphql route generation from service-runtime-node.
 
 ## [3.0.3-beta.4] - 2019-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.0.7] - 2019-03-28
 ### Added
 - tsErrorsAsWarnings parameter for the `linkApp` and `relinkApp` methods of the `Builder` class
+## [3.0.7-beta] - 2019-03-28
 
 ## [3.0.6] - 2019-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.0.8-beta] - 2019-03-28
 
-## [3.0.7-beta.0] - 2019-03-28
-
 ### Changed
 - Conflate 2xx and 5xx status labels to success and error respectively.
-- Moves metrics status from name to dimension (`http-handler-2xx-render` becomes `http-handler-render` with `2xx` count)
 - Adds `graphql-operation` metric that considers if _any_ resolver had errors, with two dimensions: success and error
 - Logs each resolver error individually and add request information
 - Stop logging successful route handlers
 - Add single hardcoded retry for sending error logs
 - Prepare for `graphql` route id (deprecating `__graphql`)
 - Disallow declaration of `graphql` as http route handler
+
+## [3.0.7-beta.0] - 2019-03-28
 
 ## [3.0.7] - 2019-03-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.8] - 2019-03-28
+
 ## [3.0.8-beta] - 2019-03-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.0.7] - 2019-03-28
-### Added
-- tsErrorsAsWarnings parameter for the `linkApp` and `relinkApp` methods of the `Builder` class
-## [3.0.7-beta] - 2019-03-28
-
 ### Changed
+- Conflate 2xx and 5xx status labels to success and error respectively.
 - Moves metrics status from name to dimension (`http-handler-2xx-render` becomes `http-handler-render` with `2xx` count)
 - Adds `graphql-operation` metric that considers if _any_ resolver had errors, with two dimensions: success and error
-- Adds success and error dimensions to individual resolver metrics
 - Logs each resolver error individually and add request information
 - Stop logging successful route handlers
 - Add single hardcoded retry for sending error logs
 - Prepare for `graphql` route id (deprecating `__graphql`)
 - Disallow declaration of `graphql` as http route handler
+
+## [3.0.7] - 2019-03-28
+### Added
+- tsErrorsAsWarnings parameter for the `linkApp` and `relinkApp` methods of the `Builder` class
+
+## [3.0.7-beta] - 2019-03-28
 
 ## [3.0.6] - 2019-03-28
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@vtex/api",
+<<<<<<< HEAD
   "version": "3.0.7",
+=======
+  "version": "3.0.7-beta",
+>>>>>>> Release v3.0.7-beta
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.0.8-beta",
+  "version": "3.0.8",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vtex/api",
-<<<<<<< HEAD
   "version": "3.0.7",
-=======
-  "version": "3.0.7-beta",
->>>>>>> Release v3.0.7-beta
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.0.7",
+  "version": "3.0.8-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/metrics.ts
+++ b/src/HttpClient/middlewares/metrics.ts
@@ -8,7 +8,7 @@ const statusLabel = (status: number) =>
 export const metricsMiddleware = (metrics: MetricsAccumulator) => {
   return async (ctx: MiddlewareContext, next: () => Promise<void>) => {
     const start = ctx.config.metric ? process.hrtime() : null
-    let status
+    let status: string = 'unknown'
 
     try {
       await next()
@@ -33,8 +33,9 @@ export const metricsMiddleware = (metrics: MetricsAccumulator) => {
     } finally {
       if (ctx.config.metric) {
         const end = process.hrtime(start as [number, number])
-        const label = `http-client-${status}-${ctx.config.metric}`
+        const label = `http-client-${ctx.config.metric}`
         const extensions: Record<string, string | number> = {
+          [status]: 1,
         }
 
         if (ctx.cacheHit) {

--- a/src/HttpClient/middlewares/metrics.ts
+++ b/src/HttpClient/middlewares/metrics.ts
@@ -1,9 +1,7 @@
 import { MetricsAccumulator } from '../../metrics/MetricsAccumulator'
 import { TIMEOUT_CODE } from '../../utils/retry'
+import { statusLabel } from '../../utils/status'
 import { MiddlewareContext } from '../context'
-
-const statusLabel = (status: number) =>
-  `${Math.floor(status/100)}xx`
 
 export const metricsMiddleware = (metrics: MetricsAccumulator) => {
   return async (ctx: MiddlewareContext, next: () => Promise<void>) => {
@@ -33,10 +31,8 @@ export const metricsMiddleware = (metrics: MetricsAccumulator) => {
     } finally {
       if (ctx.config.metric) {
         const end = process.hrtime(start as [number, number])
-        const label = `http-client-${ctx.config.metric}`
-        const extensions: Record<string, string | number> = {
-          [status]: 1,
-        }
+        const label = `http-client-${status}-${ctx.config.metric}`
+        const extensions: Record<string, string | number> = {}
 
         if (ctx.cacheHit) {
           Object.assign(extensions, ctx.cacheHit)

--- a/src/service/Runtime.ts
+++ b/src/service/Runtime.ts
@@ -4,7 +4,7 @@ import { ClientsImplementation, IOClients } from '../clients/IOClients'
 import { EnvMetric, MetricsAccumulator } from '../metrics/MetricsAccumulator'
 import { addProcessListeners } from '../utils/unhandled'
 
-import { createGraphQLRoute, GRAPHQL_ROUTE } from './graphql'
+import { createGraphQLRoute, GRAPHQL_ROUTE, GRAPHQL_ROUTE_LEGACY } from './graphql'
 import { createHttpRoute } from './http'
 import { Service } from './Service'
 import { ClientsConfig, RouteHandler, ServiceDescriptor } from './typings'
@@ -38,7 +38,12 @@ export class Runtime<ClientsT extends IOClients = IOClients, StateT = void, Cust
       : {}
 
     if (config.graphql) {
-      this.routes[GRAPHQL_ROUTE] = createGraphQLRoute<ClientsT, StateT, CustomT>(config.graphql, Clients, clients.options)
+      let graphqlRoute = GRAPHQL_ROUTE
+      if (descriptor.routes && descriptor.routes[GRAPHQL_ROUTE_LEGACY]) {
+        console.warn('Using legacy graphql route id', GRAPHQL_ROUTE_LEGACY)
+        graphqlRoute = GRAPHQL_ROUTE_LEGACY
+      }
+      this.routes[graphqlRoute] = createGraphQLRoute<ClientsT, StateT, CustomT>(config.graphql, Clients, clients.options)
     }
 
     this.events = config.events

--- a/src/service/Service.ts
+++ b/src/service/Service.ts
@@ -14,5 +14,8 @@ import { ServiceConfig } from './typings'
  */
 export class Service<ClientsT extends IOClients = IOClients, StateT = void, CustomT = void>{
   constructor(public config: ServiceConfig<ClientsT, StateT, CustomT>) {
+    if (config.routes && config.routes.graphql) {
+      throw new Error('Route id "graphql" is reserved. To create a GraphQL app, export a "graphql" key with {resolvers}.')
+    }
   }
 }

--- a/src/service/graphql/index.ts
+++ b/src/service/graphql/index.ts
@@ -28,8 +28,8 @@ export const createGraphQLRoute = <ClientsT extends IOClients, StateT, CustomT>(
 
     return createHttpRoute<ClientsT, StateT, CustomT & GraphQLContext>(Clients, options)([
       injectGraphql,
-      error,
       timings,
+      error,
       upload,
       parseQuery,
       injectSchema,

--- a/src/service/graphql/index.ts
+++ b/src/service/graphql/index.ts
@@ -12,7 +12,8 @@ import { timings } from './middlewares/timings'
 import { upload } from './middlewares/upload'
 import { GraphQLContext, GraphQLServiceContext } from './typings'
 
-export const GRAPHQL_ROUTE = '__graphql'
+export const GRAPHQL_ROUTE_LEGACY = '__graphql'
+export const GRAPHQL_ROUTE = 'graphql'
 
 export const createGraphQLRoute = <ClientsT extends IOClients, StateT, CustomT>(
     graphql: GraphQLOptions<ClientsT, StateT, CustomT>,

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -34,13 +34,13 @@ const isErrorWhitelisted = (errors: any) => Array.isArray(errors) && any(
 )
 
 export const error = async (ctx: GraphQLServiceContext, next: () => Promise<void>) => {
-  const {vtex: { account, workspace }, graphql: { graphqlResponse }} = ctx
+  const {vtex: { account, workspace }} = ctx
   let parsedError: any
 
   try {
     await next()
 
-    parsedError = parseErrorResponse(graphqlResponse || {})
+    parsedError = parseErrorResponse(ctx.graphql.graphqlResponse || {})
   }
   catch (e) {
     if (e.isGraphQLError) {

--- a/src/service/graphql/middlewares/timings.ts
+++ b/src/service/graphql/middlewares/timings.ts
@@ -29,9 +29,8 @@ const batchResolversTracing = (resolvers: ResolverTracing[], graphqlErrors?: any
       parentType: resolver.parentType,
       pathName,
       returnType: resolver.returnType,
-      [status]: 1,
     }
-    metrics.batchMetric(`graphql-resolver-${pathName}`, nanoToMillis(resolver.duration), extensions)
+    metrics.batchMetric(`graphql-resolver-${status}-${pathName}`, nanoToMillis(resolver.duration), extensions)
   })
 }
 
@@ -42,7 +41,7 @@ export const timings = async (ctx: GraphQLServiceContext, next: () => Promise<vo
   await next()
 
   // Batch success or error metric for entire operation
-  metrics.batch(`graphql-operation`, process.hrtime(start), { [ctx.graphql.status as string]: 1 })
+  metrics.batch(`graphql-operation-${ctx.graphql.status}`, process.hrtime(start))
 
   // Batch timings for individual resolvers
   const resolverTimings = path(['extensions', 'tracing', 'execution', 'resolvers'], ctx.graphql.graphqlResponse!) as ResolverTracing[]

--- a/src/service/graphql/typings.ts
+++ b/src/service/graphql/typings.ts
@@ -13,6 +13,7 @@ export interface GraphQLContext {
     query?: HttpQueryRequest['query']
     graphqlResponse?: GraphQLResponse
     responseInit?: HttpQueryResponse['responseInit']
+    status?: 'success' | 'error'
   }
 }
 

--- a/src/service/graphql/typings.ts
+++ b/src/service/graphql/typings.ts
@@ -14,6 +14,7 @@ export interface GraphQLContext {
     graphqlResponse?: GraphQLResponse
     responseInit?: HttpQueryResponse['responseInit']
     status?: 'success' | 'error'
+    graphqlErrors?: any[]
   }
 }
 

--- a/src/service/graphql/utils/pathname.ts
+++ b/src/service/graphql/utils/pathname.ts
@@ -1,0 +1,6 @@
+import { filter } from 'ramda'
+
+export const generatePathName = (rpath: [string | number]) => {
+  const pathFieldNames = filter(value => typeof value === 'string', rpath)
+  return pathFieldNames.join('.')
+}

--- a/src/service/http/index.ts
+++ b/src/service/http/index.ts
@@ -6,7 +6,7 @@ import { timer } from '../../utils/time'
 import { RouteHandler } from '../typings'
 import { clients } from './middlewares/clients'
 import { error } from './middlewares/error'
-import { logger } from './middlewares/logger'
+import { timings } from './middlewares/timings'
 
 export const createHttpRoute = <ClientsT extends IOClients, StateT, CustomT>(
   Clients: ClientsImplementation<ClientsT>,
@@ -14,6 +14,6 @@ export const createHttpRoute = <ClientsT extends IOClients, StateT, CustomT>(
 ) => {
   return (handler: RouteHandler<ClientsT, StateT, CustomT> | Array<RouteHandler<ClientsT, StateT, CustomT>>) => {
     const middlewares = Array.isArray(handler) ? handler : [handler]
-    return compose([clients(Clients, options), logger, error, ...middlewares].map(timer))
+    return compose([clients(Clients, options), timings, error, ...middlewares].map(timer))
   }
 }

--- a/src/service/http/middlewares/error.ts
+++ b/src/service/http/middlewares/error.ts
@@ -12,6 +12,8 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
   } catch (e) {
     console.error('[node-vtex-api error]', e)
     const err = cleanError(e)
+
+    // Add response
     ctx.status = e && e.status >= 400 && e.status <= 599
       ? e.status
       : ctx.status >= 500 && ctx.status <= 599
@@ -20,7 +22,37 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
     ctx.body = ctx.body || err
     ctx.set(CACHE_CONTROL_HEADER, production ? `public, max-age=${TWO_SECONDS_S}` : `no-cache, no-store`)
 
-    // Rethrows to be caught by logger middleware
-    throw err
+    // Log error
+    const {
+      method,
+      status,
+      vtex: {
+        operationId,
+        requestId,
+        route: {
+          id,
+        },
+      },
+      headers: {
+        'x-forwarded-path': forwardedPath,
+        'x-forwarded-host': forwardedHost,
+        'x-forwarded-proto': forwardedProto,
+        'x-vtex-platform': platform,
+      },
+    } = ctx
+
+    // Use sendLog directly to avoid cleaning error twice.
+    ctx.clients.logger.sendLog('-', {
+      ...error,
+      forwardedHost,
+      forwardedPath,
+      forwardedProto,
+      method,
+      operationId,
+      platform,
+      requestId,
+      routeId: id,
+      status,
+    }, 'error')
   }
 }

--- a/src/service/http/middlewares/error.ts
+++ b/src/service/http/middlewares/error.ts
@@ -41,7 +41,6 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
       },
     } = ctx
 
-    // Use sendLog directly to avoid cleaning error twice.
     const log = {
       ...err,
       forwardedHost,
@@ -55,6 +54,7 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
       status,
     }
 
+    // Use sendLog directly to avoid cleaning error twice.
     ctx.clients.logger.sendLog('-', log, 'error').catch((reason) => {
       console.error('Error logging error 🙄 retrying once...', reason ? reason.response : '')
       ctx.clients.logger.sendLog('-', log, 'error').catch()

--- a/src/service/http/middlewares/error.ts
+++ b/src/service/http/middlewares/error.ts
@@ -42,7 +42,7 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
     } = ctx
 
     // Use sendLog directly to avoid cleaning error twice.
-    ctx.clients.logger.sendLog('-', {
+    const log = {
       ...error,
       forwardedHost,
       forwardedPath,
@@ -53,6 +53,11 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
       requestId,
       routeId: id,
       status,
-    }, 'error')
+    }
+
+    ctx.clients.logger.sendLog('-', log, 'error').catch((reason) => {
+      console.error('Error logging error 🙄 retrying once...', reason ? reason.response : '')
+      ctx.clients.logger.sendLog('-', log, 'error').catch()
+    })
   }
 }

--- a/src/service/http/middlewares/error.ts
+++ b/src/service/http/middlewares/error.ts
@@ -43,7 +43,7 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
 
     // Use sendLog directly to avoid cleaning error twice.
     const log = {
-      ...error,
+      ...err,
       forwardedHost,
       forwardedPath,
       forwardedProto,

--- a/src/service/http/middlewares/timings.ts
+++ b/src/service/http/middlewares/timings.ts
@@ -1,7 +1,6 @@
 import { IOClients } from '../../../clients/IOClients'
 import { hrToMillis } from '../../../utils/time'
 import { updateLastLogger } from '../../../utils/unhandled'
-import { GRAPHQL_ROUTE } from '../../graphql'
 import { ServiceContext } from '../../typings'
 
 const statusLabel = (status: number) => `${Math.floor(status/100)}xx`
@@ -13,7 +12,7 @@ const log = <T extends IOClients, U, V>(
   `${new Date().toISOString()}\t${account}/${workspace}:${id}\t${status}\t${method}\t${path}\t${millis}ms`
 
 
-export async function logger<T extends IOClients, U, V> (ctx: ServiceContext<T, U, V>, next: () => Promise<any>) {
+export async function timings<T extends IOClients, U, V> (ctx: ServiceContext<T, U, V>, next: () => Promise<any>) {
   const start = process.hrtime()
   let error
 
@@ -59,7 +58,7 @@ export async function logger<T extends IOClients, U, V> (ctx: ServiceContext<T, 
       status,
     }, logType)
 
-    metrics.batch(`http-handler-${statusLabel(status)}-${id.replace(GRAPHQL_ROUTE, 'graphql')}`, end)
+    metrics.batch(`http-handler-${statusLabel(status)}-${id}`, end)
     console.log(log(ctx, millis))
   }
 }

--- a/src/service/http/middlewares/timings.ts
+++ b/src/service/http/middlewares/timings.ts
@@ -23,6 +23,6 @@ export async function timings<T extends IOClients, U, V> (ctx: ServiceContext<T,
   const end = process.hrtime(start)
   const millis = hrToMillis(end)
 
-  metrics.batch(`http-handler-${statusLabel(status)}-${id}`, end)
+  metrics.batch(`http-handler-${id}`, end, { [statusLabel(status)]: 1 })
   console.log(log(ctx, millis))
 }

--- a/src/service/http/middlewares/timings.ts
+++ b/src/service/http/middlewares/timings.ts
@@ -1,9 +1,8 @@
 import { IOClients } from '../../../clients/IOClients'
+import { statusLabel } from '../../../utils/status'
 import { hrToMillis } from '../../../utils/time'
 import { updateLastLogger } from '../../../utils/unhandled'
 import { ServiceContext } from '../../typings'
-
-const statusLabel = (status: number) => `${Math.floor(status/100)}xx`
 
 const log = <T extends IOClients, U, V>(
   {vtex: {account, workspace, route: {id}}, path, method, status}: ServiceContext<T, U, V>,
@@ -23,6 +22,6 @@ export async function timings<T extends IOClients, U, V> (ctx: ServiceContext<T,
   const end = process.hrtime(start)
   const millis = hrToMillis(end)
 
-  metrics.batch(`http-handler-${id}`, end, { [statusLabel(status)]: 1 })
+  metrics.batch(`http-handler-${statusLabel(status)}-${id}`, end, { [status]: 1 })
   console.log(log(ctx, millis))
 }

--- a/src/service/http/middlewares/timings.ts
+++ b/src/service/http/middlewares/timings.ts
@@ -11,54 +11,18 @@ const log = <T extends IOClients, U, V>(
 ) =>
   `${new Date().toISOString()}\t${account}/${workspace}:${id}\t${status}\t${method}\t${path}\t${millis}ms`
 
-
 export async function timings<T extends IOClients, U, V> (ctx: ServiceContext<T, U, V>, next: () => Promise<any>) {
   const start = process.hrtime()
-  let error
 
   updateLastLogger(ctx.clients.logger)
 
-  try {
-    await next()
-  } catch (e) {
-    error = e
-  } finally {
-    const {
-      method,
-      status,
-      vtex: {
-        operationId,
-        requestId,
-        route: {
-          id,
-        },
-      },
-      headers: {
-        'x-forwarded-path': forwardedPath,
-        'x-forwarded-host': forwardedHost,
-        'x-forwarded-proto': forwardedProto,
-        'x-vtex-platform': platform,
-      },
-    } = ctx
-    const end = process.hrtime(start)
-    const millis = hrToMillis(end)
-    const logType = error ? 'error' : 'info'
+  // Errors will be caught by the next middleware so we don't have to catch.
+  await next()
 
-    ctx.clients.logger.sendLog('-', {
-      ... error ? error : null,
-      forwardedHost,
-      forwardedPath,
-      forwardedProto,
-      method,
-      millis,
-      operationId,
-      platform,
-      requestId,
-      routeId: id,
-      status,
-    }, logType)
+  const { status, vtex: { route: { id } } } = ctx
+  const end = process.hrtime(start)
+  const millis = hrToMillis(end)
 
-    metrics.batch(`http-handler-${statusLabel(status)}-${id}`, end)
-    console.log(log(ctx, millis))
-  }
+  metrics.batch(`http-handler-${statusLabel(status)}-${id}`, end)
+  console.log(log(ctx, millis))
 }

--- a/src/service/typings.ts
+++ b/src/service/typings.ts
@@ -8,7 +8,6 @@ import { ParsedUrlQuery } from 'querystring'
 import { ClientsImplementation, IOClients } from '../clients/IOClients'
 import { InstanceOptions } from '../HttpClient'
 import { Recorder } from '../HttpClient/middlewares/recorder'
-import { StatusTrack } from '../metrics/MetricsAccumulator'
 
 export interface Context<T extends IOClients> {
   clients: T

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -1,0 +1,9 @@
+export const statusLabel = (status: number) => {
+  if (status >= 500) {
+    return 'error'
+  }
+  if (status >= 200 && status < 300) {
+    return 'success'
+  }
+  return 'other'
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -20,7 +20,8 @@ function recordTimings(start: [number, number], name: string, timings: Record<st
   // Capture the total amount of time spent in this middleware
   const end = process.hrtime(start)
   timings[name] = end
-  metrics.batch(name, end)
+  const label = `middleware-${name}`
+  metrics.batch(label, end)
 
   // This middleware has added it's own metrics
   // Just add them to `timings` scoped by the middleware's name and batch them
@@ -28,7 +29,7 @@ function recordTimings(start: [number, number], name: string, timings: Record<st
   if (middlewareMetricsKeys.length > 0) {
     forEach((k: string) => {
       const metricEnd = middlewareMetrics[k]
-      const metricName = `${name}-${k}`
+      const metricName = `${label}-${k}`
       timings[metricName] = metricEnd
       metrics.batch(metricName, metricEnd)
     }, middlewareMetricsKeys)


### PR DESCRIPTION
- Moves metrics status from name to dimension (`http-handler-2xx-render` becomes `http-handler-render` with `2xx` count)
- Adds `graphql-operation` metric that considers if _any_ resolver had errors, with two dimensions: success and error
- Adds success and error dimensions to individual resolver metrics
- Logs each resolver error individually and add request information
- Stop logging successful route handlers
- Add single hardcoded retry for sending error logs
- Prepare for `graphql` route id (deprecating `__graphql`)
- Disallow declaration of `graphql` as http route handler
