### PR TITLE
Clean auth in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.2.1] - 2019-04-09
 ### Fixed
 - Security hole as `Authorization`, `Proxy-Authorization` and `vtexIdClientAutCookie` headers were being sent to graphql errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Security hole as `Authorization`, `Proxy-Authorization` and `vtexIdClientAutCookie` headers were being sent to graphql errors
 
 ## [3.2.0] - 2019-04-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -78,6 +78,10 @@ const destroyCircular = (from: any, seen: string[]) => {
         if (!!proxyAuth) {
           delete headers[proxyAuth]
         }
+        const vtexIdClientAutCookie = findCaseInsensitive('vtexidclientautcookie', headerNames)
+        if (!!vtexIdClientAutCookie) {
+          delete headers[vtexIdClientAutCookie]
+        }
       }
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Now that errors are correctly reported, we have a security whole where the authorization header of an app deep inside our architecture is exposed to our front-end when an error occurs.

#### What problem is this solving?
This PR fixes the aforementioned error by removing `Authorization`,`Proxy-Authorization` and `vtexIdclientAutCookie` headers

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
