### PR TITLE
Fix inflightKey on URLs with query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.18.1] - 2019-05-21
+
 ## [3.18.0] - 2019-05-20
 ### Added
 - Generate `manifest.json` schema from TypeScript definition.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Apps.ts
+++ b/src/clients/Apps.ts
@@ -5,7 +5,7 @@ import { Readable, Writable } from 'stream'
 import { extract } from 'tar-fs'
 import { createGunzip, ZlibOptions } from 'zlib'
 
-import { CacheType, inflightURL, InfraClient, InstanceOptions } from '../HttpClient'
+import { CacheType, inflightURL, inflightUrlWithQuery, InfraClient, InstanceOptions } from '../HttpClient'
 import { IgnoreNotFoundRequestConfig } from '../HttpClient/middlewares/notFound'
 import { AppBundleLinked, AppFilesList, AppManifest } from '../responses'
 import { IOContext } from '../service/typings'
@@ -181,7 +181,7 @@ export class Apps extends InfraClient {
       since,
     }
     const metric = 'apps-list'
-    const inflightKey = inflightURL
+    const inflightKey = inflightUrlWithQuery
     return this.http.get<AppsList>(this.routes.Apps(), {params, metric, inflightKey})
   }
 
@@ -193,7 +193,7 @@ export class Apps extends InfraClient {
       prefix,
     }
     const metric = linked ? 'apps-list-files' : 'registry-list-files'
-    const inflightKey = inflightURL
+    const inflightKey = inflightUrlWithQuery
     return this.http.get<AppFilesList>(this.routes.Files(locator), {params, metric, inflightKey})
   }
 
@@ -288,7 +288,7 @@ export class Apps extends InfraClient {
   public getDependencies = (filter: string = '') => {
     const params = {filter}
     const metric = 'apps-get-deps'
-    const inflightKey = inflightURL
+    const inflightKey = inflightUrlWithQuery
     return this.http.get<Record<string, string[]>>(this.routes.Dependencies(), {params, metric, inflightKey})
   }
 
@@ -303,7 +303,7 @@ export class Apps extends InfraClient {
   public resolveDependencies = (apps: string[], registries: string[], filter: string = '') => {
     const params = {apps, registries, filter}
     const metric = 'apps-resolve-deps'
-    const inflightKey = inflightURL
+    const inflightKey = inflightUrlWithQuery
     return this.http.get(this.routes.ResolveDependencies(), {params, metric, inflightKey})
   }
 

--- a/src/clients/Registry.ts
+++ b/src/clients/Registry.ts
@@ -5,7 +5,7 @@ import { extract } from 'tar-fs'
 import { createGunzip, ZlibOptions } from 'zlib'
 
 import { DEFAULT_WORKSPACE } from '../constants'
-import { CacheType, inflightURL, InfraClient, InstanceOptions } from '../HttpClient'
+import { CacheType, inflightURL, inflightUrlWithQuery, InfraClient, InstanceOptions } from '../HttpClient'
 import { IgnoreNotFoundRequestConfig } from '../HttpClient/middlewares/notFound'
 import { AppBundlePublished, AppFilesList, AppManifest } from '../responses'
 import { IOContext } from '../service/typings'
@@ -79,14 +79,14 @@ export class Registry extends InfraClient {
   }
 
   public getAppManifest = (app: string, version: string, opts?: AppsManifestOptions) => {
-    const inflightKey = inflightURL
+    const inflightKey = inflightUrlWithQuery
     const params = opts
     const metric = 'registry-manifest'
     return this.http.get<AppManifest>(routes.AppVersion(app, version), {params, metric, inflightKey})
   }
 
   public listAppFiles = (app: string, version: string, opts?: ListAppFilesOptions) => {
-    const inflightKey = inflightURL
+    const inflightKey = inflightUrlWithQuery
     const params = opts
     const metric = 'registry-list-files'
     return this.http.get<AppFilesList>(routes.AppFiles(app, version), {params, metric, inflightKey})

--- a/src/clients/VBase.ts
+++ b/src/clients/VBase.ts
@@ -4,7 +4,7 @@ import { basename } from 'path'
 import { Readable } from 'stream'
 import { createGzip } from 'zlib'
 
-import { inflightURL, InfraClient, InstanceOptions } from '../HttpClient'
+import { inflightURL, inflightUrlWithQuery, InfraClient, InstanceOptions } from '../HttpClient'
 import { IgnoreNotFoundRequestConfig } from '../HttpClient/middlewares/notFound'
 import { BucketMetadata, FileListItem } from '../responses'
 import { IOContext } from '../service/typings'
@@ -48,7 +48,7 @@ export class VBase extends InfraClient {
       params = {prefix: opts}
     }
     const metric = 'vbase-list'
-    const inflightKey = inflightURL
+    const inflightKey = inflightUrlWithQuery
     return this.http.get<BucketFileList>(routes.Files(bucket), {params, metric, inflightKey})
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change `inflightURL` to `inflightUrlWithQuery` on every request which has mutable `params`.

#### What problem is this solving?
If two request with different params are issued at the "same time", the second one will be dropped and it will have the same response as the first one.

On one hand, it is a sign that `inflightURL` truly works, on the other hand it is breaking `styles-graphql`.

Registry`s `listAppFiles` was failling when issued twice with different prefixes. Which is exactly what `styles-graphql` does for getting SVGs, overrides and styles.

#### How should this be manually tested?
You can test it running the following GraphQL query:
```
query Style { 
  listOverrides { path } 
  selectedIconPack { svg } 
  selectedStyle { path } 
}
```
If `selectedIconPack.svg` comes empty (with `<defs />` tag empty) some of the times, then it is still broken. Otherwise the problem is fixed.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
