### PR TITLE
Add TSConfig and TypingsInfo routes to Builder client

### DIFF
--- a/src/clients/Builder.ts
+++ b/src/clients/Builder.ts
@@ -15,6 +15,8 @@ const routes = {
   Link: (app: string) => `${routes.Builder}/link/${app}`,
   Publish: (app: string) => `${routes.Builder}/publish/${app}`,
   Relink: (app: string) => `${routes.Builder}/relink/${app}`,
+  TSConfig: () => `${routes.Builder}/tsconfig`,
+  Typings: () => `${routes.Builder}/typings`,
 }
 
 export class Builder extends AppClient {
@@ -22,6 +24,14 @@ export class Builder extends AppClient {
 
   constructor (ioContext: IOContext, opts?: InstanceOptions) {
     super('vtex.builder-hub', ioContext, opts)
+  }
+
+  public tsConfig = () => {
+    return this.http.get(routes.TSConfig())
+  }
+
+  public typingsInfo = () => {
+    return this.http.get(routes.Typings())
   }
 
   public availability = async (app: string, hintIndex: number) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `TSConfig` and `TypingsInfo` routes on Builder client. The `TSConfig` route returns the `tsconfig` from each builder. The `TypingsInfo` route returns the dependencies injected by each builder. 

#### What problem is this solving?
These routes were added on `toolbelt` by extending the `Builder` client. Adding these routes will make the code cleaner on `toolbelt`

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
