### PR TITLE
Add saveV2 to MessagesGraphQL client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.52.0] - 2019-09-16
+
 ### Added
 - Add saveV2 method in MessagesGraphQL client
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add saveV2 method in MessagesGraphQL client
+
 ## [3.51.1] - 2019-09-13
 ### Fixed
 - Add host to IOContext

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.51.1",
+  "version": "3.52.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -27,6 +27,13 @@ export interface IOMessageSaveInput extends IOMessageInput {
   content: string
 }
 
+export interface MessageSaveInputV2 {
+  srcMessage: string
+  context?: string
+  targetMessage: string
+  groupContext?: string
+}
+
 export interface Translate {
   messages: MessagesInput[]
   from?: string
@@ -45,6 +52,12 @@ export interface SaveArgs {
     messages: IOMessageSaveInput[]
     provider: string
   }>
+}
+
+export interface SaveArgsV2 {
+  to: string
+  messages: MessageSaveInputV2[]
+  from?: string
 }
 
 interface TranslateResponse {
@@ -92,6 +105,17 @@ export class MessagesGraphQL extends AppGraphQLClient {
   }, {
     metric: 'messages-save-translation',
   }).then(path(['data', 'save'])) as Promise<boolean>
+
+  public saveV2 = (args: SaveArgsV2): Promise<boolean> => this.graphql.mutate<boolean, { args: SaveArgsV2 }>({
+    mutate: `
+    mutation Save($args: SaveArgsV2!) {
+      saveV2(args: $args)
+    }
+    `,
+    variables: { args },
+  }, {
+    metric: 'messages-saveV2-translation',
+  }).then(path(['data', 'saveV2'])) as Promise<boolean>
 
 }
 

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -108,7 +108,7 @@ export class MessagesGraphQL extends AppGraphQLClient {
 
   public saveV2 = (args: SaveArgsV2): Promise<boolean> => this.graphql.mutate<boolean, { args: SaveArgsV2 }>({
     mutate: `
-    mutation Save($args: SaveArgsV2!) {
+    mutation SaveV2($args: SaveArgsV2!) {
       saveV2(args: $args)
     }
     `,

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -57,7 +57,7 @@ export interface SaveArgs {
 export interface SaveArgsV2 {
   to: string
   messages: MessageSaveInputV2[]
-  from?: string
+  from: string
 }
 
 interface TranslateResponse {


### PR DESCRIPTION
Add method saveV2 to MessagesGraphQL client. The corresponding graphQL resolver in messages uses the concept of message being its own id.

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
