### PR TITLE
Fix destroyCircular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removal of circular references in logs.
 
 ## [3.26.3] - 2019-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.26.4] - 2019-06-27
 ### Fixed
 - Removal of circular references in logs.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.26.3",
+  "version": "3.26.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -10,7 +10,7 @@ const findCaseInsensitive = (target: string, set: string[]) => find(
   set
 )
 
-const destroyCircular = (from: any, seen: string[]) => {
+const destroyCircular = (from: any, seen: any[]) => {
   const to: {[key: string]: any} = Array.isArray(from) ? [] : {}
 
   seen.push(from)
@@ -33,7 +33,6 @@ const destroyCircular = (from: any, seen: string[]) => {
       } else {
         to[key] = value
       }
-
       continue
     }
 
@@ -65,8 +64,8 @@ const destroyCircular = (from: any, seen: string[]) => {
   ]
 
   for (const property of axiosProperties) {
-    if (from[property]) {
-      to[property] = pick(PICKED_AXIOS_PROPS, from[property])
+    if (to[property]) {
+      to[property] = pick(PICKED_AXIOS_PROPS, to[property])
       const headers = to[property] && to[property].headers
       if (headers) {
         const headerNames = keys(headers)


### PR DESCRIPTION
This PR fixes the removal of circular references in the `destroyCircular` function by picking axios properties of the `to` object instead of the `from`. 

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
