### PR TITLE
Fix unlink route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Usage of `routes.Links` function in the `routes.Unlink` function (Apps client)
 
 ## [3.9.1] - 2019-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.9.2] - 2019-05-02
 ### Fixed
 - Usage of `routes.Links` function in the `routes.Unlink` function (Apps client)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Apps.ts
+++ b/src/clients/Apps.ts
@@ -32,7 +32,7 @@ const createRoutes = ({account, workspace}: IOContext) => {
     ResolveDependencies: () => `${routes.Workspace}/dependencies/_resolve`,
     ResolveDependenciesWithManifest: () => `${routes.Workspace}/v2/apps/_resolve`,
     Settings: (app: string) => `${routes.App(app)}/settings`,
-    Unlink: (app: string) => `${routes.Links}/${app}`,
+    Unlink: (app: string) => `${routes.Links()}/${app}`,
     Workspace: `/${account}/${workspace}`,
   }
   return routes


### PR DESCRIPTION
This PR makes the `routes.Unlink` function (in the Apps client) return the correct route.

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
