### PR TITLE
Fix graphql middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.16-beta] - 2019-04-04
+
 ## [3.0.15] - 2019-04-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.16-beta.0] - 2019-04-04
+
 ## [3.0.16-beta] - 2019-04-04
 
 ## [3.0.15] - 2019-04-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.16] - 2019-04-04
+
 ## [3.0.16-beta.0] - 2019-04-04
 
 ## [3.0.16-beta] - 2019-04-04

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.0.16-beta.0",
+  "version": "3.0.16",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.0.15",
+  "version": "3.0.16-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.0.16-beta",
+  "version": "3.0.16-beta.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -67,6 +67,7 @@ export async function error (ctx: GraphQLServiceContext, next: () => Promise<voi
   }
   finally {
     if (graphqlErrors) {
+      console.log('settings error to graphql status')
       ctx.graphql.status = 'error'
       ctx.set('Cache-Control', 'no-cache, no-store')
 
@@ -98,6 +99,7 @@ export async function error (ctx: GraphQLServiceContext, next: () => Promise<voi
         console.log(getSplunkQuery(account, workspace))
       }
     } else {
+      console.log('settings success to graphql status')
       ctx.graphql.status = 'success'
     }
   }

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -67,7 +67,6 @@ export async function error (ctx: GraphQLServiceContext, next: () => Promise<voi
   }
   finally {
     if (graphqlErrors) {
-      console.log('settings error to graphql status')
       ctx.graphql.status = 'error'
       ctx.set('Cache-Control', 'no-cache, no-store')
 
@@ -99,7 +98,6 @@ export async function error (ctx: GraphQLServiceContext, next: () => Promise<voi
         console.log(getSplunkQuery(account, workspace))
       }
     } else {
-      console.log('settings success to graphql status')
       ctx.graphql.status = 'success'
     }
   }

--- a/src/service/graphql/middlewares/run.ts
+++ b/src/service/graphql/middlewares/run.ts
@@ -37,30 +37,35 @@ export const run = async (ctx: GraphQLServiceContext, next: () => Promise<void>)
   // so we delete it here and restore it after execution.
   delete ctx.graphql
 
-  const {graphqlResponse, responseInit} = await runHttpQuery([], {
-    method,
-    options: {
-      cacheControl: {
-        calculateHttpHeaders: true,
-        defaultMaxAge: defaultMaxAgeFromCtx(ctx),
-        stripFormattedExtensions: false,
-      },
-      context: ctx,
-      dataSources,
-      debug: !production,
-      formatError,
-      formatResponse,
-      persistedQueries,
-      schema,
-      tracing: true,
-    } as any,
-    query: query!,
-    request,
-  })
+  try {
+    const {graphqlResponse, responseInit} = await runHttpQuery([], {
+      method,
+      options: {
+        cacheControl: {
+          calculateHttpHeaders: true,
+          defaultMaxAge: defaultMaxAgeFromCtx(ctx),
+          stripFormattedExtensions: false,
+        },
+        context: ctx,
+        dataSources,
+        debug: !production,
+        formatError,
+        formatResponse,
+        persistedQueries,
+        schema,
+        tracing: true,
+      } as any,
+      query: query!,
+      request,
+    })
 
-  ctx.graphql = graphql
-  ctx.graphql.responseInit = responseInit
-  ctx.graphql.graphqlResponse = JSON.parse(graphqlResponse)
+    ctx.graphql = graphql
+    ctx.graphql.responseInit = responseInit
+    ctx.graphql.graphqlResponse = JSON.parse(graphqlResponse)
+  } catch (err) {
+    ctx.graphql = graphql
+    throw err
+  }
 
   await next()
 }

--- a/src/service/graphql/middlewares/run.ts
+++ b/src/service/graphql/middlewares/run.ts
@@ -64,7 +64,6 @@ export const run = async (ctx: GraphQLServiceContext, next: () => Promise<void>)
     ctx.graphql.graphqlResponse = JSON.parse(graphqlResponse)
   } catch (err) {
     ctx.graphql = graphql
-    console.log('reseting graphql', graphql)
     throw err
   }
 

--- a/src/service/graphql/middlewares/run.ts
+++ b/src/service/graphql/middlewares/run.ts
@@ -64,6 +64,7 @@ export const run = async (ctx: GraphQLServiceContext, next: () => Promise<void>)
     ctx.graphql.graphqlResponse = JSON.parse(graphqlResponse)
   } catch (err) {
     ctx.graphql = graphql
+    console.log('reseting graphql', graphql)
     throw err
   }
 

--- a/src/service/graphql/middlewares/timings.ts
+++ b/src/service/graphql/middlewares/timings.ts
@@ -44,6 +44,8 @@ export const timings = async (ctx: GraphQLServiceContext, next: () => Promise<vo
   metrics.batch(`graphql-operation-${ctx.graphql.status}`, process.hrtime(start))
 
   // Batch timings for individual resolvers
-  const resolverTimings = path(['extensions', 'tracing', 'execution', 'resolvers'], ctx.graphql.graphqlResponse!) as ResolverTracing[]
-  batchResolversTracing(resolverTimings, ctx.graphql.graphqlErrors)
+  const resolverTimings = path<ResolverTracing[] | undefined>(['extensions', 'tracing', 'execution', 'resolvers'], ctx.graphql.graphqlResponse!)
+  if (resolverTimings) {
+    batchResolversTracing(resolverTimings, ctx.graphql.graphqlErrors)
+  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
When `runHttpQuery` function fails and throws, the graphql context is never re-assigned to the context, causing multiple failures along the pipeline execution. This PR solves this problem by always re-assigning the graphql context to the koa context even when runHttpQuery fails

#### What problem is this solving?


#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
