### PR TITLE
Fix retries and add default retries to messages client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.4.0] - 2019-04-18
+
 ## [3.3.1] - 2019-04-16
 
 ## [3.3.0] - 2019-04-11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/context.ts
+++ b/src/HttpClient/context.ts
@@ -7,7 +7,22 @@ export type InflightKeyGenerator = (x: RequestConfig) => string
 
 export interface RequestConfig extends AxiosRequestConfig {
   'axios-retry'?: IAxiosRetryConfig
+  /**
+   * Identifies the type of request for metrification purposes. Should vary with client method.
+   */
   metric?: string
+  /**
+   * In verbose mode, a counter will be incremented for each request made with the same `metric` label.
+   */
+  count?: number
+  /**
+   * In verbose mode, a label will be created with a counter for each request made with the same `metric` label.
+   */
+  label?: string
+  /**
+   * Outputs verbose logs to console for this request.
+   */
+  verbose?: boolean
   production?: boolean
   cacheable?: CacheType
   memoizeable?: boolean

--- a/src/clients/Messages.ts
+++ b/src/clients/Messages.ts
@@ -27,7 +27,6 @@ export class Messages extends IODataSource {
     inflightKey: inflightUrlWithQuery,
     metric: 'messages-translate',
     params: {
-      __p: process.env.VTEX_APP_ID,
       data: JSON.stringify(data),
       to,
     },
@@ -38,9 +37,6 @@ export class Messages extends IODataSource {
       Authorization: this.context!.authToken,
     },
     metric: 'messages-save-translation',
-    params: {
-      __p: process.env.VTEX_APP_ID,
-    },
   })
 }
 

--- a/src/service/Runtime.ts
+++ b/src/service/Runtime.ts
@@ -10,8 +10,13 @@ import { Service } from './Service'
 import { ClientsConfig, RouteHandler, ServiceDescriptor } from './typings'
 
 const defaultClients: ClientsConfig = {
-  implementation: IOClients,
-  options: {},
+  options: {
+    messages: {
+      concurrency: 15,
+      retries: 2,
+      timeout: 1000,
+    },
+  },
 }
 
 export class Runtime<ClientsT extends IOClients = IOClients, StateT = void, CustomT = void> {
@@ -27,8 +32,11 @@ export class Runtime<ClientsT extends IOClients = IOClients, StateT = void, Cust
   ) {
     const {config} = service
     const clients = {
-      ...defaultClients,
-      ...config.clients,
+      implementation: config.clients && config.clients.implementation || IOClients,
+      options: {
+        ...defaultClients.options,
+        ...config.clients ? config.clients.options : null,
+      },
     }
 
     const Clients = clients.implementation as ClientsImplementation<ClientsT>

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -2,14 +2,21 @@ import {isNetworkOrIdempotentRequestError, isSafeRequestError} from 'axios-retry
 
 export const TIMEOUT_CODE = 'ProxyTimeout'
 
+const printLabel = (e: any, message: string) => {
+  if (!e || !e.config || !e.config.label) {
+    return
+  }
+  console.warn(e.config.label, message)
+}
+
 export const isNetworkErrorOrRouterTimeout = (e: any) => {
   if (isNetworkOrIdempotentRequestError(e)) {
-    console.warn('Retry from network error', e.message)
+    printLabel(e, 'Retry from network error')
     return true
   }
 
   if (e && isSafeRequestError(e) && e.response && e.response.data && e.response.data.code === TIMEOUT_CODE) {
-    console.warn('Retry from timeout', e.message)
+    printLabel(e, 'Retry from timeout')
     return true
   }
 
@@ -19,6 +26,7 @@ export const isNetworkErrorOrRouterTimeout = (e: any) => {
 // Retry on timeout from our end
 export const isAbortedOrNetworkErrorOrRouterTimeout = (e: any) => {
   if (e && e.code === 'ECONNABORTED') {
+    printLabel(e, 'Retry from abort')
     return true
   }
   return isNetworkErrorOrRouterTimeout(e)


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix retries and add default retries to Messages clients.

This also adds a `verbose` flag that logs any requests that have a `metric` property. Useful for debugging, and often hand-implemented when investigating. Better to just bake this in.

**IMPORTANT**
As the retry middleware was basically broken, I'm taking this opportunity to deprecate the `retryConfig` option and turn it into a simpler `retries`, so in the future we might decide to change the implementation without having to keep this quirky API. This means the default `retryConfig` options are now always applied whenever you use retries:

```
{
  retries: 0, // This is overwritten by user config
  retryCondition: isAbortedOrNetworkErrorOrRouterTimeout,
  retryDelay: exponentialDelay,
  shouldResetTimeout: true,
}
```

#### What problem is this solving?

Retries were _very broken_.

- `retryConfig` was one single object for the entire _instance_, so the internal `retryCount` would be considered client-wide. That means the first n requests would retry as expected, but not any further requests made by the same client.
- We had an atrocious, early-game interceptor that removed circular props from the error object. This borks how our retry plugin works, because it expects `config` to be there.

#### How should this be manually tested?

Configure retries, watch them actually happen.

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
