### PR TITLE
Deprecate colossus Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.44.0] - 2019-08-19
+
 ### Changed
 - Deprecate Colossus logger completely, using stdout instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Deprecate Colossus logger completely, using stdout instead.
+
 ## [3.43.0] - 2019-08-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.43.0",
+  "version": "3.44.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Logger.ts
+++ b/src/clients/Logger.ts
@@ -4,17 +4,12 @@ import { IOContext } from '../service/typings'
 import { cleanError } from '../utils/error'
 
 const DEFAULT_SUBJECT = '-'
-const production = process.env.VTEX_PRODUCTION === 'true'
 
 export enum LogLevel {
   Debug = 'debug',
   Info = 'info',
   Warn = 'warn',
   Error = 'error',
-}
-
-const routes = {
-  Log: (level: LogLevel) => `/logs/${level}`,
 }
 
 export class Logger extends InfraClient {
@@ -37,27 +32,15 @@ export class Logger extends InfraClient {
   public error = (error: any, subject: string = DEFAULT_SUBJECT) =>
     this.sendLog(subject, cleanError(error), LogLevel.Error)
 
-  public sendLog = (subject: string, message: any, level: LogLevel) : Promise<void> => {
+  public sendLog = (_: string, message: any, level: LogLevel) : Promise<void> => {
     // Use stdout logger
     if (this.logger) {
       this.logger.log(message, level)
     }
 
-    if (!message) {
-      message = new Error('Logger.sendLog was called with null or undefined message')
-      message.code = 'ERR_NIL_ERR'
-      console.error(message)
-    }
-
-    if (typeof message === 'string' || message instanceof String) {
-      message = {message}
-    }
-
-    if (message && typeof message === 'object') {
-      message.production = production
-    }
-
-    return this.http.put(routes.Log(level), message, {params: {subject}, metric: 'logger-send'})
+    // Deprecate logging to colossus
+    console.warn('Logger in ctx.clients.logger is deprecated, please use ctx.vtex.logger instead.')
+    return Promise.resolve()
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

As announced previously: https://vtex.slack.com/archives/C1Q399J9H/p1565302965251500

#### What problem is this solving?

Deprecating Colossus logging API and moving completely to stdout.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
