### PR TITLE
Add parameter to skip SemVer ensure in app publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.47.0] - 2019-08-29
+
 - Add parameter `skipSemVerEnsure` in app publish.
 
 ## [3.46.0] - 2019-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add parameter `skipSemVerEnsure` in app publish.
+
 ## [3.46.0] - 2019-08-26
 
 ## [3.46.0-beta.2] - 2019-08-26

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.46.0",
+  "version": "3.47.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Builder.ts
+++ b/src/clients/Builder.ts
@@ -53,8 +53,8 @@ export class Builder extends AppClient {
     return this.zipAndSend(routes.Link(app), app, files, zipOptions, params)
   }
 
-  public publishApp = (app: string, files: File[], zipOptions: ZipOptions = {sticky: true}) => {
-    return this.zipAndSend(routes.Publish(app), app, files, zipOptions)
+  public publishApp = (app: string, files: File[], zipOptions: ZipOptions = {sticky: true}, params: RequestParams = {}) => {
+    return this.zipAndSend(routes.Publish(app), app, files, zipOptions, params)
   }
 
   public relinkApp = (app: string, changes: Change[], params: RequestParams = {}) => {
@@ -103,6 +103,7 @@ export class Builder extends AppClient {
 
 interface RequestParams {
   tsErrorsAsWarnings?: boolean,
+  skipSemVerEnsure?: boolean,
 }
 
 interface ZipOptions {


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->
A new feature to check that SemVer is being obeyed when publishing an app has been developed for the node builder in builder hub. This PR creates a parameter to skip this check and publish the app even if it violates SemVer.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
