### PR TITLE
remove trackIncomingRequestStats from graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.6.1] - 2019-04-24
+
 ## [3.6.0] - 2019-04-24
 
 ## [3.5.2-beta] - 2019-04-24

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/graphql/index.ts
+++ b/src/service/graphql/index.ts
@@ -4,7 +4,6 @@ import { createHttpRoute } from '../http'
 import { GraphQLOptions, RouteHandler } from '../typings'
 
 import { removeSetCookie } from '../http/middlewares/setCookie'
-import { trackIncomingRequestStats } from '../utils/incomingRequestStats'
 import { error } from './middlewares/error'
 import { createFormatters } from './middlewares/formatters'
 import { parseQuery } from './middlewares/query'
@@ -30,7 +29,6 @@ export const createGraphQLRoute = <ClientsT extends IOClients, StateT, CustomT>(
     }
 
     return createHttpRoute<ClientsT, StateT, CustomT & GraphQLContext>(Clients, options)([
-      trackIncomingRequestStats,
       removeSetCookie,
       injectGraphql,
       timings,


### PR DESCRIPTION
#### What is the purpose of this pull request?
incoming requests front graphql route is already tracked by http service.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
