### PR TITLE
Handle translatable string arrays too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.38.0] - 2019-08-08
 ### Added
 - Inside the class `Translatable`, allow `string` arrays to be translated too.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Inside the class `Translatable`, allow `string` arrays to be translated too.
 
 ## [3.37.2] - 2019-08-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.37.2",
+  "version": "3.38.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -28,7 +28,7 @@ export class Translatable extends SchemaDirectiveVisitor {
 
 const handleSingleString = async (response: any, context: ServiceContext<IOClients, void, void>) => {
   // Messages only knows how to process non empty strings.
-  if (typeof response !== 'string' && typeof response !== 'object' || response == null) {
+  if ((typeof response !== 'string' && typeof response !== 'object') || Array.isArray(response) || response == null) {
     return response
   }
 

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -1,8 +1,10 @@
 import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
+import { map } from 'ramda'
 
 import { ServiceContext } from '../../../typings'
 import { messagesLoader } from '../messagesLoader'
+
 
 export class Translatable extends SchemaDirectiveVisitor {
   public visitFieldDefinition (field: GraphQLField<any, ServiceContext>) {
@@ -17,43 +19,78 @@ export class Translatable extends SchemaDirectiveVisitor {
         }
       }
 
+      const isNotTranslatableString = (response: any) => {
+        return typeof response !== 'string' && typeof response !== 'object'
+      }
+
+      const isNotTranslatableStringArray = (response: any) => {
+        if(!Array.isArray(response)) {
+          return true
+        }
+
+        let isArrayWithOnlyTranslatableStrings = true
+        response.map(
+          element => {
+            if(isNotTranslatableString(element)) {
+              isArrayWithOnlyTranslatableStrings = false // find a way to optmize and break the "map"  process in this case
+            }
+          }
+        )
+
+        return !isArrayWithOnlyTranslatableStrings
+      }
+
       const response = await resolve(root, args, context, info)
 
-      // Messages only knows how to process non empty strings.
-      if ((typeof response !== 'string' && typeof response !== 'object') || Array.isArray(response) || response == null) {
+      // Messages only knows how to process non empty strings, here we also allow array of strings
+      if (isNotTranslatableString(response) || isNotTranslatableStringArray(response)  || response == null) {
         return response
       }
 
-      const resObj = typeof response === 'string'
-        ? {
-          content: response,
-          description: '',
-          from: undefined,
-          id: response,
-        }
-        : response
-      const { content, from, id } = resObj
+      const handleTranslatableString = async (response: any) => {
+        const resObj = typeof response === 'string'
+          ? {
+            content: response,
+            description: '',
+            from: undefined,
+            id: response,
+          }
+          : response
+        const { content, from, id } = resObj
 
       const to =
         locale != null
           ? locale
           : (await segment.getSegment()).cultureInfo
 
-      if (content == null && id == null) {
-        throw new Error(`@translatable directive needs a content or id to translate, but received ${JSON.stringify(response)}`)
+        if (content == null && id == null) {
+          throw new Error(`@translatable directive needs a content or id to translate, but received ${JSON.stringify(response)}`)
+        }
+
+        // If the message is already in the target locale, return the content.
+        if (!to || from === to) {
+          return content
+        }
+
+        return context.loaders.messages!.load({
+          ...resObj,
+          from,
+          to,
+        })
       }
 
-      // If the message is already in the target locale, return the content.
-      if (!to || from === to) {
-        return content
+      const handleTranslatableStringArray = async (response: any) => {
+        return map (
+          (element: any) => handleTranslatableString(element),
+          response
+        )
       }
 
-      return context.loaders.messages!.load({
-        ...resObj,
-        behavior,
-        from,
-        to,
-      })
+      if(Array.isArray(response)) {
+        return handleTranslatableStringArray(response)
+      } else {
+        return handleTranslatableString(response)
+      }
     }
   }
 }

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -2,9 +2,9 @@ import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 import { map } from 'ramda'
 
+import { IOClients } from '../../../../clients/IOClients'
 import { ServiceContext } from '../../../typings'
 import { messagesLoader } from '../messagesLoader'
-
 
 export class Translatable extends SchemaDirectiveVisitor {
   public visitFieldDefinition (field: GraphQLField<any, ServiceContext>) {
@@ -19,78 +19,45 @@ export class Translatable extends SchemaDirectiveVisitor {
         }
       }
 
-      const isNotTranslatableString = (response: any) => {
-        return typeof response !== 'string' && typeof response !== 'object'
-      }
-
-      const isNotTranslatableStringArray = (response: any) => {
-        if(!Array.isArray(response)) {
-          return true
-        }
-
-        let isArrayWithOnlyTranslatableStrings = true
-        response.map(
-          element => {
-            if(isNotTranslatableString(element)) {
-              isArrayWithOnlyTranslatableStrings = false // find a way to optmize and break the "map"  process in this case
-            }
-          }
-        )
-
-        return !isArrayWithOnlyTranslatableStrings
-      }
-
       const response = await resolve(root, args, context, info)
 
-      // Messages only knows how to process non empty strings, here we also allow array of strings
-      if (isNotTranslatableString(response) || isNotTranslatableStringArray(response)  || response == null) {
-        return response
-      }
-
-      const handleTranslatableString = async (response: any) => {
-        const resObj = typeof response === 'string'
-          ? {
-            content: response,
-            description: '',
-            from: undefined,
-            id: response,
-          }
-          : response
-        const { content, from, id } = resObj
-
-      const to =
-        locale != null
-          ? locale
-          : (await segment.getSegment()).cultureInfo
-
-        if (content == null && id == null) {
-          throw new Error(`@translatable directive needs a content or id to translate, but received ${JSON.stringify(response)}`)
-        }
-
-        // If the message is already in the target locale, return the content.
-        if (!to || from === to) {
-          return content
-        }
-
-        return context.loaders.messages!.load({
-          ...resObj,
-          from,
-          to,
-        })
-      }
-
-      const handleTranslatableStringArray = async (response: any) => {
-        return map (
-          (element: any) => handleTranslatableString(element),
-          response
-        )
-      }
-
-      if(Array.isArray(response)) {
-        return handleTranslatableStringArray(response)
-      } else {
-        return handleTranslatableString(response)
-      }
+      return !Array.isArray(response) ? handleSingleString(response, context) : map((element: any) => handleSingleString(element, context), response)
     }
   }
+}
+
+const handleSingleString = async (response: any, context: ServiceContext<IOClients, void, void>) => {
+  // Messages only knows how to process non empty strings.
+  if (typeof response !== 'string' && typeof response !== 'object' || response == null) {
+    return response
+  }
+
+  const resObj = typeof response === 'string'
+    ? {
+      content: response,
+      description: '',
+      from: undefined,
+      id: response,
+    }
+    : response
+  const { content, from, id } = resObj
+
+  const { clients: { segment } } = context
+  const { cultureInfo: to } = await segment.getSegment()
+
+  if (content == null && id == null) {
+    throw new Error(`@translatable directive needs a content or id to translate, but received ${JSON.stringify(response)}`)
+  }
+
+  // If the message is already in the target locale, return the content.
+  if (!to || from === to) {
+    return content
+  }
+
+  return context.loaders.messages!.load({
+    ...resObj,
+    behavior,
+    from,
+    to,
+  })
 }

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -6,7 +6,6 @@ import { IOClients } from '../../../../clients/IOClients';
 import { ServiceContext } from '../../../typings';
 import { messagesLoader } from '../messagesLoader';
 
-
 export class Translatable extends SchemaDirectiveVisitor {
   public visitFieldDefinition (field: GraphQLField<any, ServiceContext>) {
     const { resolve = defaultFieldResolver } = field
@@ -22,13 +21,13 @@ export class Translatable extends SchemaDirectiveVisitor {
 
       const response = await resolve(root, args, context, info)
 
-      const handler = handleSingleString(context)
+      const handler = handleSingleString(context, behavior)
       return Array.isArray(response) ? await map(response, handler) : await handler(response)
     }
   }
 }
 
-const handleSingleString = (context: ServiceContext<IOClients, void, void>) => async (response: any) => {
+const handleSingleString = (context: ServiceContext<IOClients, void, void>, behavior: string) => async (response: any) => {
   // Messages only knows how to process non empty strings.
   if ((typeof response !== 'string' && typeof response !== 'object') || Array.isArray(response) || response == null) {
     return response

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -18,9 +18,7 @@ export class Translatable extends SchemaDirectiveVisitor {
           messages: messagesLoader(clients),
         }
       }
-
       const response = await resolve(root, args, context, info)
-
       const handler = handleSingleString(context, behavior)
       return Array.isArray(response) ? await map(response, handler) : await handler(response)
     }
@@ -32,7 +30,6 @@ const handleSingleString = (context: ServiceContext<IOClients, void, void>, beha
   if ((typeof response !== 'string' && typeof response !== 'object') || Array.isArray(response) || response == null) {
     return response
   }
-
   const resObj = typeof response === 'string'
     ? {
       content: response,
@@ -41,8 +38,8 @@ const handleSingleString = (context: ServiceContext<IOClients, void, void>, beha
       id: response,
     }
     : response
-  const { content, from, id } = resObj
 
+  const { content, from, id } = resObj
   const { clients: { segment }, vtex: { locale } } = context
   const to =
     locale != null

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -1,17 +1,17 @@
-import { map } from 'bluebird';
-import { defaultFieldResolver, GraphQLField } from 'graphql';
-import { SchemaDirectiveVisitor } from 'graphql-tools';
+import { map } from 'bluebird'
+import { defaultFieldResolver, GraphQLField } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
 
-import { IOClients } from '../../../../clients/IOClients';
-import { ServiceContext } from '../../../typings';
-import { messagesLoader } from '../messagesLoader';
+import { IOClients } from '../../../../clients/IOClients'
+import { ServiceContext } from '../../../typings'
+import { messagesLoader } from '../messagesLoader'
 
 export class Translatable extends SchemaDirectiveVisitor {
   public visitFieldDefinition (field: GraphQLField<any, ServiceContext>) {
     const { resolve = defaultFieldResolver } = field
     const { behavior = 'FULL' } = this.args
     field.resolve = async (root, args, context, info) => {
-      const { clients: { segment }, clients, vtex: { locale } } = context
+      const { clients: { segment }, clients } = context
       if (!context.loaders || !context.loaders.messages) {
         context.loaders = {
           ...context.loaders,
@@ -43,9 +43,11 @@ const handleSingleString = (context: ServiceContext<IOClients, void, void>, beha
     : response
   const { content, from, id } = resObj
 
-  const { clients: { segment } } = context
-  const { cultureInfo: to } = await segment.getSegment()
-
+  const { clients: { segment }, vtex: { locale } } = context
+  const to =
+    locale != null
+    ? locale
+    : (await segment.getSegment()).cultureInfo
   if (content == null && id == null) {
     throw new Error(`@translatable directive needs a content or id to translate, but received ${JSON.stringify(response)}`)
   }

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -1,10 +1,11 @@
-import { defaultFieldResolver, GraphQLField } from 'graphql'
-import { SchemaDirectiveVisitor } from 'graphql-tools'
-import { map } from 'ramda'
+import { map } from 'bluebird';
+import { defaultFieldResolver, GraphQLField } from 'graphql';
+import { SchemaDirectiveVisitor } from 'graphql-tools';
 
-import { IOClients } from '../../../../clients/IOClients'
-import { ServiceContext } from '../../../typings'
-import { messagesLoader } from '../messagesLoader'
+import { IOClients } from '../../../../clients/IOClients';
+import { ServiceContext } from '../../../typings';
+import { messagesLoader } from '../messagesLoader';
+
 
 export class Translatable extends SchemaDirectiveVisitor {
   public visitFieldDefinition (field: GraphQLField<any, ServiceContext>) {
@@ -21,12 +22,13 @@ export class Translatable extends SchemaDirectiveVisitor {
 
       const response = await resolve(root, args, context, info)
 
-      return !Array.isArray(response) ? handleSingleString(response, context) : map((element: any) => handleSingleString(element, context), response)
+      const handler = handleSingleString(context)
+      return Array.isArray(response) ? await map(response, handler) : await handler(response)
     }
   }
 }
 
-const handleSingleString = async (response: any, context: ServiceContext<IOClients, void, void>) => {
+const handleSingleString = (context: ServiceContext<IOClients, void, void>) => async (response: any) => {
   // Messages only knows how to process non empty strings.
   if ((typeof response !== 'string' && typeof response !== 'object') || Array.isArray(response) || response == null) {
     return response

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -41,10 +41,12 @@ const handleSingleString = (context: ServiceContext<IOClients, void, void>, beha
 
   const { content, from, id } = resObj
   const { clients: { segment }, vtex: { locale } } = context
+
   const to =
     locale != null
     ? locale
     : (await segment.getSegment()).cultureInfo
+
   if (content == null && id == null) {
     throw new Error(`@translatable directive needs a content or id to translate, but received ${JSON.stringify(response)}`)
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Inside the class `Translatable`, allow `string` arrays to be translated too, not only simple non-empty strings as before. 

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
