### PR TITLE
Add x-vtex-product to open segments for specific produt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.33.0] - 2019-07-26
+
 ## [3.32.2] - 2019-07-24
 ### Added
 - Accept `VtexIdclientAutCookie` as param to `getAccountData`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.32.2",
+  "version": "3.33.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -4,7 +4,7 @@ import compose, { Middleware } from 'koa-compose'
 import pLimit from 'p-limit'
 
 import { CacheLayer } from '../caches/CacheLayer'
-import { SEGMENT_HEADER, SESSION_HEADER } from '../constants'
+import { PRODUCT_HEADER, SEGMENT_HEADER, SESSION_HEADER } from '../constants'
 import { MetricsAccumulator } from '../metrics/MetricsAccumulator'
 import { forExternal, forRoot, forWorkspace } from './factories'
 import { CacheableRequestConfig, Cached, cacheMiddleware, CacheType } from './middlewares/cache'
@@ -42,6 +42,7 @@ interface ClientOptions {
   operationId: string
   verbose?: boolean
   name?: string
+  product?: string
 }
 
 export class HttpClient {
@@ -60,6 +61,7 @@ export class HttpClient {
       diskCache,
       name,
       metrics,
+      product,
       serverTiming,
       recorder,
       userAgent,
@@ -80,6 +82,7 @@ export class HttpClient {
       ... operationId ? {'x-vtex-operation-id': operationId} : null,
       ... segmentToken ? {[SEGMENT_HEADER]: segmentToken} : null,
       ... sessionToken ? {[SESSION_HEADER]: sessionToken} : null,
+      ... product ? {[PRODUCT_HEADER]: product} : null,
     }
 
     if (authType && authToken) {

--- a/src/clients/LicenseManager.ts
+++ b/src/clients/LicenseManager.ts
@@ -10,7 +10,7 @@ const BASE_URL = '/api/license-manager'
 const routes = {
   accountData: `${BASE_URL}/account`,
   resourceAccess: `${BASE_URL}/resources`,
-  topbarData: `${BASE_URL}/site/pvt/newtopbar`
+  topbarData: `${BASE_URL}/site/pvt/newtopbar`,
 }
 
 const inflightKey = ({baseURL, url, params}: RequestConfig) => {

--- a/src/clients/Segment.ts
+++ b/src/clients/Segment.ts
@@ -78,13 +78,13 @@ export class Segment extends JanusClient {
       forceMaxAge: SEGMENT_MAX_AGE_S,
       headers: {
         'Content-Type': 'application/json',
-        [PRODUCT_HEADER]: product,
+        [PRODUCT_HEADER]: product || '',
       },
       inflightKey: inflightUrlWithQuery,
       metric: 'segment-get',
       params: {
         ...sanitizeParams(query),
-        session_path: product,
+        session_path: product || '',
       },
     }))
   }

--- a/src/clients/Segment.ts
+++ b/src/clients/Segment.ts
@@ -1,6 +1,7 @@
 import parseCookie from 'cookie'
 import { pickBy, prop } from 'ramda'
 
+import { PRODUCT_HEADER } from '../constants'
 import { inflightUrlWithQuery, JanusClient } from '../HttpClient'
 
 export interface SegmentData {
@@ -71,15 +72,19 @@ export class Segment extends JanusClient {
   }
 
   private rawSegment = (token?: string | null, query?: Record<string, string>) => {
+    const { product } = this.context
+
     return this.http.getRaw<SegmentData>(routes.segments(token), ({
       forceMaxAge: SEGMENT_MAX_AGE_S,
       headers: {
         'Content-Type': 'application/json',
+        [PRODUCT_HEADER]: product,
       },
       inflightKey: inflightUrlWithQuery,
       metric: 'segment-get',
       params: {
         ...sanitizeParams(query),
+        session_path: product,
       },
     }))
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,4 @@ export const DEFAULT_WORKSPACE = 'master'
 
 export const SEGMENT_HEADER = 'x-vtex-segment'
 export const SESSION_HEADER = 'x-vtex-session'
+export const PRODUCT_HEADER = 'x-vtex-product'

--- a/src/service/graphql/schema/index.ts
+++ b/src/service/graphql/schema/index.ts
@@ -35,8 +35,6 @@ export const makeSchema = (ctx: GraphQLServiceContext) => {
       schemaDirectives: appDirectives,
     },
     clients: { segment },
-    vtex: { segmentToken },
-    query: { session_path, session_host },
   } = ctx
 
   if (cache.executableSchema) {
@@ -47,9 +45,7 @@ export const makeSchema = (ctx: GraphQLServiceContext) => {
 
   // The target translation locale is only necessary if this GraphQL app uses the `IOMessage` resolver.
   const getLocaleTo = async () => {
-    const sessionQuery = {session_path, session_host}
-    const { segmentData: { cultureInfo } } = await segment.getOrCreateSegment(sessionQuery, segmentToken)
-
+    const { cultureInfo } = await segment.getSegment()
     return cultureInfo
   }
 

--- a/src/service/graphql/schema/index.ts
+++ b/src/service/graphql/schema/index.ts
@@ -31,9 +31,13 @@ try{
 
 export const makeSchema = (ctx: GraphQLServiceContext) => {
   const {
-    resolvers: appResolvers,
-    schemaDirectives: appDirectives,
-  } = ctx.graphql
+    graphql: { resolvers: appResolvers,
+      schemaDirectives: appDirectives,
+    },
+    clients: { segment },
+    vtex: { segmentToken },
+    query: { session_path, session_host },
+  } = ctx
 
   if (cache.executableSchema) {
     return cache.executableSchema
@@ -43,7 +47,9 @@ export const makeSchema = (ctx: GraphQLServiceContext) => {
 
   // The target translation locale is only necessary if this GraphQL app uses the `IOMessage` resolver.
   const getLocaleTo = async () => {
-    const {cultureInfo} = await ctx.clients.segment.getSegment()
+    const sessionQuery = {session_path, session_host}
+    const { segmentData: { cultureInfo } } = await segment.getOrCreateSegment(sessionQuery, segmentToken)
+
     return cultureInfo
   }
 

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -9,7 +9,7 @@ export class Translatable extends SchemaDirectiveVisitor {
   public visitFieldDefinition (field: GraphQLField<any, ServiceContext>) {
     const { resolve = defaultFieldResolver } = field
     field.resolve = async (root, args, context, info) => {
-      const { clients: { segment }, clients, query: { session_path, session_host }, vtex: { segmentToken } } = context
+      const { clients: { segment }, clients } = context
       if (!context.loaders || !context.loaders.messages) {
         context.loaders = {
           ...context.loaders,
@@ -34,12 +34,7 @@ export class Translatable extends SchemaDirectiveVisitor {
         : response
       const { content, from, id } = resObj
 
-      const sessionQuery = {
-        session_host, 
-        session_path,
-      }
-      const { segmentData } = await segment.getOrCreateSegment(sessionQuery, segmentToken)
-      const { cultureInfo: to } = segmentData
+      const { cultureInfo: to } = await segment.getSegment()
 
       if (content == null && id == null) {
         throw new Error(`@translatable directive needs a content or id to translate, but received ${JSON.stringify(response)}`)

--- a/src/service/http/middlewares/error.ts
+++ b/src/service/http/middlewares/error.ts
@@ -54,6 +54,7 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
         'x-forwarded-proto': forwardedProto,
         'x-vtex-caller': caller,
         'x-vtex-platform': platform,
+        'x-vtex-product': product,
       },
     } = ctx
 
@@ -73,6 +74,7 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
       operationId,
       params,
       platform,
+      product,
       query,
       requestId,
       routeId: id,

--- a/src/service/typings.ts
+++ b/src/service/typings.ts
@@ -9,7 +9,7 @@ import { ParsedUrlQuery } from 'querystring'
 import { ClientsImplementation, IOClients } from '../clients/IOClients'
 import { InstanceOptions } from '../HttpClient'
 import { Recorder } from '../HttpClient/middlewares/recorder'
-import { IOMessage } from '../utils/message';
+import { IOMessage } from '../utils/message'
 
 type ServerTiming = Record<string, string>
 
@@ -73,6 +73,7 @@ export interface IOContext {
   // Identifies the user based on the cookie `VtexIdclientAutCookie_${account}`. Cookies are only available in private routes.
   storeUserAuthToken?: string
   production: boolean
+  product: string
   recorder?: Recorder
   region: string
   route: {


### PR DESCRIPTION
#### What is the purpose of this pull request?
It passes the querystrings `session_path` and `session_host`, which are used to separate products when we open message's segments.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
