### PR TITLE
Index messages by from to shrink body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.55.1] - 2019-09-27
+
 ## [3.55.0] - 2019-09-25
 
 ## [3.54.1] - 2019-09-23

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.55.0",
+  "version": "3.55.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -6,16 +6,21 @@ import { IOMessage } from '../utils/message'
 
 type IOMessageInput = Pick<IOMessage, 'id' | 'content' | 'description' | 'behavior'>
 
+export interface IndexedMessageV2 {
+  messages: IOMessageInputV2[]
+  from: string
+}
+
 export interface IOMessageInputV2 {
   content: string
   context?: string
   behavior?: Behavior
-  from: string
 }
 
 export type Behavior = 'FULL' | 'USER_ONLY' | 'USER_AND_APP'
 
 export interface IOMessageV2 extends IOMessageInputV2 {
+  from: string
   to: string
 }
 
@@ -42,7 +47,7 @@ export interface Translate {
 }
 
 export interface TranslateInputV2 {
-  messages: IOMessageInputV2[]
+  indexedByFrom: IndexedMessageV2[]
   to: string
 }
 

--- a/src/service/graphql/schema/messagesLoaderV2.ts
+++ b/src/service/graphql/schema/messagesLoaderV2.ts
@@ -4,7 +4,11 @@ import { pluck, sortBy, toPairs, zip } from 'ramda'
 import { IOClients } from '../../../clients/IOClients'
 import { IndexedMessageV2, IOMessageV2 } from './../../../clients/MessagesGraphQL'
 
-const sortByContentAndFrom = (indexedMessages: Array<[string, IOMessageV2]>) => sortBy(([_, {content, from}]) => from+content, indexedMessages)
+const sortByContentAndFrom = (indexedMessages: Array<[string, IOMessageV2]>) => sortBy(
+  ([_, {content, from}]) => `__from:${from}__content:${content}`,
+  indexedMessages
+)
+
 const sortByIndex = (indexedTranslations: Array<[string, string]>) => sortBy(([index, _]) => Number(index), indexedTranslations)
 
 const indexMessagesByFrom = (messages: IOMessageV2[]) => messages.reduce(

--- a/src/service/graphql/schema/messagesLoaderV2.ts
+++ b/src/service/graphql/schema/messagesLoaderV2.ts
@@ -2,27 +2,42 @@ import DataLoader from 'dataloader'
 import { pluck, sortBy, toPairs, zip } from 'ramda'
 
 import { IOClients } from '../../../clients/IOClients'
-import { IOMessageV2 } from './../../../clients/MessagesGraphQL'
+import { IndexedMessageV2, IOMessageV2 } from './../../../clients/MessagesGraphQL'
 
-const sortByContent = (indexedMessages: Array<[string, IOMessageV2]>) => sortBy(([_, message]) => message.content!, indexedMessages)
+const sortByContentAndFrom = (indexedMessages: Array<[string, IOMessageV2]>) => sortBy(([_, {content, from}]) => from+content, indexedMessages)
 const sortByIndex = (indexedTranslations: Array<[string, string]>) => sortBy(([index, _]) => Number(index), indexedTranslations)
 
-const messageToInputV2 = (message: IOMessageV2) => ({
-  behavior: message.behavior,
-  content: message.content,
-  context: message.context,
-  from: message.from,
-})
+const indexMessagesByFrom = (messages: IOMessageV2[]) => messages.reduce(
+  (acc, {from, context, content, behavior}) => {
+    const lastIndexed = acc.length && acc[acc.length-1]
+    const formatted = {
+      behavior,
+      content,
+      context,
+    }
+    if (lastIndexed && lastIndexed.from === from) {
+      lastIndexed.messages.push(formatted)
+    } else {
+      acc.push({
+        from,
+        messages: [formatted],
+      })
+    }
+    return acc
+  },
+  [] as IndexedMessageV2[]
+)
 
 export const messagesLoaderV2 = (clients: IOClients) =>
   new DataLoader<IOMessageV2, string>(async (messages: IOMessageV2[]) => {
     const to = messages[0].to!
     const indexedMessages = toPairs(messages) as Array<[string, IOMessageV2]>
-    const sortedIndexedMessages = sortByContent(indexedMessages)
+    const sortedIndexedMessages = sortByContentAndFrom(indexedMessages)
     const originalIndexes = pluck(0, sortedIndexedMessages) as string[]
     const sortedMessages = pluck(1, sortedIndexedMessages) as IOMessageV2[]
+    const indexedByFrom = indexMessagesByFrom(sortedMessages)
     const translations = await clients.messagesGraphQL.translateV2({
-      messages: sortedMessages.map(messageToInputV2),
+      indexedByFrom,
       to,
     })
     const indexedTranslations = zip(originalIndexes, translations)


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR optimizes #240 and index messages by `from`, instead of only moving the from inside each message

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
