### PR TITLE
Feature/socket stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.3.1] - 2019-04-16
 
+## [3.3.1-beta.1] - 2019-04-17
+
 ## [3.3.1-beta.0] - 2019-04-17
 
 ## [3.3.1-beta] - 2019-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.6.0] - 2019-04-24
+
 ## [3.5.2-beta] - 2019-04-24
 
 ## [3.5.1] - 2019-04-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.3.1] - 2019-04-16
 
+## [3.3.1-beta.0] - 2019-04-17
+
 ## [3.3.1-beta] - 2019-04-15
 
 ## [3.3.0] - 2019-04-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.5.2-beta] - 2019-04-24
+
 ## [3.5.1] - 2019-04-23
 
 ## [3.5.0] - 2019-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.3.1] - 2019-04-16
 
+## [3.3.1-beta] - 2019-04-15
+
 ## [3.3.0] - 2019-04-11
 ### Added
 - Messages `saveTransalation` method
@@ -417,4 +419,3 @@ instead
 ## [0.48.0] - 2018-09-21
 ### Changed
 - `HttpClient` now adds `'Accept-Encoding': 'gzip'` header by default.
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.5.1",
+  "version": "3.5.2-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.5.2-beta",
+  "version": "3.6.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/request.ts
+++ b/src/HttpClient/middlewares/request.ts
@@ -2,13 +2,14 @@ import axios from 'axios'
 import retry, {exponentialDelay} from 'axios-retry'
 import {Agent} from 'http'
 import {Limit} from 'p-limit'
+import {mapObjIndexed, sum, values} from 'ramda'
 
 import {isAbortedOrNetworkErrorOrRouterTimeout} from '../../utils/retry'
 import {hrToMillis} from '../../utils/time'
 
 import {MiddlewareContext} from '../context'
 
-export const httpAgent = new Agent({
+const httpAgent = new Agent({
   keepAlive: true,
   maxFreeSockets: 50,
 })
@@ -81,4 +82,26 @@ export const requestMiddleware = (limit?: Limit) => async (ctx: MiddlewareContex
   }
 
   ctx.response = await (limit ? limit(makeRequest) : makeRequest())
+}
+
+function countPerOrigin (obj: { [key: string]: any[] }) {
+  try {
+    return mapObjIndexed(val => val.length, obj)
+  } catch (_) {
+    return {}
+  }
+}
+
+export function httpAgentStats () {
+  const socketsPerOrigin = countPerOrigin(httpAgent.sockets)
+  const sockets = sum(values(socketsPerOrigin))
+  const pendingRequestsPerOrigin = countPerOrigin(httpAgent.requests)
+  const pendingRequests = sum(values(pendingRequestsPerOrigin))
+
+  return {
+    pendingRequests,
+    pendingRequestsPerOrigin,
+    sockets,
+    socketsPerOrigin,
+  }
 }

--- a/src/HttpClient/middlewares/request.ts
+++ b/src/HttpClient/middlewares/request.ts
@@ -8,11 +8,13 @@ import {hrToMillis} from '../../utils/time'
 
 import {MiddlewareContext} from '../context'
 
+export const httpAgent = new Agent({
+  keepAlive: true,
+  maxFreeSockets: 50,
+})
+
 const http = axios.create({
-  httpAgent: new Agent({
-    keepAlive: true,
-    maxFreeSockets: 50,
-  }),
+  httpAgent,
 })
 
 retry(http, {

--- a/src/metrics/MetricsAccumulator.ts
+++ b/src/metrics/MetricsAccumulator.ts
@@ -49,7 +49,7 @@ function cpuUsage () {
   return diff
 }
 
-function cntPerOrigin (obj: { [key: string]: any[] }) {
+function countPerOrigin (obj: { [key: string]: any[] }) {
   try {
     return mapObjIndexed(val => val.length, obj)
   } catch (_) {
@@ -58,16 +58,16 @@ function cntPerOrigin (obj: { [key: string]: any[] }) {
 }
 
 export function socketStats () {
-  const cntSocketsPerOrigin = cntPerOrigin(httpAgent.sockets)
-  const cntSockets = sum(values(cntSocketsPerOrigin))
-  const cntPendingRequestsPerOrigin = cntPerOrigin(httpAgent.requests)
-  const cntPendingRequests = sum(values(cntPendingRequestsPerOrigin))
+  const socketsPerOrigin = countPerOrigin(httpAgent.sockets)
+  const sockets = sum(values(socketsPerOrigin))
+  const pendingRequestsPerOrigin = countPerOrigin(httpAgent.requests)
+  const pendingRequests = sum(values(pendingRequestsPerOrigin))
 
   return {
-    cntPendingRequests,
-    cntPendingRequestsPerOrigin,
-    cntSockets,
-    cntSocketsPerOrigin,
+    pendingRequests,
+    pendingRequestsPerOrigin,
+    sockets,
+    socketsPerOrigin,
   }
 }
 

--- a/src/metrics/MetricsAccumulator.ts
+++ b/src/metrics/MetricsAccumulator.ts
@@ -2,6 +2,7 @@ import { assoc, flatten, map, mapObjIndexed, values } from 'ramda'
 import { mean, median, percentile } from 'stats-lite'
 
 import { httpAgentStats } from '../HttpClient/middlewares/request'
+import { incomingRequestStats } from '../service/utils/incomingRequestStats'
 import { hrToMillis } from '../utils/time'
 
 export interface Metric {
@@ -47,6 +48,12 @@ function cpuUsage () {
     user: lastCpu.user + diff.user,
   }
   return diff
+}
+
+function getIncomingRequestStats () {
+  const stats = incomingRequestStats.get()
+  incomingRequestStats.clear()
+  return stats
 }
 
 export type StatusTrack = () => EnvMetric[]
@@ -173,6 +180,11 @@ export class MetricsAccumulator {
       {
         ...httpAgentStats(),
         name: 'httpAgent',
+        production,
+      },
+      {
+        ...getIncomingRequestStats(),
+        name: 'incomingRequest',
         production,
       },
     ]

--- a/src/metrics/MetricsAccumulator.ts
+++ b/src/metrics/MetricsAccumulator.ts
@@ -1,7 +1,7 @@
-import { assoc, flatten, map, mapObjIndexed, sum, values } from 'ramda'
+import { assoc, flatten, map, mapObjIndexed, values } from 'ramda'
 import { mean, median, percentile } from 'stats-lite'
 
-import { httpAgent } from '../HttpClient/middlewares/request'
+import { httpAgentStats } from '../HttpClient/middlewares/request'
 import { hrToMillis } from '../utils/time'
 
 export interface Metric {
@@ -47,28 +47,6 @@ function cpuUsage () {
     user: lastCpu.user + diff.user,
   }
   return diff
-}
-
-function countPerOrigin (obj: { [key: string]: any[] }) {
-  try {
-    return mapObjIndexed(val => val.length, obj)
-  } catch (_) {
-    return {}
-  }
-}
-
-export function socketStats () {
-  const socketsPerOrigin = countPerOrigin(httpAgent.sockets)
-  const sockets = sum(values(socketsPerOrigin))
-  const pendingRequestsPerOrigin = countPerOrigin(httpAgent.requests)
-  const pendingRequests = sum(values(pendingRequestsPerOrigin))
-
-  return {
-    pendingRequests,
-    pendingRequestsPerOrigin,
-    sockets,
-    socketsPerOrigin,
-  }
 }
 
 export type StatusTrack = () => EnvMetric[]
@@ -193,8 +171,8 @@ export class MetricsAccumulator {
         production,
       },
       {
-        ...socketStats(),
-        name: 'socket',
+        ...httpAgentStats(),
+        name: 'httpAgent',
         production,
       },
     ]

--- a/src/service/graphql/index.ts
+++ b/src/service/graphql/index.ts
@@ -4,6 +4,7 @@ import { createHttpRoute } from '../http'
 import { GraphQLOptions, RouteHandler } from '../typings'
 
 import { removeSetCookie } from '../http/middlewares/setCookie'
+import { trackIncomingRequestStats } from '../utils/incomingRequestStats'
 import { error } from './middlewares/error'
 import { createFormatters } from './middlewares/formatters'
 import { parseQuery } from './middlewares/query'
@@ -29,6 +30,7 @@ export const createGraphQLRoute = <ClientsT extends IOClients, StateT, CustomT>(
     }
 
     return createHttpRoute<ClientsT, StateT, CustomT & GraphQLContext>(Clients, options)([
+      trackIncomingRequestStats,
       removeSetCookie,
       injectGraphql,
       timings,

--- a/src/service/http/index.ts
+++ b/src/service/http/index.ts
@@ -2,6 +2,7 @@ import { ClientsImplementation, IOClients } from '../../clients/IOClients'
 import { InstanceOptions } from '../../HttpClient'
 import { RouteHandler } from '../typings'
 import { compose } from '../utils/compose'
+import { trackIncomingRequestStats } from '../utils/incomingRequestStats'
 import { clients } from './middlewares/clients'
 import { error } from './middlewares/error'
 import { removeSetCookie } from './middlewares/setCookie'
@@ -13,7 +14,7 @@ export const createHttpRoute = <ClientsT extends IOClients, StateT, CustomT>(
 ) => {
   return (handler: RouteHandler<ClientsT, StateT, CustomT> | Array<RouteHandler<ClientsT, StateT, CustomT>>) => {
     const middlewares = Array.isArray(handler) ? handler : [handler]
-    const pipeline = [clients(Clients, options), removeSetCookie, timings, error, ...middlewares]
+    const pipeline = [trackIncomingRequestStats, clients(Clients, options), removeSetCookie, timings, error, ...middlewares]
     return compose(pipeline)
   }
 }

--- a/src/service/utils/incomingRequestStats.ts
+++ b/src/service/utils/incomingRequestStats.ts
@@ -1,0 +1,29 @@
+import { IOClients } from '../../clients/IOClients'
+import { ServiceContext } from '../typings'
+
+class IncomingRequestStats {
+  public closed = 0
+  public total = 0
+
+  public get () {
+    return {
+      closed: this.closed,
+      total: this.total,
+    }
+  }
+
+  public clear () {
+    this.closed = 0
+    this.total = 0
+  }
+}
+
+export const incomingRequestStats = new IncomingRequestStats()
+
+export async function trackIncomingRequestStats <T extends IOClients, U, V> (ctx: ServiceContext<T, U, V>, next: () => Promise<any>) {
+  ctx.req.on('close', () => {
+    incomingRequestStats.closed++
+  })
+  incomingRequestStats.total++
+  await next()
+}

--- a/src/service/utils/incomingRequestStats.ts
+++ b/src/service/utils/incomingRequestStats.ts
@@ -20,10 +20,12 @@ class IncomingRequestStats {
 
 export const incomingRequestStats = new IncomingRequestStats()
 
+const requestClosed = () => {
+  incomingRequestStats.closed++
+}
+
 export async function trackIncomingRequestStats <T extends IOClients, U, V> (ctx: ServiceContext<T, U, V>, next: () => Promise<any>) {
-  ctx.req.on('close', () => {
-    incomingRequestStats.closed++
-  })
+  ctx.req.on('close', requestClosed)
   incomingRequestStats.total++
   await next()
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Tracks number of sockets per origin.
- Tracks number of requests not assigned to a socket per origin.

These metrics will be useful to fine tune `maxFreeSockets`, `maxSockets`, and the maximum number of sockets per node process.
Currently `maxSockets` is set to infinity.

#### What problem is this solving?

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
