### PR TITLE
Add forceMaxAge param to RequestConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Option `forceMaxAge` option to `HttpClient` request config. This allows certain requests to forceably be cached for `forceMaxAge` seconds, regardless of the responses' `Cache-control` header, as long as status is 200.
+
 ## [3.1.2] - 2019-04-09
 ### Changed
 - Makes errors compliant to [apollo's specification](https://www.apollographql.com/docs/apollo-server/features/errors)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0-beta.5] - 2019-04-09
+
 ## [3.2.0-beta.4] - 2019-04-08
 
 ## [3.2.0-beta.3] - 2019-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0-beta.1] - 2019-04-08
+
 ## [3.2.0-beta.0] - 2019-04-08
 
 ## [3.2.0-beta] - 2019-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0-beta.3] - 2019-04-08
+
 ### Added
 - `segment.getSegment` and `segment.getSegmentByToken`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0-beta.0] - 2019-04-08
+
 ## [3.2.0-beta] - 2019-04-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0-beta.6] - 2019-04-09
+
 ## [3.2.0-beta.5] - 2019-04-09
 
 ## [3.2.0-beta.4] - 2019-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0-beta.4] - 2019-04-08
+
 ## [3.2.0-beta.3] - 2019-04-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0-beta] - 2019-04-08
+
 ### Added
 - Option `forceMaxAge` option to `HttpClient` request config. This allows certain requests to forceably be cached for `forceMaxAge` seconds, regardless of the responses' `Cache-control` header, as long as status is 200.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0-beta.2] - 2019-04-08
+
 ## [3.2.0-beta.1] - 2019-04-08
 
 ## [3.2.0-beta.0] - 2019-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0-beta.7] - 2019-04-09
+
 ## [3.2.0-beta.6] - 2019-04-09
 
 ## [3.2.0-beta.5] - 2019-04-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `segment.getSegment` and `segment.getSegmentByToken`
+
 ## [3.2.0-beta.2] - 2019-04-08
 
 ## [3.2.0-beta.1] - 2019-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.2.0] - 2019-04-09
+
 ## [3.2.0-beta.7] - 2019-04-09
 
 ## [3.2.0-beta.6] - 2019-04-09

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0-beta.3",
+  "version": "3.2.0-beta.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0-beta.1",
+  "version": "3.2.0-beta.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0-beta.6",
+  "version": "3.2.0-beta.7",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.1.2",
+  "version": "3.2.0-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0-beta.4",
+  "version": "3.2.0-beta.5",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0-beta.2",
+  "version": "3.2.0-beta.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0-beta",
+  "version": "3.2.0-beta.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0-beta.0",
+  "version": "3.2.0-beta.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0-beta.5",
+  "version": "3.2.0-beta.6",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0-beta.7",
+  "version": "3.2.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/context.ts
+++ b/src/HttpClient/context.ts
@@ -12,6 +12,7 @@ export interface RequestConfig extends AxiosRequestConfig {
   cacheable?: CacheType
   memoizeable?: boolean
   inflightKey?: InflightKeyGenerator
+  forceMaxAge?: number
 }
 
 export interface CacheHit {

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -121,7 +121,7 @@ export const cacheMiddleware = ({type, storage, segmentToken}: CacheOptions) => 
     const {data, headers, status} = ctx.response as AxiosResponse
     const {age, etag, maxAge: headerMaxAge, noStore, noCache} = parseCacheHeaders(headers)
     const {forceMaxAge} = ctx.config
-    const maxAge = forceMaxAge && !noStore && cacheableStatusCodes.includes(status) ? Math.max(forceMaxAge, headerMaxAge) : headerMaxAge
+    const maxAge = forceMaxAge && cacheableStatusCodes.includes(status) ? Math.max(forceMaxAge, headerMaxAge) : headerMaxAge
 
     if (headers[ROUTER_CACHE_KEY] === ROUTER_CACHE_HIT) {
       if (ctx.cacheHit) {
@@ -139,7 +139,7 @@ export const cacheMiddleware = ({type, storage, segmentToken}: CacheOptions) => 
     }
 
     // Indicates this should NOT be cached and this request will not be considered a miss.
-    if (noStore || (noCache && !etag)) {
+    if (!forceMaxAge && (noStore || (noCache && !etag))) {
       return
     }
 

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -1,5 +1,5 @@
 import {AxiosRequestConfig, AxiosResponse} from 'axios'
-import {URL, URLSearchParams} from 'url'
+import {URL} from 'url'
 import {CacheLayer} from '../../caches/CacheLayer'
 import {MiddlewareContext, RequestConfig} from '../context'
 
@@ -113,7 +113,9 @@ export const cacheMiddleware = ({type, storage, segmentToken}: CacheOptions) => 
     }
 
     const {data, headers, status} = ctx.response as AxiosResponse
-    const {age, etag, maxAge, noStore, noCache} = parseCacheHeaders(headers)
+    const {age, etag, maxAge: headerMaxAge, noStore, noCache} = parseCacheHeaders(headers)
+    const {forceMaxAge} = ctx.config
+    const maxAge = forceMaxAge && status === 200 ? Math.max(forceMaxAge, headerMaxAge) : headerMaxAge
 
     if (headers[ROUTER_CACHE_KEY] === ROUTER_CACHE_HIT) {
       if (ctx.cacheHit) {
@@ -167,7 +169,7 @@ export interface Cached {
   response: Partial<AxiosResponse>
 }
 
-export type CacheableRequestConfig = AxiosRequestConfig & {
+export type CacheableRequestConfig = RequestConfig & {
   url: string,
   cacheable: CacheType,
   memoizable: boolean

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -115,7 +115,7 @@ export const cacheMiddleware = ({type, storage, segmentToken}: CacheOptions) => 
     const {data, headers, status} = ctx.response as AxiosResponse
     const {age, etag, maxAge: headerMaxAge, noStore, noCache} = parseCacheHeaders(headers)
     const {forceMaxAge} = ctx.config
-    const maxAge = forceMaxAge && status === 200 ? Math.max(forceMaxAge, headerMaxAge) : headerMaxAge
+    const maxAge = forceMaxAge && status === 200 && !noStore ? Math.max(forceMaxAge, headerMaxAge) : headerMaxAge
 
     if (headers[ROUTER_CACHE_KEY] === ROUTER_CACHE_HIT) {
       if (ctx.cacheHit) {

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -157,7 +157,7 @@ export const cacheMiddleware = ({type, storage, segmentToken}: CacheOptions) => 
 
     if (shouldCache) {
       const currentAge = revalidated ? 0 : age
-      const varySegment = ctx.response.headers.vary.includes('x-vtex-segment')
+      const varySegment = ctx.response.headers.vary && ctx.response.headers.vary.includes('x-vtex-segment')
       const setKey = varySegment ? keyWithSegment : key
       await storage.set(setKey, {
         etag,

--- a/src/HttpClient/middlewares/inflight.ts
+++ b/src/HttpClient/middlewares/inflight.ts
@@ -1,3 +1,4 @@
+import { stringify } from 'qs'
 import { InflightKeyGenerator, MiddlewareContext, RequestConfig } from '../context'
 
 export type Inflight = Required<Pick<MiddlewareContext, 'cacheHit' | 'response'>>
@@ -56,3 +57,5 @@ export const singleFlightMiddleware = async (ctx: MiddlewareContext, next: () =>
 }
 
 export const inflightURL: InflightKeyGenerator = ({baseURL, url}: RequestConfig) => baseURL! + url!
+
+export const inflightUrlWithQuery: InflightKeyGenerator = ({baseURL, url, params}: RequestConfig) => baseURL! + url! + stringify(params, {arrayFormat: 'repeat', addQueryPrefix: true})

--- a/src/clients/Messages.ts
+++ b/src/clients/Messages.ts
@@ -1,4 +1,5 @@
 import { InstanceOptions } from '../HttpClient'
+import { inflightUrlWithQuery } from '../HttpClient/middlewares/inflight'
 import { forWorkspace, IODataSource } from '../IODataSource'
 import { IOMessage } from '../service/graphql/schema/typeDefs/ioMessage'
 import { IOContext } from '../service/typings'
@@ -15,6 +16,7 @@ export class Messages extends IODataSource {
     headers: {
       Authorization: this.context!.authToken,
     },
+    inflightKey: inflightUrlWithQuery,
     metric: 'messages-translate',
     params: {
       __p: process.env.VTEX_APP_ID,

--- a/src/clients/Segment.ts
+++ b/src/clients/Segment.ts
@@ -19,6 +19,7 @@ export interface SegmentData {
 }
 
 const SEGMENT_COOKIE = 'vtex_segment'
+const SEGMENT_MAX_AGE_S = 10 * 60 // 10 minutes - segment is actually immutable
 
 const sanitizeParams = (params?: Record<string, string>) => {
   return pickBy((_, key) => !!key, params || {})
@@ -55,6 +56,7 @@ export class Segment extends IODataSource {
     const {segmentToken, authToken, account} = this.context!
     const selectedToken = token || segmentToken
     return this.http.getRaw<SegmentData>(routes.segments(selectedToken), ({
+      forceMaxAge: SEGMENT_MAX_AGE_S,
       headers: {
         'Content-Type': 'application/json',
         'Proxy-Authorization': authToken,

--- a/src/clients/Segment.ts
+++ b/src/clients/Segment.ts
@@ -31,10 +31,18 @@ const routes = {
 }
 
 export class Segment extends IODataSource {
+  public segment: (query?: Record<string, string>, token?: string) => Promise<SegmentData>
   protected httpClientFactory = forExternal
   protected service = 'http://portal.vtexcommercestable.com.br'
 
-  public segment = (query?: Record<string, string>, token?: string) =>
+  constructor() {
+    super()
+
+    // Backwards compatibility
+    this.segment = this.getSegment.bind(this)
+  }
+
+  public getSegment = (query?: Record<string, string>, token?: string) =>
     this.rawSegment(query, token).then(prop('data'))
 
   public getOrCreateSegment = async (query?: Record<string, string>, token?: string) => {
@@ -63,8 +71,8 @@ export class Segment extends IODataSource {
       },
       metric: 'segment-get',
       params: {
-        an: account,
         ...sanitizeParams(query),
+        an: account,
       },
     }))
   }

--- a/src/clients/Segment.ts
+++ b/src/clients/Segment.ts
@@ -1,6 +1,7 @@
 import parseCookie from 'cookie'
 import { pickBy, prop } from 'ramda'
 
+import { inflightUrlWithQuery } from '../HttpClient/middlewares/inflight'
 import { forExternal, IODataSource } from '../IODataSource'
 
 export interface SegmentData {
@@ -69,6 +70,7 @@ export class Segment extends IODataSource {
         'Content-Type': 'application/json',
         'Proxy-Authorization': authToken,
       },
+      inflightKey: inflightUrlWithQuery,
       metric: 'segment-get',
       params: {
         ...sanitizeParams(query),

--- a/src/clients/Segment.ts
+++ b/src/clients/Segment.ts
@@ -41,7 +41,7 @@ export class Segment extends IODataSource {
    * @memberof Segment
    */
   public segment = (query?: Record<string, string>, token?: string) =>
-    this.rawSegment(token, query).then(prop('data'))
+    this.rawSegment(token || this.context!.segmentToken, query).then(prop('data'))
 
   /**
    * Get the segment data using the current `ctx.vtex.segmentToken`

--- a/src/service/graphql/schema/index.ts
+++ b/src/service/graphql/schema/index.ts
@@ -43,7 +43,7 @@ export const makeSchema = (ctx: GraphQLServiceContext) => {
 
   // The target translation locale is only necessary if this GraphQL app uses the `IOMessage` resolver.
   const getLocaleTo = async () => {
-    const {cultureInfo} = await ctx.clients.segment.segment()
+    const {cultureInfo} = await ctx.clients.segment.getSegment()
     return cultureInfo
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow users to cache forceably when the incoming API doesn't respond with maxAge.

#### What problem is this solving?

Segment API is being called 33k/min for immutable resources. Caching this should drastically reduce the number of calls.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
