### PR TITLE
Use "buildFeatures" inside "manifest"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.12.0] - 2019-05-07
+
 ### Added
 - Add "buildFeatures" inside "manifest".
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add "buildFeatures" inside "manifest".
+
 ## [3.11.0] - 2019-05-06
 
 ## [3.10.0] - 2019-05-06

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Apps.ts
+++ b/src/clients/Apps.ts
@@ -65,6 +65,7 @@ const workspaceFields = [
   '_resolvedDependencies',
   'settingsSchema',
   '_isRoot',
+  '_buildFeatures',
 ].join(',')
 
 interface AppLocator {
@@ -328,6 +329,7 @@ export interface AppMetaInfo {
   settingsSchema?: Record<string, any>
   _resolvedDependencies: Record<string, string>
   _isRoot: boolean
+  _buildFeatures: Array<'scopeMessages'>
 }
 
 export interface WorkspaceMetaInfo {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Now we can access the `build features` inside `manifest` through an array of strings (called `buildFeatures`, which has only the string `'scopeMessages'` at the moment)

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
This way, we can access if a feature is already in place just by verifying its presence in the array above. For the `scopeMessages` use case, for example, it is possible to verify if the builder is already capable of handling the scopes and then we can scope the messages received inside pages-graphql accordingly, for example.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
