### PR TITLE
Set free socket timeout to avoid socket hang up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.55.4-beta] - 2019-10-09
+
 ## [3.55.3] - 2019-10-09
 ### Fixed
 - Messages Save v2 interface

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/koa": "^2.0.48",
     "@types/koa-compose": "^3.2.3",
     "@wry/equality": "^0.1.9",
+    "agentkeepalive": "^4.0.2",
     "apollo-datasource": "^0.3.1",
     "apollo-server-core": "^2.4.8",
     "apollo-server-errors": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.55.3",
+  "version": "3.55.4-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/request.ts
+++ b/src/HttpClient/middlewares/request.ts
@@ -1,6 +1,6 @@
+import Agent from 'agentkeepalive'
 import axios from 'axios'
 import retry, { exponentialDelay } from 'axios-retry'
-import { Agent } from 'http'
 import { Limit } from 'p-limit'
 import { stringify } from 'qs'
 import { mapObjIndexed, path, sum, toLower, values } from 'ramda'
@@ -10,6 +10,7 @@ import { isAbortedOrNetworkErrorOrRouterTimeout } from '../../utils/retry'
 import { MiddlewareContext } from '../typings'
 
 const httpAgent = new Agent({
+  freeSocketTimeout: 15 * 1000,
   keepAlive: true,
   maxFreeSockets: 50,
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -272,6 +272,15 @@
   dependencies:
     tslib "^1.9.3"
 
+agentkeepalive@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.0.2.tgz#38a490b779a97bd542d153e5a7da0d1fdef35dd3"
+  integrity sha512-A5gSniD4xMCYtSD4ilUHpQRB9ZbNjtIPittKUv7bA0j0UCwbT3EJBUYLKPJ/dtmaXRYWI2mG4/O90xbi7oahNw==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -735,6 +744,13 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -746,7 +762,7 @@ define-properties@^1.1.2:
   dependencies:
     object-keys "^1.0.12"
 
-depd@~1.1.2:
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
@@ -1034,6 +1050,13 @@ http-errors@^1.7.1:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
 
 iconv-lite@0.4.23:
   version "0.4.23"
@@ -1325,6 +1348,11 @@ mkdirp@^0.5.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.0.0, ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Try to fix socket hang up errors.

#### What problem is this solving?
We are experiencing a lot of socket hang up errors and it seems to be related to keep alive configuration. Apparently `node` is trying to reuse a closed socket.

This is a nice article to learn about keep alive: https://lob.com/blog/use-http-keep-alive
It talks about server vs client timeouts in the end, that can be our problem.

#### How should this be manually tested?
It's very hard to reproduce the socket hang up error. The idea is to release a beta version of service-runtime-node, let it run for a day or two and check if socket hang up errors are decreasing.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
