### PR TITLE
Do not separate messages `translate` queries in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.31.0] - 2019-07-15
 ### Changed
 - Do not separate messages `translate` queries in batches. Instead, use a single POST request for all translations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Do not separate messages `translate` queries in batches. Instead, use a single POST request for all translations.
 
 ## [3.30.2] - 2019-07-10
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.30.2",
+  "version": "3.31.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/GraphQLClient.ts
+++ b/src/HttpClient/GraphQLClient.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { GraphQLError } from 'graphql'
 
 import { HttpClient } from './HttpClient'
@@ -28,12 +29,16 @@ export class GraphQLClient {
   ) {}
 
   public query = <Data extends Serializable, Variables extends object>(
-    { query, variables, useGet }: QueryOptions<Variables>,
+    { query, variables }: QueryOptions<Variables>,
     config: RequestConfig = {}
-  ) => this.http.post<GraphQLResponse<Data>>(config.url || '',
-    { query, variables },
-    config
-  )
+  ) => {
+    const data = { query, variables }
+    const bodyHash = createHash('md5').update(JSON.stringify(data)).digest('hex')
+    return this.http.post<GraphQLResponse<Data>>(config.url || '',
+      { query, variables },
+      { ...config, params: { bodyHash } }
+    )
+  }
 
   public mutate = <Data extends Serializable, Variables extends object>(
     { mutate, variables }: MutateOptions<Variables>,

--- a/src/HttpClient/GraphQLClient.ts
+++ b/src/HttpClient/GraphQLClient.ts
@@ -30,18 +30,10 @@ export class GraphQLClient {
   public query = <Data extends Serializable, Variables extends object>(
     { query, variables, useGet }: QueryOptions<Variables>,
     config: RequestConfig = {}
-  ) => useGet !== false
-    ? this.http.get<GraphQLResponse<Data>>(config.url || '', {
-      ...config,
-      params: {
-        query,
-        variables: JSON.stringify(variables),
-      },
-    })
-    : this.http.post<GraphQLResponse<Data>>(config.url || '',
-      { query, variables },
-      config
-    )
+  ) => this.http.post<GraphQLResponse<Data>>(config.url || '',
+    { query, variables },
+    config
+  )
 
   public mutate = <Data extends Serializable, Variables extends object>(
     { mutate, variables }: MutateOptions<Variables>,

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -3,7 +3,7 @@ import { append, flatten, map, path, pluck, sortBy, toPairs, zip } from 'ramda'
 
 import { AppGraphQLClient, inflightUrlWithQuery, InstanceOptions } from '../HttpClient'
 import { IOContext } from '../service/typings'
-import { IOMessage, removeProviderFromId } from '../utils/message'
+import { IOMessage } from '../utils/message'
 
 type IOMessageInput = Pick<IOMessage, 'id' | 'content' | 'description' | 'provider'>
 
@@ -32,10 +32,6 @@ interface TranslateResponse {
 
 const MAX_QUERYSTRING_LENGTH = 1548
 
-const sortById = (indexedMessages: Array<[string, IOMessageInput]>) => sortBy(([, {id}]) => id, indexedMessages)
-
-const sortByIndex = (indexedTranslations: Array<[string, string]>) => sortBy(([index, _]) => Number(index), indexedTranslations)
-
 export class MessagesGraphQL extends AppGraphQLClient {
   constructor(vtex: IOContext, options?: InstanceOptions) {
     super('vtex.messages', vtex, options)
@@ -48,17 +44,11 @@ export class MessagesGraphQL extends AppGraphQLClient {
         translate(args: $args)
       }
       `,
-      variables: {
-        args: {
-          ...args,
-          messages: map(removeProviderFromId, args.messages),
-        },
-      },
+      variables: { args },
     }, {
-      inflightKey: inflightUrlWithQuery,
+      //inflightKey: inflightUrlWithQuery,
       metric: 'messages-translate',
-    })
-    .then(path(['data', 'translate'])) as Promise<TranslateResponse['translate']>
+    }).then(path(['data', 'translate'])) as Promise<TranslateResponse['translate']>
 
   public save = (args: SaveArgs): Promise<boolean> => this.graphql.mutate<boolean, { args: SaveArgs }>({
     mutate: `

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -46,7 +46,7 @@ export class MessagesGraphQL extends AppGraphQLClient {
       `,
       variables: { args },
     }, {
-      //inflightKey: inflightUrlWithQuery,
+      inflightKey: inflightUrlWithQuery,
       metric: 'messages-translate',
     }).then(path(['data', 'translate'])) as Promise<TranslateResponse['translate']>
 

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -5,7 +5,7 @@ import { AppGraphQLClient, inflightUrlWithQuery, InstanceOptions } from '../Http
 import { IOContext } from '../service/typings'
 import { IOMessage } from '../utils/message'
 
-type IOMessageInput = Pick<IOMessage, 'id' | 'content' | 'description' | 'provider'>
+type IOMessageInput = Pick<IOMessage, 'id' | 'content' | 'description'>
 
 export interface IOMessageSaveInput extends IOMessageInput {
   content: string

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -5,14 +5,13 @@ import { AppGraphQLClient, inflightUrlWithQuery, InstanceOptions } from '../Http
 import { IOContext } from '../service/typings'
 import { IOMessage, removeProviderFromId } from '../utils/message'
 
-type IOMessageInput = Pick<IOMessage, 'id' | 'content' | 'description'>
+type IOMessageInput = Pick<IOMessage, 'id' | 'content' | 'description' | 'provider'>
 
 export interface IOMessageSaveInput extends IOMessageInput {
   content: string
 }
 
 export interface Translate {
-  provider: string
   messages: IOMessageInput[]
   from?: string
   to: string
@@ -37,63 +36,12 @@ const sortById = (indexedMessages: Array<[string, IOMessageInput]>) => sortBy(([
 
 const sortByIndex = (indexedTranslations: Array<[string, string]>) => sortBy(([index, _]) => Number(index), indexedTranslations)
 
-const batchData = (lengths: number[], indexedData: IOMessageInput[]) => {
-  let batchedData: IOMessageInput[][] = []
-  let batch: IOMessageInput[] = []
-  let sumLength = 0
-
-  indexedData.forEach((obj: IOMessageInput, index: number) => {
-    const length = lengths[index]
-    if (sumLength + length > MAX_QUERYSTRING_LENGTH) {
-      batchedData = append(batch, batchedData)
-      batch = [obj]
-      sumLength = length
-    } else {
-      sumLength = sumLength + length
-      batch = append(obj, batch)
-    }
-  })
-
-  return append(batch, batchedData)
-}
-
 export class MessagesGraphQL extends AppGraphQLClient {
   constructor(vtex: IOContext, options?: InstanceOptions) {
     super('vtex.messages', vtex, options)
   }
 
-  public translate = async (args: Translate): Promise<string[]> => {
-    const { messages } = args
-    const indexedMessages = toPairs(messages) as Array<[string, IOMessageInput]>
-    const sortedIndexedMessages = sortById(indexedMessages)
-    const originalIndexes = pluck(0, sortedIndexedMessages) as string[]
-    const sortedMessages = pluck(1, sortedIndexedMessages) as IOMessageInput[]
-    const strLength = map(obj => JSON.stringify(obj).length, sortedMessages)
-    const batches = batchData(strLength, sortedMessages)
-    const translations = await mapP(
-      batches,
-      batch => this.doTranslate({
-        ...args,
-        messages: batch,
-      })
-    ).then(flatten)
-    const indexedTranslations = zip(originalIndexes, translations) as Array<[string, string]>
-    const translationsInOriginalOrder = sortByIndex(indexedTranslations)
-    return pluck(1, translationsInOriginalOrder)
-  }
-
-  public save = (args: SaveArgs): Promise<boolean> => this.graphql.mutate<boolean, { args: SaveArgs }>({
-    mutate: `
-    mutation Save($args: SaveArgs!) {
-      save(args: $args)
-    }
-    `,
-    variables: { args },
-  }, {
-    metric: 'messages-save-translation',
-  }).then(path(['data', 'save'])) as Promise<boolean>
-
-  private doTranslate = (args: Translate) =>
+  public translate = async (args: Translate): Promise<string[]> =>
     this.graphql.query<TranslateResponse, { args: Translate }>({
       query: `
       query Translate($args: TranslateArgs!) {
@@ -111,5 +59,17 @@ export class MessagesGraphQL extends AppGraphQLClient {
       metric: 'messages-translate',
     })
     .then(path(['data', 'translate'])) as Promise<TranslateResponse['translate']>
+
+  public save = (args: SaveArgs): Promise<boolean> => this.graphql.mutate<boolean, { args: SaveArgs }>({
+    mutate: `
+    mutation Save($args: SaveArgs!) {
+      save(args: $args)
+    }
+    `,
+    variables: { args },
+  }, {
+    metric: 'messages-save-translation',
+  }).then(path(['data', 'save'])) as Promise<boolean>
+
 }
 

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -27,7 +27,7 @@ export interface SaveArgs {
 }
 
 interface TranslateResponse {
-  translate: string[]
+  newTranslate: string[]
 }
 
 const MAX_QUERYSTRING_LENGTH = 1548
@@ -40,15 +40,15 @@ export class MessagesGraphQL extends AppGraphQLClient {
   public translate = async (args: Translate): Promise<string[]> =>
     this.graphql.query<TranslateResponse, { args: Translate }>({
       query: `
-      query Translate($args: TranslateArgs!) {
-        translate(args: $args)
+      query Translate($args: NewTranslateArgs!) {
+        newTranslate(args: $args)
       }
       `,
       variables: { args },
     }, {
       inflightKey: inflightUrlWithQuery,
       metric: 'messages-translate',
-    }).then(path(['data', 'translate'])) as Promise<TranslateResponse['translate']>
+    }).then(path(['data', 'newTranslate'])) as Promise<TranslateResponse['newTranslate']>
 
   public save = (args: SaveArgs): Promise<boolean> => this.graphql.mutate<boolean, { args: SaveArgs }>({
     mutate: `

--- a/src/service/graphql/schema/messagesLoader.ts
+++ b/src/service/graphql/schema/messagesLoader.ts
@@ -1,31 +1,55 @@
 import { props } from 'bluebird'
 import DataLoader from 'dataloader'
-import { forEachObjIndexed, mapObjIndexed, pick, repeat } from 'ramda'
+import { compose, forEachObjIndexed, map, mapObjIndexed, pick, pluck, repeat, sortBy, toPairs, values, zip } from 'ramda'
 
 import { IOClients } from '../../../clients/IOClients'
-import { IOMessage, providerFromMessage } from '../../../utils/message'
+import { IOMessage, providerFromMessage, removeProviderFromId } from '../../../utils/message'
+
+const sortByProvider = (indexedMessages: Array<[string, IOMessage]>) => sortBy(([_, message]) => providerFromMessage(message), indexedMessages)
+
+const sortByIndex = (indexedTranslations: Array<[string, string]>) => sortBy(([index, _]) => Number(index), indexedTranslations)
 
 export const messagesLoader = (clients: IOClients) =>
   new DataLoader<IOMessage, string>(async (messages: IOMessage[]) => {
     const to = messages[0].to!
     const from = messages[0].from
     const behavior = messages[0].behavior
+    const indexedMessages = toPairs(messages) as Array<[string, IOMessage]>
+    const sortedIndexedMessages = sortByProvider(indexedMessages)
+    const originalIndexes = pluck(0, sortedIndexedMessages) as string[]
+    const sortedMessages = pluck(1, sortedIndexedMessages) as IOMessage[]
     const messagesByProvider: Record<string, IOMessage[]> = {}
     const indexByProvider: Record<string, number[]> = {}
 
-    messages.forEach((message, index) => {
-      message.provider = providerFromMessage(message)
-      delete message.from
-      delete message.to
+    sortedMessages.forEach((message, index) => {
+      const provider = providerFromMessage(message)
+      if (!messagesByProvider[provider]) {
+        messagesByProvider[provider] = []
+
+        indexByProvider[provider] = []
+      }
+      messagesByProvider[provider].push(pick(['id', 'content', 'description'], message))
+      indexByProvider[provider].push(index)
     })
 
-    const translations = await clients.messagesGraphQL.translate({
-        behavior,
-        from,
-        messages,
-        to
-      })
+    const messagesInput = compose(
+      values,
+      mapObjIndexed(
+        (messagesArray, provider) => ({
+          messages: map(removeProviderFromId, messagesArray),
+          provider,
+        })
+      )
+    )(messagesByProvider)
 
-    console.log(`The translatons are: ` + JSON.stringify(translations, null,2 ))
-    return translations
+    const translations = await clients.messagesGraphQL.translate({
+      behavior,
+      from,
+      messages: messagesInput,
+      to,
+    })
+
+    const indexedTranslations = zip(originalIndexes, translations)
+    const translationsInOriginalOrder = sortByIndex(indexedTranslations)
+    return pluck(1, translationsInOriginalOrder)
   })

--- a/src/service/graphql/schema/messagesLoader.ts
+++ b/src/service/graphql/schema/messagesLoader.ts
@@ -14,39 +14,18 @@ export const messagesLoader = (clients: IOClients) =>
     const indexByProvider: Record<string, number[]> = {}
 
     messages.forEach((message, index) => {
-      const provider = providerFromMessage(message)
-      if (!messagesByProvider[provider]) {
-        messagesByProvider[provider] = []
-        indexByProvider[provider] = []
-      }
-      messagesByProvider[provider].push(pick(['id', 'content', 'description'], message))
-      indexByProvider[provider].push(index)
+      message.provider = providerFromMessage(message)
+      delete message.from
+      delete message.to
     })
 
-    const translationsByProvider: Record<string, string[]> = await props(
-      mapObjIndexed(
-        (messagesArray, provider) =>
-          clients.messagesGraphQL.translate({
-            behavior,
-            from,
-            messages: messagesArray,
-            provider,
-            to,
-          }),
-        messagesByProvider
-      )
-    )
+    const translations = await clients.messagesGraphQL.translate({
+        behavior,
+        from,
+        messages,
+        to
+      })
 
-    const translations = repeat('', messages.length)
-    forEachObjIndexed<string[], Record<string, string[]>>(
-      (translationsArray, provider) => {
-        const indices = indexByProvider[provider]
-        translationsArray.forEach((translation, index) => {
-          translations[indices[index]] = translation
-        })
-      },
-      translationsByProvider
-    )
-
+    console.log(`The translatons are: ` + JSON.stringify(translations, null,2 ))
     return translations
   })

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -7,7 +7,6 @@ export interface IOMessage {
   from?: string
   to?: string
   behavior?: string
-  provider?: string
 }
 
 export const providerFromMessage = (message: IOMessage) => {

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -7,6 +7,7 @@ export interface IOMessage {
   from?: string
   to?: string
   behavior?: string
+  provider?: string
 }
 
 export const providerFromMessage = (message: IOMessage) => {


### PR DESCRIPTION
This PR makes the messagesGraphQLClient send a single POST request in its `translate` method instead of sending batches of GET requests.

These changes should make VTEX IO's translation feature more reliable since less requests are sent to the `messages` service.

To be reviewed along with vtex/messages#55.

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
* [x] Refactor
