### PR TITLE
Don't cache availability request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.3.1] - 2019-04-16
+
 ## [3.3.0] - 2019-04-11
 ### Added
 - Messages `saveTransalation` method

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Builder.ts
+++ b/src/clients/Builder.ts
@@ -2,6 +2,7 @@ import archiver from 'archiver'
 import {ZlibOptions} from 'zlib'
 
 import {HttpClient, InstanceOptions} from '../HttpClient'
+import {CacheType} from '../HttpClient/middlewares/cache'
 import {IOContext} from '../service/typings'
 
 import {Change} from './Apps'
@@ -41,7 +42,7 @@ export class Builder {
     const metric = 'bh-availability'
     const {data: {availability},
            headers: {'x-vtex-sticky-host': host},
-          } = await this.http.getRaw(routes.Availability(app), {headers, metric})
+          } = await this.http.getRaw(routes.Availability(app), {headers, metric, cacheable: CacheType.None})
     const {hostname, score} = availability as AvailabilityResponse
     return {host, hostname, score}
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This removes cache from the builder availability request.

#### What problem is this solving?
This request was returning the same host, even after varying the `x-vtex-sticky-host` header, so toolbelt had no choice but to select the only builder returned by the router.

#### How should this be manually tested?
Before changes, linking an app would produce three availability requests returning the same builder:
```
debug:   Retrieved availability score 0 from host vtex-builder-hub-0-99-2-dev-2f5b51e93678bc6-8597686b64-ckdq6
debug:   Retrieved availability score 0 from host vtex-builder-hub-0-99-2-dev-2f5b51e93678bc6-8597686b64-ckdq6
debug:   Retrieved availability score 0 from host vtex-builder-hub-0-99-2-dev-2f5b51e93678bc6-8597686b64-ckdq6
```
Now, these builders should be different:
```
debug:   Retrieved availability score 0 from host vtex-builder-hub-0-99-3-dev-958eb56d3315a38-f9cb8f5f6-7snf6
debug:   Retrieved availability score 0 from host vtex-builder-hub-0-99-3-dev-958eb56d3315a38-f9cb8f5f6-5ph6w
debug:   Retrieved availability score 0 from host vtex-builder-hub-0-99-3-dev-958eb56d3315a38-f9cb8f5f6-5tlxk
```

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
