### PR TITLE
Fix logger behavior when passing string as argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.27.2] - 2019-07-08
+
 ## [3.27.1] - 2019-07-02
 ### Added
 - Http head request

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.27.1",
+  "version": "3.27.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Logger.ts
+++ b/src/clients/Logger.ts
@@ -40,6 +40,10 @@ export class Logger extends InfraClient {
       console.error(message)
     }
 
+    if (typeof message === 'string' || message instanceof String) {
+      message = {message}
+    }
+
     if (message && typeof message === 'object') {
       message.production = production
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This makes the `Logger` client properly log a call to `sendLog` when a string is passed as the `message` argument.

#### What problem is this solving?
When a string is passed to the `Logger` client, it logs gibberish to Splunk. For instance, this the result of `this.clients.logger.info('testing 1, 2, 3')`:
```
{	[-]	
  	 account:	 storecomponents	
  	 body:	 dGVzdGluZyAxLCAyLCAz	
  	 code:	 event_published	
  	 key:	 log_info	
  	 level:	 info	
  	 msg:	 Event published	
  	 region:	 aws-us-east-1	
  	 sender:	 vtex.builder-hub@0.132.2	
  	 subject:	 -	
  	 type:	 binary	
  	 version:	 0.25.4	
  	 workspace:	 marcos	
}
``` 
 This PR fixes the issue by wrapping the string in a object containing a `message` field.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
