### PR TITLE
fixes router cache stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.28.1] - 2019-07-08
+
 ## [3.28.0] - 2019-07-08
 
 ## [3.27.2] - 2019-07-08

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.28.0",
+  "version": "3.28.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -13,7 +13,7 @@ import { memoizationMiddleware, Memoized } from './middlewares/memoization'
 import { metricsMiddleware } from './middlewares/metrics'
 import { acceptNotFoundMiddleware, notFoundFallbackMiddleware } from './middlewares/notFound'
 import { recorderMiddleware } from './middlewares/recorder'
-import { defaultsMiddleware, requestMiddleware } from './middlewares/request'
+import { defaultsMiddleware, requestMiddleware, routerCacheMiddleware } from './middlewares/request'
 import { AuthType, IOResponse, MiddlewareContext, Recorder, RequestConfig } from './typings'
 
 const DEFAULT_TIMEOUT_MS = 1000
@@ -98,6 +98,7 @@ export class HttpClient {
       ...memoryCache ? [cacheMiddleware({type: CacheType.Memory, storage: memoryCache})] : [],
       ...diskCache ? [cacheMiddleware({type: CacheType.Disk, storage: diskCache})] : [],
       notFoundFallbackMiddleware,
+      routerCacheMiddleware,
       requestMiddleware(limit),
     ])
   }

--- a/src/HttpClient/middlewares/inflight.ts
+++ b/src/HttpClient/middlewares/inflight.ts
@@ -24,6 +24,7 @@ export const singleFlightMiddleware = async (ctx: MiddlewareContext, next: () =>
   const key = inflightKey(ctx.config)
   const isInflight = inflight.has(key) ? 1 : 0
   ctx.cacheHit = {
+    ...ctx.cacheHit,
     inflight: isInflight,
   }
 

--- a/src/HttpClient/middlewares/memoization.ts
+++ b/src/HttpClient/middlewares/memoization.ts
@@ -1,5 +1,5 @@
 import { MiddlewareContext } from '../typings'
-import { cacheKey, CacheType, isCacheable } from './cache'
+import { cacheKey, CacheType, isLocallyCacheable } from './cache'
 
 export type Memoized = Required<Pick<MiddlewareContext, 'cacheHit' | 'response'>>
 
@@ -9,13 +9,14 @@ interface MemoizationOptions {
 
 export const memoizationMiddleware = ({memoizedCache}: MemoizationOptions) => {
   return async (ctx: MiddlewareContext, next: () => Promise<void>) => {
-    if (!isCacheable(ctx.config, CacheType.Any) || !ctx.config.memoizable) {
+    if (!isLocallyCacheable(ctx.config, CacheType.Any) || !ctx.config.memoizable) {
       return await next()
     }
 
     const key = cacheKey(ctx.config)
     const isMemoized = memoizedCache.has(key) ? 1 : 0
     ctx.cacheHit = {
+      ...ctx.cacheHit,
       inflight: isMemoized,
     }
 

--- a/src/HttpClient/middlewares/metrics.ts
+++ b/src/HttpClient/middlewares/metrics.ts
@@ -82,9 +82,7 @@ export const metricsMiddleware = ({metrics, serverTiming, name}: MetricsOpts) =>
 
         metrics.batch(label, end, extensions)
       }
-      const cacheHit = ctx.cacheHit && values(ctx.cacheHit).reduce((a, b) => a || b !== 0, false)
-      if (!cacheHit && serverTiming) {
-
+      if (serverTiming) {
         // Timings in the client's perspective
         const dur = hrToMillis(process.hrtime(serverTimingStart))
         if (!serverTiming[serverTimingLabel] || Number(serverTiming[serverTimingLabel]) < dur) {
@@ -92,8 +90,9 @@ export const metricsMiddleware = ({metrics, serverTiming, name}: MetricsOpts) =>
         }
 
         // Forward server timings
+        const cacheHit = ctx.cacheHit && values(ctx.cacheHit).reduce((a, b) => a || b !== 0, false)
         const serverTimingsHeader = path<string>(['response', 'headers', 'server-timing'], ctx)
-        if (serverTimingsHeader) {
+        if (!cacheHit && serverTimingsHeader) {
           const parsedServerTiming = parseServerTiming(serverTimingsHeader)
           forEach(
             ([timingsName, timingsDur]) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Router cache status was not being correctly updated in `ctx.cacheHits` variable. This PR solves this problem and makes server-timings show only not-cached requests

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
