### PR TITLE
getAccountData now requires to pass the param VtexIdclientAutCookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `getAccountData` now requires to pass the param `VtexIdclientAutCookie`.
 
 ## [3.33.0] - 2019-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.33.1] - 2019-07-29
 ### Changed
 - `getAccountData` now requires to pass the param `VtexIdclientAutCookie`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.33.0",
+  "version": "3.33.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/LicenseManager.ts
+++ b/src/clients/LicenseManager.ts
@@ -19,12 +19,10 @@ const inflightKey = ({baseURL, url, params}: RequestConfig) => {
 
 export class LicenseManager extends JanusClient {
   public getAccountData (VtexIdclientAutCookie: string) {
-    const authToken = VtexIdclientAutCookie || this.context.authToken
-
     return this.http.get(routes.accountData, {
       forceMaxAge: TWO_MINUTES_S,
       headers: {
-        VtexIdclientAutCookie: authToken,
+        VtexIdclientAutCookie,
       },
       inflightKey,
       metric: 'lm-account-data',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Continue the work started at https://github.com/vtex/node-vtex-api/pull/192

#### What problem is this solving?

Usage of LM client.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
