### PR TITLE
Add DynamicSmartCache graphql directive

### DIFF
--- a/src/service/graphql/schema/schemaDirectives/DinamycSmartCache.ts
+++ b/src/service/graphql/schema/schemaDirectives/DinamycSmartCache.ts
@@ -1,0 +1,25 @@
+import { defaultFieldResolver, GraphQLField } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+import { ETAG_CONTROL_HEADER } from './SmartCacheDirective'
+
+const DEFAULT_ARGS = {
+  maxAge: undefined,
+}
+
+export class DinamycSmartCache extends SchemaDirectiveVisitor {
+  public visitFieldDefinition (field: GraphQLField<any, any>) {
+    const {resolve = defaultFieldResolver} = field
+
+    field.resolve = async (root, args, context, info) => {  
+      const response = await resolve(root, args, context, info)
+
+      const { maxAge } = response || DEFAULT_ARGS
+      if(maxAge){
+        context.set(ETAG_CONTROL_HEADER, maxAge)
+        context.vtex.recorder = context.state.recorder
+      }
+
+      return response
+    }
+  }
+}

--- a/src/service/graphql/schema/schemaDirectives/SmartCacheDirective.ts
+++ b/src/service/graphql/schema/schemaDirectives/SmartCacheDirective.ts
@@ -3,7 +3,7 @@ import { SchemaDirectiveVisitor } from 'graphql-tools'
 
 import { maxAgeEnums } from '../../utils/maxAgeEnum'
 
-const ETAG_CONTROL_HEADER = 'x-vtex-etag-control'
+export const ETAG_CONTROL_HEADER = 'x-vtex-etag-control'
 
 interface Args {
   maxAge: keyof typeof maxAgeEnums | undefined

--- a/src/service/graphql/schema/schemaDirectives/index.ts
+++ b/src/service/graphql/schema/schemaDirectives/index.ts
@@ -1,9 +1,11 @@
 import { Auth } from './Auth'
+import { DinamycSmartCache } from './DinamycSmartCache'
 import { SmartCacheDirective } from './SmartCacheDirective'
 import { Translatable } from './Translatable'
 
 export const nativeSchemaDirectives = {
   auth: Auth,
+  dinamycsmartcache: DinamycSmartCache,
   smartcache: SmartCacheDirective,
   translatable: Translatable,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR makes possible to read from a graphql response the maxAge for `x-vtex-etag-control`

<!--- Describe your changes in detail. -->

#### What problem is this solving?
There are some situations where we need that smartcache's `x-vtex-etag-control` to be dynamic.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
