### PR TITLE
Use session header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Propagate `x-vtex-session` across requests.
 
 ## [3.23.0] - 2019-06-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.24.0-beta] - 2019-06-13
 ### Added
 - Propagate `x-vtex-session` across requests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.24.0-beta.0] - 2019-06-13
+
 ## [3.24.0-beta] - 2019-06-13
 ### Added
 - Propagate `x-vtex-session` across requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.24.0] - 2019-06-14
+
 ## [3.24.0-beta.0] - 2019-06-13
 
 ## [3.24.0-beta] - 2019-06-13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.23.0",
+  "version": "3.24.0-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.24.0-beta.0",
+  "version": "3.24.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.24.0-beta",
+  "version": "3.24.0-beta.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -4,7 +4,7 @@ import compose, { Middleware } from 'koa-compose'
 import pLimit from 'p-limit'
 
 import { CacheLayer } from '../caches/CacheLayer'
-import { SEGMENT_HEADER } from '../constants'
+import { SEGMENT_HEADER, SESSION_HEADER } from '../constants'
 import { MetricsAccumulator } from '../metrics/MetricsAccumulator'
 import { forExternal, forRoot, forWorkspace } from './factories'
 import { CacheableRequestConfig, Cached, cacheMiddleware, CacheType } from './middlewares/cache'
@@ -50,7 +50,7 @@ export class HttpClient {
   private runMiddlewares: compose.ComposedMiddleware<MiddlewareContext>
 
   public constructor (opts: ClientOptions) {
-    const {baseURL, authToken, authType, memoryCache, diskCache, metrics, recorder, userAgent, timeout = DEFAULT_TIMEOUT_MS, segmentToken, retries, concurrency, headers: defaultHeaders, params, operationId, verbose} = opts
+    const {baseURL, authToken, authType, memoryCache, diskCache, metrics, recorder, userAgent, timeout = DEFAULT_TIMEOUT_MS, segmentToken, sessionToken, retries, concurrency, headers: defaultHeaders, params, operationId, verbose} = opts
     const limit = concurrency && concurrency > 0 && pLimit(concurrency) || undefined
     const headers: Record<string, string> = {
       ...defaultHeaders,
@@ -58,6 +58,7 @@ export class HttpClient {
       'User-Agent': userAgent,
       ... operationId ? {'x-vtex-operation-id': operationId} : null,
       ... segmentToken ? {[SEGMENT_HEADER]: segmentToken} : null,
+      ... sessionToken ? {[SESSION_HEADER]: sessionToken} : null,
     }
 
     if (authType && authToken) {

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -2,7 +2,7 @@ import { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { URL } from 'url'
 
 import { CacheLayer } from '../../caches/CacheLayer'
-import { SEGMENT_HEADER } from '../../constants'
+import { SEGMENT_HEADER, SESSION_HEADER } from '../../constants'
 import { MiddlewareContext, RequestConfig } from '../typings'
 
 const ROUTER_CACHE_KEY = 'x-router-cache'
@@ -49,7 +49,7 @@ const parseCacheHeaders = (headers: Record<string, string>) => {
 }
 
 export function isCacheable (arg: RequestConfig, type: CacheType): arg is CacheableRequestConfig {
-  return arg && !!arg.cacheable
+  return arg && !!arg.cacheable && !arg.headers[SESSION_HEADER]
     && (arg.cacheable === type || arg.cacheable === CacheType.Any || type === CacheType.Any)
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
 export const DEFAULT_WORKSPACE = 'master'
 
 export const SEGMENT_HEADER = 'x-vtex-segment'
+export const SESSION_HEADER = 'x-vtex-session'

--- a/src/service/graphql/index.ts
+++ b/src/service/graphql/index.ts
@@ -1,9 +1,9 @@
 import { ClientsImplementation, IOClients } from '../../clients/IOClients'
 import { InstanceOptions } from '../../HttpClient'
 import { createHttpRoute } from '../http'
-import { GraphQLOptions, RouteHandler } from '../typings'
-
 import { removeSetCookie } from '../http/middlewares/setCookie'
+import { vary } from '../http/middlewares/vary'
+import { GraphQLOptions, RouteHandler } from '../typings'
 import { error } from './middlewares/error'
 import { createFormatters } from './middlewares/formatters'
 import { parseQuery } from './middlewares/query'
@@ -29,6 +29,7 @@ export const createGraphQLRoute = <ClientsT extends IOClients, StateT, CustomT>(
     }
 
     return createHttpRoute<ClientsT, StateT, CustomT & GraphQLContext>(Clients, options)([
+      vary,
       removeSetCookie,
       injectGraphql,
       timings,

--- a/src/service/graphql/utils/cacheControl.ts
+++ b/src/service/graphql/utils/cacheControl.ts
@@ -69,7 +69,7 @@ export const cacheControl = (response: GraphQLResponse, ctx: GraphQLServiceConte
   const segment = hints && anySegment(hints)
   const maxAge = linked
     ? 'no-store'
-    : (age === 0 || isPublicEndpoint(ctx) || !production)
+    : (isPublicEndpoint(ctx) || !production)
       ? 'no-cache'
       : `max-age=${age}`
   return {

--- a/src/service/http/index.ts
+++ b/src/service/http/index.ts
@@ -8,6 +8,7 @@ import { error } from './middlewares/error'
 import { trackIncomingRequestStats } from './middlewares/requestStats'
 import { removeSetCookie } from './middlewares/setCookie'
 import { timings } from './middlewares/timings'
+import { vary } from './middlewares/vary'
 
 export const createHttpRoute = <ClientsT extends IOClients, StateT, CustomT>(
   Clients: ClientsImplementation<ClientsT>,
@@ -15,7 +16,7 @@ export const createHttpRoute = <ClientsT extends IOClients, StateT, CustomT>(
 ) => {
   return (handler: RouteHandler<ClientsT, StateT, CustomT> | Array<RouteHandler<ClientsT, StateT, CustomT>>) => {
     const middlewares = Array.isArray(handler) ? handler : [handler]
-    const pipeline = [trackIncomingRequestStats, authTokens, clients(Clients, options), removeSetCookie, timings, error, ...middlewares]
+    const pipeline = [trackIncomingRequestStats, vary, authTokens, clients(Clients, options), removeSetCookie, timings, error, ...middlewares]
     return compose(pipeline)
   }
 }

--- a/src/service/http/middlewares/vary.ts
+++ b/src/service/http/middlewares/vary.ts
@@ -3,7 +3,7 @@ import { SEGMENT_HEADER, SESSION_HEADER } from '../../../constants'
 import { ServiceContext } from '../../typings'
 
 export async function vary <T extends IOClients, U, V> (ctx: ServiceContext<T, U, V>, next: () => Promise<any>) {
-  const { headers, method } = ctx
+  const { method } = ctx
 
   // We don't need to vary non GET requests, since they are never cached
   if (method.toUpperCase() !== 'GET') {
@@ -11,10 +11,10 @@ export async function vary <T extends IOClients, U, V> (ctx: ServiceContext<T, U
     return
   }
 
-  if (headers.get(SEGMENT_HEADER)) {
+  if (ctx.get(SEGMENT_HEADER)) {
     ctx.vary(SEGMENT_HEADER)
   }
-  if (headers.get(SESSION_HEADER)) {
+  if (ctx.get(SESSION_HEADER)) {
     ctx.vary(SESSION_HEADER)
   }
 

--- a/src/service/http/middlewares/vary.ts
+++ b/src/service/http/middlewares/vary.ts
@@ -1,0 +1,22 @@
+import { IOClients } from '../../../clients/IOClients'
+import { SEGMENT_HEADER, SESSION_HEADER } from '../../../constants'
+import { ServiceContext } from '../../typings'
+
+export async function vary <T extends IOClients, U, V> (ctx: ServiceContext<T, U, V>, next: () => Promise<any>) {
+  const { headers, method } = ctx
+
+  // We don't need to vary non GET requests, since they are never cached
+  if (method.toUpperCase() !== 'GET') {
+    await next()
+    return
+  }
+
+  if (headers.get(SEGMENT_HEADER)) {
+    ctx.vary(SEGMENT_HEADER)
+  }
+  if (headers.get(SESSION_HEADER)) {
+    ctx.vary(SESSION_HEADER)
+  }
+
+  await next()
+}


### PR DESCRIPTION
This PR prepares `node-vtex-api`'s `HttpClient` to propagate the session header (`x-vtex-session`) across requests.

It also implements the `vary` middleware that correctly sets the `vary` configuration whenever segment or session headers are present in a request.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
