### PR TITLE
Include extensions on dev GraphQL responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.25.0] - 2019-06-19
+
 ## [3.24.1] - 2019-06-17
 ### Fixed
 - Fixes `Please use a named function as handler for better metrics` warnings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.24.1",
+  "version": "3.25.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/graphql/middlewares/response.ts
+++ b/src/service/graphql/middlewares/response.ts
@@ -6,6 +6,7 @@ import { cacheControl } from '../utils/cacheControl'
 
 export async function response (ctx: GraphQLServiceContext, next: () => Promise<void>) {
   const {responseInit, graphqlResponse} = ctx.graphql
+  const {production} = ctx.vtex
 
   const {
     maxAge = '',
@@ -23,7 +24,10 @@ export async function response (ctx: GraphQLServiceContext, next: () => Promise<
     ctx.vary(SEGMENT_HEADER)
   }
 
-  ctx.body = pick(['data', 'errors'], graphqlResponse!)
+  const fields = production
+    ? ['data', 'errors']
+    : ['data', 'errors', 'extensions']
 
+  ctx.body = pick(fields, graphqlResponse!)
   await next()
 }

--- a/src/service/graphql/middlewares/response.ts
+++ b/src/service/graphql/middlewares/response.ts
@@ -4,6 +4,9 @@ import { SEGMENT_HEADER } from '../../../constants'
 import { GraphQLServiceContext } from '../typings'
 import { cacheControl } from '../utils/cacheControl'
 
+const DEV_FIELDS = ['data', 'errors', 'extensions']
+const PROD_FIELDS = ['data', 'errors']
+
 export async function response (ctx: GraphQLServiceContext, next: () => Promise<void>) {
   const {responseInit, graphqlResponse} = ctx.graphql
   const {production} = ctx.vtex
@@ -24,10 +27,7 @@ export async function response (ctx: GraphQLServiceContext, next: () => Promise<
     ctx.vary(SEGMENT_HEADER)
   }
 
-  const fields = production
-    ? ['data', 'errors']
-    : ['data', 'errors', 'extensions']
-
+  const fields = production ? PROD_FIELDS : DEV_FIELDS
   ctx.body = pick(fields, graphqlResponse!)
   await next()
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To include extensions on dev GraphQL responses

#### What problem is this solving?

This allows tracing information to be returned with the response.
Tracing information can be used to enhance profiling of GrahpQL resolvers.

#### Test instructions

1. Link any GraphQL app and will see an available service route for GraphQL (e.g. `http://styles-graphql.vtex.aws-us-east-1.vtex.io/storecomponents/athos/_v/graphql?__v=1.7.2`).
2. Using something like https://github.com/prisma/graphql-playground you can query that route. Since it is a private route, you'll need to add the proper authorization headers in the request.
3. With this changes, you'll receive extension data in the response.

On GraphQL Playground you'll be able to see tracing information like:

<img width="671" alt="Screen Shot 2019-06-19 at 13 58 55" src="https://user-images.githubusercontent.com/7853668/59785142-6f36ec00-929a-11e9-9b19-5540e504d97f.png">

Instead of:

<img width="670" alt="Screen Shot 2019-06-19 at 14 00 58" src="https://user-images.githubusercontent.com/7853668/59785254-b9b86880-929a-11e9-8fcd-4a4593a3f112.png">


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
