### PR TITLE
Stop ignoring metrics with 0ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.44.3] - 2019-08-20
 ### Fixed
 - Stop ignoring 0ms metrics.
 - Rename GraphQL middlewares to resolve metrics conflict.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stop ignoring 0ms metrics.
+- Rename GraphQL middlewares to resolve metrics conflict.
+
+### Changed
+- Stop measuring event-loop overhead.
 
 ## [3.44.2] - 2019-08-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.44.2",
+  "version": "3.44.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/metrics/MetricsAccumulator.ts
+++ b/src/metrics/MetricsAccumulator.ts
@@ -94,7 +94,7 @@ export class MetricsAccumulator {
       this.metricsMillis[name] = []
     }
 
-    if (timeMillis) {
+    if (timeMillis != null) {
       this.metricsMillis[name].push(timeMillis)
     }
 

--- a/src/service/graphql/index.ts
+++ b/src/service/graphql/index.ts
@@ -2,13 +2,13 @@ import { ClientsImplementation, IOClients } from '../../clients/IOClients'
 import { InstanceOptions } from '../../HttpClient'
 import { createHttpRoute } from '../http'
 import { GraphQLOptions, RouteHandler } from '../typings'
-import { error } from './middlewares/error'
+import { graphqlError } from './middlewares/error'
 import { createFormatters } from './middlewares/formatters'
 import { parseQuery } from './middlewares/query'
 import { response } from './middlewares/response'
 import { run } from './middlewares/run'
 import { injectSchema } from './middlewares/schema'
-import { timings } from './middlewares/timings'
+import { graphqlTimings } from './middlewares/timings'
 import { upload } from './middlewares/upload'
 import { GraphQLContext, GraphQLServiceContext } from './typings'
 
@@ -28,8 +28,8 @@ export const createGraphQLRoute = <ClientsT extends IOClients, StateT, CustomT>(
 
     return createHttpRoute<ClientsT, StateT, CustomT & GraphQLContext>(Clients, options)([
       injectGraphql,
-      timings,
-      error,
+      graphqlTimings,
+      graphqlError,
       upload,
       parseQuery,
       createFormatters,

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -35,7 +35,7 @@ const parseErrorResponse = (response: any) => {
 
 const production = process.env.VTEX_PRODUCTION === 'true'
 
-export async function error (ctx: GraphQLServiceContext, next: () => Promise<void>) {
+export async function graphqlError (ctx: GraphQLServiceContext, next: () => Promise<void>) {
   const {
     vtex: {
       account,

--- a/src/service/graphql/middlewares/timings.ts
+++ b/src/service/graphql/middlewares/timings.ts
@@ -36,7 +36,7 @@ const batchResolversTracing = (resolvers: ResolverTracing[], graphQLErrors?: any
   })
 }
 
-export async function timings (ctx: GraphQLServiceContext, next: () => Promise<void>) {
+export async function graphqlTimings (ctx: GraphQLServiceContext, next: () => Promise<void>) {
   const start = process.hrtime()
 
   // Errors will be caught by the next middleware so we don't have to catch.

--- a/src/service/http/middlewares/timings.ts
+++ b/src/service/http/middlewares/timings.ts
@@ -25,14 +25,13 @@ export async function timings<T extends IOClients, U, V> (ctx: ServiceContext<T,
   // Errors will be caught by the next middleware so we don't have to catch.
   await next()
 
-  const { status: statusCode, vtex: { route: { id } }, timings: {total, overhead} } = ctx
+  const { status: statusCode, vtex: { route: { id } }, timings: {total} } = ctx
   const totalMillis = hrToMillis(total)
   console.log(log(ctx, totalMillis))
 
   const status = statusLabel(statusCode)
   // Only batch successful responses so metrics don't consider errors
   metrics.batch(`http-handler-${id}`, status === 'success' ? total : undefined, { [status]: 1 })
-  metrics.batch(`http-await-overhead`, overhead, { [status]: 1 })
   ctx.serverTiming![APP_ELAPSED_TIME_LOCATOR] = `${totalMillis}`
   ctx.set('Server-Timing', reduceTimings(ctx.serverTiming!))
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -87,26 +87,16 @@ export function timer<T extends IOClients, U, V>(middleware: RouteHandler<T, U, 
     }
     if (!ctx.timings) {
       ctx.timings = {
-        overhead: [0, 0],
         total: [0, 0],
       }
     }
     if (!ctx.metrics) {
       ctx.metrics = {}
     }
-    // Measure await overhead between last middleware and this one
-    if (ctx.previousTimerStart) {
-      const overhead = process.hrtime(ctx.previousTimerStart)
-      ctx.timings.overhead[0] += overhead[0]
-      ctx.timings.overhead[1] += overhead[1]
-    }
+
     const start = process.hrtime()
     try {
-      await middleware(ctx, async () => {
-        // Prepare overhead measurement for next middleware
-        ctx.previousTimerStart = process.hrtime()
-        await next()
-      })
+      await middleware(ctx, next)
       // At this point, this middleware *and all following ones* have executed
       recordTimings(start, middleware.name, ctx.timings, ctx.metrics, true)
     } catch (e) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Stop ignoring metrics with 0ms.

#### What problem is this solving?
When a middleware metric is below 0,49999ms it is rounded to 0ms and ignored.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
