### PR TITLE
Less, better metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.39.0] - 2019-08-09
+
 ## [3.38.0] - 2019-08-08
 ### Added
 - Inside the class `Translatable`, allow `string` arrays to be translated too.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.38.0",
+  "version": "3.39.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -86,8 +86,6 @@ export const cacheMiddleware = ({type, storage}: CacheOptions) => {
         }
         ctx.response = response as AxiosResponse
         ctx.cacheHit = {
-          inflight: 0,
-          memoized: 0,
           memory: 1,
           revalidated: 0,
           router: 0,
@@ -112,8 +110,6 @@ export const cacheMiddleware = ({type, storage}: CacheOptions) => {
     if (revalidated && cached) {
       ctx.response = cached.response as AxiosResponse
       ctx.cacheHit = {
-        inflight: 0,
-        memoized: 0,
         memory: 1,
         revalidated: 1,
         router: 0,
@@ -131,16 +127,6 @@ export const cacheMiddleware = ({type, storage}: CacheOptions) => {
     }
 
     const shouldCache = maxAge || etag
-
-    // Add false to cacheHits to indicate this _should_ be cached but was as miss.
-    if (!ctx.cacheHit && shouldCache) {
-      ctx.cacheHit = {
-        memoized: 0,
-        memory: 0,
-        revalidated: 0,
-        router: 0,
-      }
-    }
 
     if (shouldCache) {
       const {responseType, responseEncoding} = ctx.config

--- a/src/HttpClient/middlewares/inflight.ts
+++ b/src/HttpClient/middlewares/inflight.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto'
 import { stringify } from 'qs'
 import { InflightKeyGenerator, MiddlewareContext, RequestConfig } from '../typings'
 
@@ -23,18 +22,11 @@ export const singleFlightMiddleware = async (ctx: MiddlewareContext, next: () =>
   }
 
   const key = inflightKey(ctx.config)
-  const isInflight = inflight.has(key) ? 1 : 0
-  ctx.cacheHit = {
-    ...ctx.cacheHit,
-    inflight: isInflight,
-  }
+  const isInflight = !!inflight.has(key)
 
   if (isInflight) {
     const memoized = await inflight.get(key)!
-    ctx.cacheHit = {
-      ...memoized.cacheHit,
-      inflight: 1,
-    }
+    ctx.inflightHit = isInflight
     ctx.response = memoized.response
     return
   } else {

--- a/src/HttpClient/middlewares/memoization.ts
+++ b/src/HttpClient/middlewares/memoization.ts
@@ -14,18 +14,11 @@ export const memoizationMiddleware = ({memoizedCache}: MemoizationOptions) => {
     }
 
     const key = cacheKey(ctx.config)
-    const isMemoized = memoizedCache.has(key) ? 1 : 0
-    ctx.cacheHit = {
-      ...ctx.cacheHit,
-      inflight: isMemoized,
-    }
+    const isMemoized = !!memoizedCache.has(key)
 
     if (isMemoized) {
       const memoized = await memoizedCache.get(key)!
-      ctx.cacheHit = {
-        ...memoized.cacheHit,
-        memoized: 1,
-      }
+      ctx.memoizedHit = isMemoized
       ctx.response = memoized.response
       return
     } else {

--- a/src/HttpClient/middlewares/request.ts
+++ b/src/HttpClient/middlewares/request.ts
@@ -77,8 +77,6 @@ export const routerCacheMiddleware = async (ctx: MiddlewareContext, next: () => 
   const status = path(ROUTER_RESPONSE_STATUS_PATH, ctx)
   if (routerCacheHit === ROUTER_CACHE_HIT || (routerCacheHit === ROUTER_CACHE_REVALIDATED && status !== 304)) {
     ctx.cacheHit = {
-      inflight: 0,
-      memoized: 0,
       memory: 0,
       revalidated: 0,
       ...ctx.cacheHit,

--- a/src/HttpClient/typings.ts
+++ b/src/HttpClient/typings.ts
@@ -39,14 +39,14 @@ export interface CacheHit {
   memory?: 0 | 1
   revalidated?: 0 | 1
   router?: 0 | 1
-  memoized?: 0 | 1
-  inflight?: 0 | 1
 }
 
 export interface MiddlewareContext {
   config: RequestConfig
   response?: AxiosResponse
   cacheHit?: CacheHit
+  inflightHit?: boolean
+  memoizedHit?: boolean
 }
 
 export type CacheStorage = CacheLayer<string, Cached>

--- a/src/metrics/MetricsAccumulator.ts
+++ b/src/metrics/MetricsAccumulator.ts
@@ -77,8 +77,8 @@ export class MetricsAccumulator {
    * @deprecated in favor of MetricsAccumulator.batch(name, diffNs, cacheHit)
    * @see batch
    */
-  public batchHrTimeMetricFromEnd = (name: string, end: [number, number]) => {
-    this.batchMetric(name, hrToMillis(end))
+  public batchHrTimeMetricFromEnd = (name: string, end?: [number, number]) => {
+    this.batchMetric(name, end ? hrToMillis(end) : undefined)
   }
 
   /**
@@ -89,12 +89,14 @@ export class MetricsAccumulator {
     this.batchMetric(name, hrToMillis(process.hrtime(start)))
   }
 
-  public batchMetric = (name: string, timeMillis: number, extensions?: Record<string, string | number>) => {
+  public batchMetric = (name: string, timeMillis?: number, extensions?: Record<string, string | number>) => {
     if (!this.metricsMillis[name]) {
       this.metricsMillis[name] = []
     }
 
-    this.metricsMillis[name].push(timeMillis)
+    if (timeMillis) {
+      this.metricsMillis[name].push(timeMillis)
+    }
 
     if (extensions) {
       if (!this.extensions[name]) {
@@ -121,8 +123,8 @@ export class MetricsAccumulator {
    *
    * @see https://nodejs.org/api/process.html#process_process_hrtime_time
    */
-  public batch = (name: string, diffNs: [number, number], extensions?: Record<string, string | number>) => {
-    this.batchMetric(name, hrToMillis(diffNs), extensions)
+  public batch = (name: string, diffNs?: [number, number], extensions?: Record<string, string | number>) => {
+    this.batchMetric(name, diffNs ? hrToMillis(diffNs) : undefined, extensions)
   }
 
   public addOnFlushMetric = (metricFn: () => Metric | Metric[]) => {

--- a/src/service/Runtime.ts
+++ b/src/service/Runtime.ts
@@ -9,6 +9,9 @@ import { createHttpRoute } from './http'
 import { Service } from './Service'
 import { ClientsConfig, RouteHandler, ServiceDescriptor } from './typings'
 
+const linked = !!process.env.VTEX_APP_LINK
+const noop = () => []
+
 const defaultClients: ClientsConfig = {
   options: {
     messages: {
@@ -60,15 +63,13 @@ export class Runtime<ClientsT extends IOClients = IOClients, StateT = void, Cust
     }
 
     this.events = config.events
-    this.statusTrack = global.metrics.statusTrack
+    this.statusTrack = linked ? noop : global.metrics.statusTrack
 
     addProcessListeners()
   }
 }
 
-if (!global.metrics) {
-  global.metrics = new MetricsAccumulator()
-}
+global.metrics = new MetricsAccumulator()
 
 declare global {
   namespace NodeJS {


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Stop creating individual metrics for each `status` (abort, error, success, etc) and instead add those as dimensions to client metrics
- Fix caching semantics on metrics - remove cached, inflight and memoized responses from latencies.

#### What problem is this solving?

- Decreases amount of metrics sent to Splunk
- Remove cached responses from latencies

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
