### PR TITLE
Change type of "buildFeatures" to "Record<string, string[]>"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.15.1] - 2019-05-17
+
 ### Changed
 - Change type of `buildFeatures` to `Record<string, string[]>`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Change type of `buildFeatures` to `Record<string, string[]>`
+
 ## [3.15.0] - 2019-05-13
 
 ## [3.14.1] - 2019-05-10

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Apps.ts
+++ b/src/clients/Apps.ts
@@ -324,7 +324,7 @@ export interface AppMetaInfo {
   settingsSchema?: Record<string, any>
   _resolvedDependencies: Record<string, string>
   _isRoot: boolean
-  _buildFeatures: string[]
+  _buildFeatures: Record<string, string[]>
 }
 
 export interface WorkspaceMetaInfo {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Change the type of `buildFeatures` to `Record<string, string[]>`.

Inside this `Record`, the keys are going to be the `APP_NAMEs` (`'vtex.pages-graphql'` for example) and the respective values are going to be the related arrays of the build features already available to be used by each of these apps (arrays such as `['build.json', 'scopeMessages']` outlining the string-features, for example).

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
