### PR TITLE
add data param to http cliente delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add data param to HttpClient delete method.
 
 ## [3.8.1] - 2019-04-26
 

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -119,8 +119,8 @@ export class HttpClient {
     return this.request(patchConfig).then(response => response.data as T)
   }
 
-  public delete = <T = void>(url: string, config?: RequestConfig): Promise<IOResponse<T>> => {
-    const deleteConfig: RequestConfig = {...config, url, method: 'delete'}
+  public delete = <T = void>(url: string, data?: any, config?: RequestConfig): Promise<IOResponse<T>> => {
+    const deleteConfig: RequestConfig = {...config, url, data, method: 'delete'}
     return this.request(deleteConfig)
   }
 


### PR DESCRIPTION
as title says

I am a bit worried that this may break whoever uses this.delete(url, config), because config will then be the `data`. But making data be the third param would be different with all other methods.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
