### PR TITLE
Fix middleware metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Properly times metrics, considering total elapsed and code run after `await next()`.
+- Avoid broken metrics when a middleware throws.
+- Do not batch metrics for unsuccessful handlers and middlewares.
+- Rename `http-handler-success-*` to `http-handler-*` and only count non-success statuses.
+
 ## [3.42.0] - 2019-08-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.43.0] - 2019-08-19
+
 ### Changed
 
 - Properly times metrics, considering total elapsed and code run after `await next()`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.42.0",
+  "version": "3.43.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/typings.ts
+++ b/src/service/typings.ts
@@ -20,6 +20,7 @@ export interface Context<T extends IOClients> {
   dataSources?: DataSources
   timings: Record<string, [number, number]>
   metrics: Record<string, [number, number]>
+  previousTimerStart: [number, number]
   serverTiming?: ServerTiming
 }
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -78,18 +78,13 @@ export function timer<T extends IOClients, U, V>(middleware: RouteHandler<T, U, 
       ctx.metrics = {}
     }
     const start = process.hrtime()
-    try {
-      await middleware(ctx, async () => {
-        recordTimings(start, middleware.name, ctx.timings, ctx.metrics)
-        ctx.metrics = {}
-        if (next) {
-          await next()
-        }
-      })
-    } catch (e) {
+    await middleware(ctx, async () => {
       recordTimings(start, middleware.name, ctx.timings, ctx.metrics)
-      throw e
-    }
+      ctx.metrics = {}
+      if (next) {
+        await next()
+      }
+    })
   }
 }
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -38,19 +38,33 @@ export const reduceTimings = (timingsObj: Record<string, string>) => compose<Rec
   toPairs
 )(timingsObj)
 
-function recordTimings(start: [number, number], name: string, timings: Record<string, [number, number]>, middlewareMetrics: Record<string, [number, number]>) {
-  // Capture the total amount of time spent in this middleware
+function recordTimings(start: [number, number], name: string, timings: Record<string, [number, number]>, middlewareMetrics: Record<string, [number, number]>, success: boolean) {
+  // Capture the total amount of time spent in this middleware, which includes following middlewares
   const end = process.hrtime(start)
-  timings[name] = end
+  // Elapsed for this middleware must disconsider total so far
+  const elapsed: [number, number] = [
+    end[0] - timings.total[0],
+    end[1] - timings.total[1],
+  ]
+  // Only record successful executions
+  if (success) {
+    timings[name] = elapsed
+  }
+  // This middlewares end is now the total
+  timings.total = end
+
+  // Batch metric
   const label = `middleware-${name}`
-  metrics.batch(label, end)
+  metrics.batch(label, success ? elapsed : undefined, {success: success ? 1 : 0})
 
   // This middleware has added it's own metrics
   // Just add them to `timings` scoped by the middleware's name and batch them
   const middlewareMetricsKeys: string[] = keys(middlewareMetrics) as string[]
-  if (middlewareMetricsKeys.length > 0) {
+  if (success && middlewareMetricsKeys.length > 0) {
     forEach((k: string) => {
       const metricEnd = middlewareMetrics[k]
+      // Delete own metrics so next middleware can have empty state but still accumulate metrics batched after `await`
+      delete middlewareMetrics[k]
       const metricName = `${label}-${k}`
       timings[metricName] = metricEnd
       metrics.batch(metricName, metricEnd)
@@ -72,19 +86,33 @@ export function timer<T extends IOClients, U, V>(middleware: RouteHandler<T, U, 
       ctx.serverTiming = {}
     }
     if (!ctx.timings) {
-      ctx.timings = {}
+      ctx.timings = {
+        overhead: [0, 0],
+        total: [0, 0],
+      }
     }
     if (!ctx.metrics) {
       ctx.metrics = {}
     }
+    // Measure await overhead between last middleware and this one
+    if (ctx.previousTimerStart) {
+      const overhead = process.hrtime(ctx.previousTimerStart)
+      ctx.timings.overhead[0] += overhead[0]
+      ctx.timings.overhead[1] += overhead[1]
+    }
     const start = process.hrtime()
-    await middleware(ctx, async () => {
-      recordTimings(start, middleware.name, ctx.timings, ctx.metrics)
-      ctx.metrics = {}
-      if (next) {
+    try {
+      await middleware(ctx, async () => {
+        // Prepare overhead measurement for next middleware
+        ctx.previousTimerStart = process.hrtime()
         await next()
-      }
-    })
+      })
+      // At this point, this middleware *and all following ones* have executed
+      recordTimings(start, middleware.name, ctx.timings, ctx.metrics, true)
+    } catch (e) {
+      recordTimings(start, middleware.name, ctx.timings, ctx.metrics, false)
+      throw e
+    }
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Properly times metrics, considering total elapsed and code run after `await next()`.
- Avoid broken metrics when a middleware throws.
- Do not batch metrics for unsuccessful handlers and middlewares.
- Rename `http-handler-success-*` to `http-handler-*` and only count non-success statuses.

#### What problem is this solving?

Errors thrown during middlewares caused metrics to be borked. Yikes!

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
