### PR TITLE
Stop duplicating error in logs and responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.48.2] - 2019-09-04
+
 ## [3.48.1] - 2019-09-04
 
 ## [3.48.1-beta.0] - 2019-09-04

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.48.1",
+  "version": "3.48.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/graphql/middlewares/formatters.ts
+++ b/src/service/graphql/middlewares/formatters.ts
@@ -28,7 +28,13 @@ const createFormatError = (details: any) => (error: any) => {
     if (!formattedError.extensions.exception) {
       formattedError.extensions.exception = formattedError.originalError
     } else {
-      const extendedException = {...formattedError.originalError, ...formattedError.extensions.exception}
+      const extendedException = {
+        message: formattedError.originalError.message,
+        name: formattedError.originalError.name,
+        stack: formattedError.originalError.stack,
+        ...formattedError.originalError,
+        ...formattedError.extensions.exception,
+      }
       formattedError.extensions.exception = cleanError(extendedException)
     }
 

--- a/src/service/graphql/middlewares/formatters.ts
+++ b/src/service/graphql/middlewares/formatters.ts
@@ -26,7 +26,12 @@ const createFormatError = (details: any) => (error: any) => {
     }
 
     if (!formattedError.extensions.exception) {
-      formattedError.extensions.exception = formattedError.originalError
+      formattedError.extensions.exception = {
+        message: formattedError.originalError.message,
+        name: formattedError.originalError.name,
+        stack: formattedError.originalError.stack,
+        ...formattedError.originalError,
+      }
     } else {
       const extendedException = {
         message: formattedError.originalError.message,

--- a/src/service/graphql/middlewares/formatters.ts
+++ b/src/service/graphql/middlewares/formatters.ts
@@ -13,10 +13,9 @@ const ERROR_FIELD_WHITELIST = ['message', 'path', 'stack', 'extensions', 'status
 const createFormatError = (details: any) => (error: any) => {
   const formattedError = pick(ERROR_FIELD_WHITELIST, error)
 
-  if (formattedError.extensions && formattedError.extensions.exception) {
-    formattedError.extensions.exception = cleanError(formattedError.extensions.exception)
-    if (formattedError.stack === formattedError.extensions.exception.stack) {
-      delete formattedError.extensions.exception.stack
+  if (!formattedError.extensions) {
+    formattedError.extensions = {
+      code: 'INTERNAL_SERVER_ERROR',
     }
   }
 
@@ -25,6 +24,16 @@ const createFormatError = (details: any) => (error: any) => {
     if (formattedError.stack === formattedError.originalError.stack) {
       delete formattedError.originalError.stack
     }
+
+    if (!formattedError.extensions.exception) {
+      formattedError.extensions.exception = formattedError.originalError
+    } else {
+      const extendedException = {...formattedError.originalError, ...formattedError.extensions.exception}
+      formattedError.extensions.exception = cleanError(extendedException)
+    }
+
+    // Make originalError not enumerable to prevent duplicated log and response information
+    Object.defineProperty(formattedError, 'originalError', {enumerable: false})
   }
 
   Object.assign(formattedError, details)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Stop duplicating error in logs and responses

#### What problem is this solving?
We are duplicating error details in our logs and responses. That's because `error.extensions.exception` and `error.originalError` most of the time have the same information.

In this PR we ensure there will always be an `error.extensions.exception` and we make `error.originalError` a non-enumerable field.

It is similar to what apollo does here: https://github.com/apollographql/apollo-server/blob/abdec21bceb0174541680cbeecfa7cf88af14cf1/packages/apollo-server-errors/src/index.ts#L143-L148

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
