### PR TITLE
Fix translate arg in MessagesGraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.44.2] - 2019-08-19
+
 ## [3.44.1] - 2019-08-19
 ### Fixed
 - Truncate long GraphQL errors so they can be sent to Splunk.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.44.1",
+  "version": "3.44.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -6,12 +6,17 @@ import { IOMessage } from '../utils/message'
 
 type IOMessageInput = Pick<IOMessage, 'id' | 'content' | 'description' | 'behavior'>
 
+interface IOMessagesInput {
+  provider: string,
+  messages: IOMessageInput[],
+}
+
 export interface IOMessageSaveInput extends IOMessageInput {
   content: string
 }
 
 export interface Translate {
-  messages: IOMessageInput[]
+  messages: IOMessagesInput[]
   from?: string
   to: string
 }

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -6,7 +6,7 @@ import { IOMessage } from '../utils/message'
 
 type IOMessageInput = Pick<IOMessage, 'id' | 'content' | 'description' | 'behavior'>
 
-interface IOMessagesInput {
+interface MessagesInput {
   provider: string,
   messages: IOMessageInput[],
 }
@@ -16,7 +16,7 @@ export interface IOMessageSaveInput extends IOMessageInput {
 }
 
 export interface Translate {
-  messages: IOMessagesInput[]
+  messages: MessagesInput[]
   from?: string
   to: string
 }


### PR DESCRIPTION
At translate args in MessageGraphQL client, the input messages type should include the property provider for a list of messages.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
