### PR TITLE
Propagate locale as 'x-vtex-locale' header on any HttpClient request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.37.0] - 2019-08-08
+
 ## [3.36.1] - 2019-08-08
 
 ## [3.36.0] - 2019-08-08

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.36.1",
+  "version": "3.37.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -5,7 +5,7 @@ import compose, { Middleware } from 'koa-compose'
 import pLimit from 'p-limit'
 
 import { CacheLayer } from '../caches/CacheLayer'
-import { BODY_HASH, PRODUCT_HEADER, SEGMENT_HEADER, SESSION_HEADER } from '../constants'
+import { BODY_HASH, LOCALE_HEADER, PRODUCT_HEADER, SEGMENT_HEADER, SESSION_HEADER } from '../constants'
 import { MetricsAccumulator } from '../metrics/MetricsAccumulator'
 import { forExternal, forRoot, forWorkspace } from './factories'
 import { CacheableRequestConfig, Cached, cacheMiddleware, CacheType } from './middlewares/cache'
@@ -25,6 +25,7 @@ interface ClientOptions {
   authToken?: string
   userAgent: string
   baseURL?: string
+  locale?: string
   timeout?: number
   recorder?: Recorder
   metrics?: MetricsAccumulator
@@ -61,6 +62,7 @@ export class HttpClient {
       authType,
       memoryCache,
       diskCache,
+      locale,
       name,
       metrics,
       product,
@@ -86,6 +88,7 @@ export class HttpClient {
       ... segmentToken ? {[SEGMENT_HEADER]: segmentToken} : null,
       ... sessionToken ? {[SESSION_HEADER]: sessionToken} : null,
       ... product ? {[PRODUCT_HEADER]: product} : null,
+      ... locale ? {[LOCALE_HEADER]: locale} : null,
     }
 
     if (authType && authToken) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,8 @@ export const DEFAULT_WORKSPACE = 'master'
 export const SEGMENT_HEADER = 'x-vtex-segment'
 export const SESSION_HEADER = 'x-vtex-session'
 export const PRODUCT_HEADER = 'x-vtex-product'
+export const LOCALE_HEADER = 'x-vtex-locale'
 
-export type VaryHeaders = typeof SEGMENT_HEADER | typeof SESSION_HEADER | typeof PRODUCT_HEADER
+export type VaryHeaders = typeof SEGMENT_HEADER | typeof SESSION_HEADER | typeof PRODUCT_HEADER | typeof LOCALE_HEADER
 
 export const BODY_HASH = '__graphqlBodyHash'

--- a/src/service/graphql/schema/index.ts
+++ b/src/service/graphql/schema/index.ts
@@ -35,6 +35,7 @@ export const makeSchema = (ctx: GraphQLServiceContext) => {
       schemaDirectives: appDirectives,
     },
     clients: { segment },
+    vtex: { locale },
   } = ctx
 
   if (cache.executableSchema) {
@@ -45,6 +46,9 @@ export const makeSchema = (ctx: GraphQLServiceContext) => {
 
   // The target translation locale is only necessary if this GraphQL app uses the `IOMessage` resolver.
   const getLocaleTo = async () => {
+    if (locale) {
+      return locale
+    }
     const { cultureInfo } = await segment.getSegment()
     return cultureInfo
   }

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -9,7 +9,7 @@ export class Translatable extends SchemaDirectiveVisitor {
     const { resolve = defaultFieldResolver } = field
     const { behavior = 'FULL' } = this.args
     field.resolve = async (root, args, context, info) => {
-      const { clients: { segment }, clients } = context
+      const { clients: { segment }, clients, vtex: { locale } } = context
       if (!context.loaders || !context.loaders.messages) {
         context.loaders = {
           ...context.loaders,
@@ -34,7 +34,10 @@ export class Translatable extends SchemaDirectiveVisitor {
         : response
       const { content, from, id } = resObj
 
-      const { cultureInfo: to } = await segment.getSegment()
+      const to =
+        locale != null
+          ? locale
+          : (await segment.getSegment()).cultureInfo
 
       if (content == null && id == null) {
         throw new Error(`@translatable directive needs a content or id to translate, but received ${JSON.stringify(response)}`)

--- a/src/service/http/middlewares/error.ts
+++ b/src/service/http/middlewares/error.ts
@@ -55,6 +55,7 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
         'x-vtex-caller': caller,
         'x-vtex-platform': platform,
         'x-vtex-product': product,
+        'x-vtex-locale': locale,
       },
     } = ctx
 
@@ -70,6 +71,7 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
       forwardedHost,
       forwardedPath,
       forwardedProto,
+      locale,
       method,
       operationId,
       params,

--- a/src/service/typings.ts
+++ b/src/service/typings.ts
@@ -73,6 +73,7 @@ export interface IOContext {
   adminUserAuthToken?: string
   // Identifies the user based on the cookie `VtexIdclientAutCookie_${account}`. Cookies are only available in private routes.
   storeUserAuthToken?: string
+  locale?: string
   production: boolean
   product: string
   recorder?: Recorder


### PR DESCRIPTION
#### What is the purpose of this pull request?
Propagate locale from `IOContext` as `x-vtex-locale` header on any HttpClient request

#### What problem is this solving?
The necessity of opening the segment cookie every time locale is needed.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
