### PR TITLE
Add caller, query and params to errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Add caller, params and query to error logs
+- Relax error typing and capture stack automatically
+
 ## [3.9.2] - 2019-05-02
 ### Fixed
 - Usage of `routes.Links` function in the `routes.Unlink` function (Apps client)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.10.0] - 2019-05-06
+
 ### Changed
 - Add caller, params and query to error logs
 - Relax error typing and capture stack automatically

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.9.2",
+  "version": "3.10.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/errors/AuthenticationError.ts
+++ b/src/errors/AuthenticationError.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios'
 
+import { ErrorLike } from './ResolverError'
 import { ResolverWarning } from './ResolverWarning'
 
 /**
@@ -14,9 +15,9 @@ export class AuthenticationError extends ResolverWarning {
 
   /**
    * Creates an instance of AuthenticationError
-   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   * @param {(string | AxiosError | ErrorLike)} messageOrError Either a message string or the complete original error object.
    */
-  constructor(messageOrError: string | Error | AxiosError) {
+  constructor(messageOrError: string | AxiosError | ErrorLike) {
     super(messageOrError, 401, 'UNAUTHENTICATED')
 
     if (typeof messageOrError === 'string' || !messageOrError.stack) {

--- a/src/errors/AuthenticationError.ts
+++ b/src/errors/AuthenticationError.ts
@@ -10,6 +10,8 @@ import { ResolverWarning } from './ResolverWarning'
  * @extends {ResolverWarning}
  */
 export class AuthenticationError extends ResolverWarning {
+  public name = 'AuthenticationError'
+
   /**
    * Creates an instance of AuthenticationError
    * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
@@ -17,7 +19,7 @@ export class AuthenticationError extends ResolverWarning {
   constructor(messageOrError: string | Error | AxiosError) {
     super(messageOrError, 401, 'UNAUTHENTICATED')
 
-    if (typeof messageOrError !== 'object') {
+    if (typeof messageOrError === 'string' || !messageOrError.stack) {
       Error.captureStackTrace(this, AuthenticationError)
     }
   }

--- a/src/errors/ForbiddenError.ts
+++ b/src/errors/ForbiddenError.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios'
 
+import { ErrorLike } from './ResolverError'
 import { ResolverWarning } from './ResolverWarning'
 
 /**
@@ -14,9 +15,9 @@ export class ForbiddenError extends ResolverWarning {
 
   /**
    * Creates an instance of ForbiddenError
-   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   * @param {(string | AxiosError | ErrorLike)} messageOrError Either a message string or the complete original error object.
    */
-  constructor(messageOrError: string | Error | AxiosError) {
+  constructor(messageOrError: string | AxiosError | ErrorLike) {
     super(messageOrError, 403, 'FORBIDDEN')
 
     if (typeof messageOrError === 'string' || !messageOrError.stack) {

--- a/src/errors/ForbiddenError.ts
+++ b/src/errors/ForbiddenError.ts
@@ -10,6 +10,8 @@ import { ResolverWarning } from './ResolverWarning'
  * @extends {ResolverWarning}
  */
 export class ForbiddenError extends ResolverWarning {
+  public name = 'ForbiddenError'
+
   /**
    * Creates an instance of ForbiddenError
    * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
@@ -17,7 +19,7 @@ export class ForbiddenError extends ResolverWarning {
   constructor(messageOrError: string | Error | AxiosError) {
     super(messageOrError, 403, 'FORBIDDEN')
 
-    if (typeof messageOrError !== 'object') {
+    if (typeof messageOrError === 'string' || !messageOrError.stack) {
       Error.captureStackTrace(this, ForbiddenError)
     }
   }

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios'
 
+import { ErrorLike } from './ResolverError'
 import { ResolverWarning } from './ResolverWarning'
 
 /**
@@ -14,9 +15,9 @@ export class NotFoundError extends ResolverWarning {
 
   /**
    * Creates an instance of NotFoundError
-   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   * @param {(string | AxiosError | ErrorLike)} messageOrError Either a message string or the complete original error object.
    */
-  constructor(messageOrError: string | Error | AxiosError) {
+  constructor(messageOrError: string | AxiosError | ErrorLike) {
     super(messageOrError, 404, 'NOT_FOUND')
 
     if (typeof messageOrError === 'string' || !messageOrError.stack) {

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -10,6 +10,8 @@ import { ResolverWarning } from './ResolverWarning'
  * @extends {ResolverWarning}
  */
 export class NotFoundError extends ResolverWarning {
+  public name = 'NotFoundError'
+
   /**
    * Creates an instance of NotFoundError
    * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
@@ -17,7 +19,7 @@ export class NotFoundError extends ResolverWarning {
   constructor(messageOrError: string | Error | AxiosError) {
     super(messageOrError, 404, 'NOT_FOUND')
 
-    if (typeof messageOrError !== 'object') {
+    if (typeof messageOrError === 'string' || !messageOrError.stack) {
       Error.captureStackTrace(this, NotFoundError)
     }
   }

--- a/src/errors/ResolverError.ts
+++ b/src/errors/ResolverError.ts
@@ -3,6 +3,13 @@ import { AxiosError } from 'axios'
 import { LogLevel } from '../clients/Logger'
 import { cleanError } from '../utils/error'
 
+export interface ErrorLike extends Error {
+  name: string
+  message: string
+  stack?: string
+  [key: string]: any
+}
+
 /**
  * The generic Error class to be thrown for caught errors inside resolvers.
  * Errors with status code greater than or equal to 500 are logged as errors.
@@ -16,12 +23,12 @@ export class ResolverError extends Error {
 
   /**
    * Creates an instance of ResolverError
-   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   * @param {(string | AxiosError | ErrorLike)} messageOrError Either a message string or the complete original error object.
    * @param {number} [status=500]
    * @param {string} [code='RESOLVER_ERROR']
    */
   constructor(
-    messageOrError: string | Error | AxiosError,
+    messageOrError: string | AxiosError | ErrorLike,
     public status: number = 500,
     public code: string = 'RESOLVER_ERROR'
   ) {
@@ -30,7 +37,9 @@ export class ResolverError extends Error {
     if (typeof messageOrError === 'object') {
       // Copy original error properties without circular references
       Object.assign(this, cleanError(messageOrError))
-    } else {
+    }
+
+    if (typeof messageOrError === 'string' || !messageOrError.stack) {
       Error.captureStackTrace(this, ResolverError)
     }
   }

--- a/src/errors/ResolverError.ts
+++ b/src/errors/ResolverError.ts
@@ -3,7 +3,8 @@ import { AxiosError } from 'axios'
 import { LogLevel } from '../clients/Logger'
 import { cleanError } from '../utils/error'
 
-export interface ErrorLike extends Error {
+export interface ErrorLike {
+  name?: string
   message: string
   stack?: string
   [key: string]: any

--- a/src/errors/ResolverError.ts
+++ b/src/errors/ResolverError.ts
@@ -4,7 +4,6 @@ import { LogLevel } from '../clients/Logger'
 import { cleanError } from '../utils/error'
 
 export interface ErrorLike extends Error {
-  name: string
   message: string
   stack?: string
   [key: string]: any
@@ -19,6 +18,7 @@ export interface ErrorLike extends Error {
  * @extends {Error}
  */
 export class ResolverError extends Error {
+  public name = 'ResolverError'
   public level = LogLevel.Error
 
   /**

--- a/src/errors/ResolverWarning.ts
+++ b/src/errors/ResolverWarning.ts
@@ -2,7 +2,7 @@ import { AxiosError } from 'axios'
 
 import { LogLevel } from '../clients/Logger'
 
-import { ResolverError } from './ResolverError'
+import { ErrorLike, ResolverError } from './ResolverError'
 
 /**
  * Indicates a non-fatal error occurred and was handled.
@@ -16,16 +16,16 @@ export class ResolverWarning extends ResolverError {
 
   /**
    * Creates an instance of ResolverWarning
-   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   * @param {(string | AxiosError | ErrorLike)} messageOrError Either a message string or the complete original error object.
    */
   constructor(
-    messageOrError: string | Error | AxiosError,
+    messageOrError: string | AxiosError | ErrorLike,
     public status: number = 422,
     public code: string = 'RESOLVER_WARNING'
   ) {
     super(messageOrError, status, code)
 
-    if (typeof messageOrError !== 'object') {
+    if (typeof messageOrError === 'string' || !messageOrError.stack) {
       Error.captureStackTrace(this, ResolverWarning)
     }
   }

--- a/src/errors/ResolverWarning.ts
+++ b/src/errors/ResolverWarning.ts
@@ -12,6 +12,7 @@ import { ErrorLike, ResolverError } from './ResolverError'
  * @extends {ResolverError}
  */
 export class ResolverWarning extends ResolverError {
+  public name = 'ResolverWarning'
   public level = LogLevel.Warn
 
   /**

--- a/src/errors/UserInputError.ts
+++ b/src/errors/UserInputError.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios'
 
+import { ErrorLike } from './ResolverError'
 import { ResolverWarning } from './ResolverWarning'
 
 /**
@@ -14,9 +15,9 @@ export class UserInputError extends ResolverWarning {
 
   /**
    * Creates an instance of UserInputError
-   * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
+   * @param {(string | AxiosError | ErrorLike)} messageOrError Either a message string or the complete original error object.
    */
-  constructor(messageOrError: string | Error | AxiosError) {
+  constructor(messageOrError: string | AxiosError | ErrorLike) {
     super(messageOrError, 400, 'BAD_USER_INPUT')
 
     if (typeof messageOrError === 'string' || !messageOrError.stack) {

--- a/src/errors/UserInputError.ts
+++ b/src/errors/UserInputError.ts
@@ -10,6 +10,8 @@ import { ResolverWarning } from './ResolverWarning'
  * @extends {ResolverWarning}
  */
 export class UserInputError extends ResolverWarning {
+  public name = 'UserInputError'
+
   /**
    * Creates an instance of UserInputError
    * @param {(string | Error | AxiosError)} messageOrError Either a message string or the complete original error object.
@@ -17,7 +19,7 @@ export class UserInputError extends ResolverWarning {
   constructor(messageOrError: string | Error | AxiosError) {
     super(messageOrError, 400, 'BAD_USER_INPUT')
 
-    if (typeof messageOrError !== 'object') {
+    if (typeof messageOrError === 'string' || !messageOrError.stack) {
       Error.captureStackTrace(this, UserInputError)
     }
   }

--- a/src/service/http/middlewares/error.ts
+++ b/src/service/http/middlewares/error.ts
@@ -39,17 +39,20 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
     const {
       method,
       status,
+      query,
       vtex: {
         operationId,
         requestId,
         route: {
           id,
+          params,
         },
       },
       headers: {
         'x-forwarded-path': forwardedPath,
         'x-forwarded-host': forwardedHost,
         'x-forwarded-proto': forwardedProto,
+        'x-vtex-caller': caller,
         'x-vtex-platform': platform,
       },
     } = ctx
@@ -62,12 +65,15 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
 
     const log = {
       ...err,
+      caller,
       forwardedHost,
       forwardedPath,
       forwardedProto,
       method,
       operationId,
+      params,
       platform,
+      query,
       requestId,
       routeId: id,
       status,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Improve debugging by adding more information to logs and allowing passing props along with message in artificial errors (e.g. an `UserInputError` which you want to send with more props than only a message and you don't have an original error to wrap). Avoids having to cast the object to any.

- Add caller, params and query to error logs
- Relax error typing and capture stack automatically

#### What problem is this solving?

Lack of context when examining logs.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
