### PR TITLE
Deprecates listing files api from VBase client

### DIFF
--- a/src/clients/VBase.ts
+++ b/src/clients/VBase.ts
@@ -17,7 +17,6 @@ const [runningAppName] = appId ? appId.split('@') : ['']
 const routes = {
   Bucket: (bucket: string) => `/buckets/${runningAppName}/${bucket}`,
   File: (bucket: string, path: string) => `${routes.Bucket(bucket)}/files/${path}`,
-  Files: (bucket: string) => `${routes.Bucket(bucket)}/files`,
 }
 
 const isVBaseOptions = (opts?: string | VBaseOptions): opts is VBaseOptions => {
@@ -41,20 +40,12 @@ export class VBase extends IODataSource {
     return this.http.get<BucketMetadata>(routes.Bucket(bucket), {metric, inflightKey})
   }
 
-  public resetBucket = (bucket: string) => {
-    return this.http.delete(routes.Files(bucket), {metric: 'vbase-reset-bucket'})
+  public resetBucket = () => {
+    throw new Error('resetBucket is deprecated in Vbase client due to lack of listing files support in Vbase API. This function will be removed in future versions')
   }
 
-  public listFiles = (bucket: string, opts?: string | VBaseOptions) => {
-    let params: VBaseOptions = {}
-    if (isVBaseOptions(opts)) {
-      params = opts
-    } else if (opts) {
-      params = {prefix: opts}
-    }
-    const metric = 'vbase-list'
-    const inflightKey = inflightURL
-    return this.http.get<BucketFileList>(routes.Files(bucket), {params, metric, inflightKey})
+  public listFiles = () => {
+    throw new Error('listFiles is deprecated in Vbase client due to lack of listing files support in Vbase API. This function will be removed in future versions')
   }
 
   public getFile = (bucket: string, path: string) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Deprecates the `/files` API used in Vbase client due to changes in API

#### What problem is this solving?
Vbase is currently deprecating files listing. This PR solves this problem by removing the endpoint used by Vbase client. However, the methods were not removed from Vbase client. When these methods are called, an exception is thrown with a deprecation message.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
