### PR TITLE
Truncate long graphql errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.44.1] - 2019-08-19
 ### Fixed
 - Truncate long GraphQL errors so they can be sent to Splunk.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Truncate long GraphQL errors so they can be sent to Splunk.
 
 ## [3.44.0] - 2019-08-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.44.0",
+  "version": "3.44.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -1,6 +1,7 @@
-import { any, chain, compose, filter, forEach, has, pluck, prop, uniqBy } from 'ramda'
+import { any, chain, compose, filter, forEach, has, map, pluck, prop, uniqBy } from 'ramda'
 
 import { LogLevel } from '../../../clients/Logger'
+import { cleanError } from '../../../utils/error'
 import { GraphQLServiceContext } from '../typings'
 import { toArray } from '../utils/array'
 import { generatePathName } from '../utils/pathname'
@@ -79,6 +80,14 @@ export async function error (ctx: GraphQLServiceContext, next: () => Promise<voi
         }
         return e
       }, graphQLErrors)
+
+      // Reduce size of `variables` prop in the errors.
+      map((e) => {
+        if (e.query && e.query.variables) {
+          const stringifiedVariables = JSON.stringify(e.query.variables)
+          e.query.variables = stringifiedVariables.length <= 1024 ? stringifiedVariables : '[variables too long]'
+        }
+      }, uniqueErrors)
       console.error(`[node-vtex-api graphql errors] total=${graphQLErrors.length} unique=${uniqueErrors.length}`, uniqueErrors)
       ctx.graphql.status = 'error'
 

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -1,7 +1,6 @@
 import { any, chain, compose, filter, forEach, has, map, pluck, prop, uniqBy } from 'ramda'
 
 import { LogLevel } from '../../../clients/Logger'
-import { cleanError } from '../../../utils/error'
 import { GraphQLServiceContext } from '../typings'
 import { toArray } from '../utils/array'
 import { generatePathName } from '../utils/pathname'


### PR DESCRIPTION
This PR makes the GraphQL error handler truncate the `error.query.variables` prop if it is too long (more than 1024 characters).

#### What problem is this solving?
After the "GET with Body" PR (#188) was merged, some GraphQL queries are sending large payloads as `variables`. In these cases, whenever an error is thrown, the log size may be too large to be sent to Splunk.

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
