### PR TITLE
Does not dispose on set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.34.1] - 2019-07-31
+
 ## [3.34.0] - 2019-07-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.34.0",
+  "version": "3.34.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/caches/LRUCache.ts
+++ b/src/caches/LRUCache.ts
@@ -17,6 +17,7 @@ export class LRUCache <K, V> implements CacheLayer<K, V>{
     this.storage = new LRU({
       ...options,
       dispose: () => this.disposed += 1,
+      noDisposeOnSet: true,
     })
     this.multilayer = new MultilayeredCache([this])
   }

--- a/src/caches/LRUDiskCache.ts
+++ b/src/caches/LRUDiskCache.ts
@@ -30,6 +30,7 @@ export class LRUDiskCache<V> implements CacheLayer<string, V>{
     const lruOptions = {
       ...options,
       dispose,
+      noDisposeOnSet: true,
     }
 
     this.lruStorage = new LRU<string, number>(lruOptions)


### PR DESCRIPTION
#### What is the purpose of this pull request?
This makes the weird log in Splunk of hits having the same number as disposed items disappear. This behavior was due to the http client implementation always setting the item back to the cache after the etag revalidation occured

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
