### PR TITLE
Add native Error classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.5.0] - 2019-04-22
+
 ### Added
 - Add native error and warning classes and log these appropriately.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add native error and warning classes and log these appropriately.
+
 ## [3.4.4] - 2019-04-22
 
 ## [3.4.4-beta] - 2019-04-19

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/IOClients.ts
+++ b/src/clients/IOClients.ts
@@ -12,7 +12,7 @@ function hasDependencies<T extends IOClients>(instanceOptions: ClientInstanceOpt
 
 export type ClientsImplementation<T extends IOClients> = new (
   clientOptions: Record<string, ClientInstanceOptions>,
-  ctx: IOContext,
+  ctx: IOContext
 ) => T
 
 export class IOClients {
@@ -20,7 +20,7 @@ export class IOClients {
 
   constructor(
     private clientOptions: Record<string, ClientInstanceOptions>,
-    private ctx: IOContext,
+    private ctx: IOContext
   ) { }
 
   public get apps() {

--- a/src/errors/AuthenticationError.ts
+++ b/src/errors/AuthenticationError.ts
@@ -1,0 +1,20 @@
+import { AxiosError } from 'axios'
+
+import { ResolverWarning } from './ResolverWarning'
+
+/**
+ * Indicates user did not provide valid credentials for authenticating this request.
+ * ResolverWarnings are logged with level "warning" denoting they were handled by user code.
+ *
+ * @class AuthenticationError
+ * @extends {ResolverWarning}
+ */
+export class AuthenticationError extends ResolverWarning {
+  /**
+   * Creates an instance of AuthenticationError
+   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   */
+  constructor(messageOrError: string | Error | AxiosError) {
+    super(messageOrError, 401, 'UNAUTHENTICATED')
+  }
+}

--- a/src/errors/AuthenticationError.ts
+++ b/src/errors/AuthenticationError.ts
@@ -16,5 +16,9 @@ export class AuthenticationError extends ResolverWarning {
    */
   constructor(messageOrError: string | Error | AxiosError) {
     super(messageOrError, 401, 'UNAUTHENTICATED')
+
+    if (typeof messageOrError !== 'object') {
+      Error.captureStackTrace(this, AuthenticationError)
+    }
   }
 }

--- a/src/errors/ForbiddenError.ts
+++ b/src/errors/ForbiddenError.ts
@@ -16,5 +16,9 @@ export class ForbiddenError extends ResolverWarning {
    */
   constructor(messageOrError: string | Error | AxiosError) {
     super(messageOrError, 403, 'FORBIDDEN')
+
+    if (typeof messageOrError !== 'object') {
+      Error.captureStackTrace(this, ForbiddenError)
+    }
   }
 }

--- a/src/errors/ForbiddenError.ts
+++ b/src/errors/ForbiddenError.ts
@@ -1,0 +1,20 @@
+import { AxiosError } from 'axios'
+
+import { ResolverWarning } from './ResolverWarning'
+
+/**
+ * Indicates user is not authorized to perform this action.
+ * ResolverWarnings are logged with level "warning" denoting they were handled by user code.
+ *
+ * @class ForbiddenError
+ * @extends {ResolverWarning}
+ */
+export class ForbiddenError extends ResolverWarning {
+  /**
+   * Creates an instance of ForbiddenError
+   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   */
+  constructor(messageOrError: string | Error | AxiosError) {
+    super(messageOrError, 403, 'FORBIDDEN')
+  }
+}

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,0 +1,20 @@
+import { AxiosError } from 'axios'
+
+import { ResolverWarning } from './ResolverWarning'
+
+/**
+ * Indicates a requested resource was not found.
+ * ResolverWarnings are logged with level "warning" denoting they were handled by user code.
+ *
+ * @class NotFoundError
+ * @extends {ResolverWarning}
+ */
+export class NotFoundError extends ResolverWarning {
+  /**
+   * Creates an instance of NotFoundError
+   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   */
+  constructor(messageOrError: string | Error | AxiosError) {
+    super(messageOrError, 404, 'NOT_FOUND')
+  }
+}

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -16,5 +16,9 @@ export class NotFoundError extends ResolverWarning {
    */
   constructor(messageOrError: string | Error | AxiosError) {
     super(messageOrError, 404, 'NOT_FOUND')
+
+    if (typeof messageOrError !== 'object') {
+      Error.captureStackTrace(this, NotFoundError)
+    }
   }
 }

--- a/src/errors/ResolverError.ts
+++ b/src/errors/ResolverError.ts
@@ -1,6 +1,7 @@
 import { AxiosError } from 'axios'
 
-import { cleanError } from './../utils/error'
+import { LogLevel } from '../clients/Logger'
+import { cleanError } from '../utils/error'
 
 /**
  * The generic Error class to be thrown for caught errors inside resolvers.
@@ -11,6 +12,8 @@ import { cleanError } from './../utils/error'
  * @extends {Error}
  */
 export class ResolverError extends Error {
+  public level = LogLevel.Error
+
   /**
    * Creates an instance of ResolverError
    * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.

--- a/src/errors/ResolverError.ts
+++ b/src/errors/ResolverError.ts
@@ -1,0 +1,34 @@
+import { AxiosError } from 'axios'
+
+import { cleanError } from './../utils/error'
+
+/**
+ * The generic Error class to be thrown for caught errors inside resolvers.
+ * Errors with status code greater than or equal to 500 are logged as errors.
+ * All other status codes are logged as warnings. @see ResolverWarning
+ *
+ * @class ResolverError
+ * @extends {Error}
+ */
+export class ResolverError extends Error {
+  /**
+   * Creates an instance of ResolverError
+   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   * @param {number} [status=500]
+   * @param {string} [code='RESOLVER_ERROR']
+   */
+  constructor(
+    messageOrError: string | Error | AxiosError,
+    public status: number = 500,
+    public code: string = 'RESOLVER_ERROR'
+  ) {
+    super(typeof messageOrError === 'string' ? messageOrError : messageOrError.message)
+
+    if (typeof messageOrError === 'object') {
+      // Copy original error properties without circular references
+      Object.assign(this, cleanError(messageOrError))
+    } else {
+      Error.captureStackTrace(this, ResolverError)
+    }
+  }
+}

--- a/src/errors/ResolverWarning.ts
+++ b/src/errors/ResolverWarning.ts
@@ -1,5 +1,7 @@
 import { AxiosError } from 'axios'
 
+import { LogLevel } from '../clients/Logger'
+
 import { ResolverError } from './ResolverError'
 
 /**
@@ -10,6 +12,8 @@ import { ResolverError } from './ResolverError'
  * @extends {ResolverError}
  */
 export class ResolverWarning extends ResolverError {
+  public level = LogLevel.Warn
+
   /**
    * Creates an instance of ResolverWarning
    * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
@@ -20,5 +24,9 @@ export class ResolverWarning extends ResolverError {
     public code: string = 'RESOLVER_WARNING'
   ) {
     super(messageOrError, status, code)
+
+    if (typeof messageOrError !== 'object') {
+      Error.captureStackTrace(this, ResolverWarning)
+    }
   }
 }

--- a/src/errors/ResolverWarning.ts
+++ b/src/errors/ResolverWarning.ts
@@ -1,0 +1,24 @@
+import { AxiosError } from 'axios'
+
+import { ResolverError } from './ResolverError'
+
+/**
+ * Indicates a non-fatal error occurred and was handled.
+ * ResolverWarnings are logged with level "warning" denoting they were handled by user code.
+ *
+ * @class ResolverWarning
+ * @extends {ResolverError}
+ */
+export class ResolverWarning extends ResolverError {
+  /**
+   * Creates an instance of ResolverWarning
+   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   */
+  constructor(
+    messageOrError: string | Error | AxiosError,
+    public status: number = 422,
+    public code: string = 'RESOLVER_WARNING'
+  ) {
+    super(messageOrError, status, code)
+  }
+}

--- a/src/errors/UserInputError.ts
+++ b/src/errors/UserInputError.ts
@@ -16,5 +16,9 @@ export class UserInputError extends ResolverWarning {
    */
   constructor(messageOrError: string | Error | AxiosError) {
     super(messageOrError, 400, 'BAD_USER_INPUT')
+
+    if (typeof messageOrError !== 'object') {
+      Error.captureStackTrace(this, UserInputError)
+    }
   }
 }

--- a/src/errors/UserInputError.ts
+++ b/src/errors/UserInputError.ts
@@ -1,0 +1,20 @@
+import { AxiosError } from 'axios'
+
+import { ResolverWarning } from './ResolverWarning'
+
+/**
+ * Indicates user input is not valid for this action.
+ * ResolverWarnings are logged with level "warning" denoting they were handled by user code.
+ *
+ * @class UserInputError
+ * @extends {ResolverWarning}
+ */
+export class UserInputError extends ResolverWarning {
+  /**
+   * Creates an instance of UserInputError
+   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   */
+  constructor(messageOrError: string | Error | AxiosError) {
+    super(messageOrError, 400, 'BAD_USER_INPUT')
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,6 @@
+export * from './AuthenticationError'
+export * from './ForbiddenError'
+export * from './NotFoundError'
+export * from './ResolverError'
+export * from './ResolverWarning'
+export * from './UserInputError'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './caches'
 export * from './clients'
 export * from './clients/IOClients'
+export * from './errors'
 export * from './HttpClient'
 export * from './IODataSource'
 export * from './metrics/MetricsAccumulator'

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -1,5 +1,6 @@
 import { any, chain, compose, filter, forEach, has, pluck, prop, uniqBy } from 'ramda'
 
+import { LogLevel } from '../../../clients/Logger'
 import { GraphQLServiceContext } from '../typings'
 import { toArray } from '../utils/array'
 import { generatePathName } from '../utils/pathname'
@@ -104,9 +105,15 @@ export async function error (ctx: GraphQLServiceContext, next: () => Promise<voi
           routeId: id,
         }
 
-        ctx.clients.logger.sendLog('-', log, 'error').catch((reason) => {
+        // Grab level from originalError, default to "error" level.
+        let level = err.originalError && err.originalError.level as LogLevel
+        if (!level || !(level === LogLevel.Error || level === LogLevel.Warn)) {
+          level = LogLevel.Error
+        }
+
+        ctx.clients.logger.sendLog('-', log, level).catch((reason) => {
           console.error('Error logging error 🙄 retrying once...', reason ? reason.response : '')
-          ctx.clients.logger.sendLog('-', log, 'error').catch()
+          ctx.clients.logger.sendLog('-', log, level).catch()
         })
       }, uniqueErrors)
 

--- a/src/service/http/middlewares/error.ts
+++ b/src/service/http/middlewares/error.ts
@@ -1,4 +1,5 @@
 import { IOClients } from '../../../clients/IOClients'
+import { LogLevel } from '../../../clients/Logger'
 import { cleanError } from '../../../utils/error'
 import { ServiceContext } from '../../typings'
 
@@ -53,6 +54,12 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
       },
     } = ctx
 
+    // Grab level from originalError, default to "error" level.
+    let level = err && err.level as LogLevel
+    if (!level || !(level === LogLevel.Error || level === LogLevel.Warn)) {
+      level = LogLevel.Error
+    }
+
     const log = {
       ...err,
       forwardedHost,
@@ -67,9 +74,9 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
     }
 
     // Use sendLog directly to avoid cleaning error twice.
-    ctx.clients.logger.sendLog('-', log, 'error').catch((reason) => {
+    ctx.clients.logger.sendLog('-', log, level).catch((reason) => {
       console.error('Error logging error 🙄 retrying once...', reason ? reason.response : '')
-      ctx.clients.logger.sendLog('-', log, 'error').catch()
+      ctx.clients.logger.sendLog('-', log, level).catch()
     })
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Add native error and warning classes and log these appropriately.

We are adding six Error classes:

- `ResolverError`, the generic 500 error.
- `ResolverWarning`, the generic "handled error" with status code 422.
- Four specific warning types: `AuthenticationError`, `ForbiddenError`, `NotFoundError`, `UserInputError`, with their appropriate status codes.

The proposal is to have user code import our native errors and:

- If they are handling a semantic error, throw with a message, e.g.:

```
async function getProductBySlug(slug: string, catalog: any){
  const products = await catalog.product(slug)
  if (products.length > 0) {
    return head(products)
  }
  throw new NotFoundError('No product was found with requested sku')
}
```

- If they are handling a caught error, wrap it to indicate it's not a failure.
```
try {
  // something optional
} catch (e) {
  throw new ResolverWarning(e)
}
```

- Or if they want to indicate this is an explosion:
```
try {
  // something required
} catch (e) {
  throw new ResolverError(e)
}
```

#### What problem is this solving?

`Product not found` should not clutter our error dashboards. Also, we need to have visibility on the infrastructure layer on whether resolvers are erroring a lot.

#### References

https://github.com/APIs-guru/graphql/blob/master/spec/Section%207%20--%20Response.md#errors
https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-errors/src/index.ts
https://github.com/graphql/graphql-js/blob/master/src/error/GraphQLError.js

https://httpstatuses.com/
