### PR TITLE
Assests client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.60.0",
+  "version": "3.61.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/InfraClient.ts
+++ b/src/HttpClient/InfraClient.ts
@@ -10,6 +10,7 @@ export class InfraClient extends IOClient {
   constructor(app: string, context: IOContext, options?: InstanceOptions, isRoot: boolean = false) {
     const {account, workspace, region} = context
     const baseURL = `http://${app}.${region}.vtex.io${isRoot ? '' : `/${account}/${workspace}`}`
+    console.log('baseURL', JSON.stringify(baseURL, null, 2))
 
     super(
       context,

--- a/src/HttpClient/InfraClient.ts
+++ b/src/HttpClient/InfraClient.ts
@@ -10,7 +10,6 @@ export class InfraClient extends IOClient {
   constructor(app: string, context: IOContext, options?: InstanceOptions, isRoot: boolean = false) {
     const {account, workspace, region} = context
     const baseURL = `http://${app}.${region}.vtex.io${isRoot ? '' : `/${account}/${workspace}`}`
-    console.log('baseURL', JSON.stringify(baseURL, null, 2))
 
     super(
       context,

--- a/src/HttpClient/InfraClient.ts
+++ b/src/HttpClient/InfraClient.ts
@@ -21,3 +21,4 @@ export class InfraClient extends IOClient {
     )
   }
 }
+

--- a/src/clients/Apps.ts
+++ b/src/clients/Apps.ts
@@ -85,7 +85,7 @@ export class Apps extends InfraClient {
   constructor(context: IOContext, options?: InstanceOptions) {
     super('apps', context, options, true)
     this.diskCache = options && options.diskCache
-    this.memoryCache = options && options.diskCache
+    this.memoryCache = options && options.memoryCache
     this._routes = createRoutes(context)
   }
 
@@ -247,21 +247,6 @@ export class Apps extends InfraClient {
       metric: linked ? 'apps-get-json' : 'registry-get-json',
       nullIfNotFound,
     } as IgnoreNotFoundRequestConfig)
-  }
-
-  public getAppJSONByVendor = <T extends object | null>(app: string, path: string, nullIfNotFound?: boolean) => {
-    const locator = parseAppId(app)
-    const linked = !!locator.build
-    const inflightKey = inflightURL
-    console.log('[locator, linked, inflightKey, app, path]', JSON.stringify([locator, linked, inflightKey, app, path], null, 2))
-    console.log('this.routes.File(locator, path)', JSON.stringify(this.routes.File(locator, path), null, 2))
-    return linked? this.getAppJSON(app, path, nullIfNotFound): 
-      this.http.get<T>(this.routes.File(locator, path), {
-        cacheable: linked ? CacheType.Memory : CacheType.Any,
-        inflightKey,
-        metric: linked ? 'apps-get-json' : 'registry-get-json',
-        nullIfNotFound,
-      } as IgnoreNotFoundRequestConfig)
   }
 
   public getAppFileStream = (app: string, path: string): Promise<IncomingMessage> => {

--- a/src/clients/Apps.ts
+++ b/src/clients/Apps.ts
@@ -249,6 +249,21 @@ export class Apps extends InfraClient {
     } as IgnoreNotFoundRequestConfig)
   }
 
+  public getAppJSONByVendor = <T extends object | null>(app: string, path: string, nullIfNotFound?: boolean) => {
+    const locator = parseAppId(app)
+    const linked = !!locator.build
+    const inflightKey = inflightURL
+    console.log('[locator, linked, inflightKey, app, path]', JSON.stringify([locator, linked, inflightKey, app, path], null, 2))
+    console.log('this.routes.File(locator, path)', JSON.stringify(this.routes.File(locator, path), null, 2))
+    return linked? this.getAppJSON(app, path, nullIfNotFound): 
+      this.http.get<T>(this.routes.File(locator, path), {
+        cacheable: linked ? CacheType.Memory : CacheType.Any,
+        inflightKey,
+        metric: linked ? 'apps-get-json' : 'registry-get-json',
+        nullIfNotFound,
+      } as IgnoreNotFoundRequestConfig)
+  }
+
   public getAppFileStream = (app: string, path: string): Promise<IncomingMessage> => {
     const locator = parseAppId(app)
     const metric = locator.build ? 'apps-get-file-s' : 'registry-get-file-s'

--- a/src/clients/Assets.ts
+++ b/src/clients/Assets.ts
@@ -1,0 +1,124 @@
+import { contains, filter, isEmpty, map, pick as ramdaPick, zipObj } from 'ramda'
+
+import { AppMetaInfo, CacheLayer } from '..'
+import { CacheType, inflightURL, InfraClient, InstanceOptions } from '../HttpClient'
+import { IgnoreNotFoundRequestConfig } from '../HttpClient/middlewares/notFound'
+import { IOContext } from '../service/typings'
+import { parseAppId, ParsedLocator } from '../utils'
+
+const dependsOnApp = (appAtMajor: string) => (a: AppMetaInfo) => {
+  const [name, major] = appAtMajor.split('@')
+  const version = a._resolvedDependencies[name]
+  if (!version) {
+    return false
+  }
+
+  const [depMajor] = version.split('.')
+  return major === depMajor
+}
+
+const useBuildJson = (app: AppMetaInfo, appVendorName: string) => {
+  const buildFeatures = (app as any)._buildFeatures as Record<string, string[]> | undefined
+  return buildFeatures && buildFeatures[appVendorName] && contains('build.json', buildFeatures[appVendorName])
+}
+
+export interface SettingsParams {
+  files?: string[]
+  pick?: string[]
+}
+
+export class Apps extends InfraClient {
+  private route: (scope: string, locator: ParsedLocator, path: string) => string
+
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super('apps', context, options, true)
+    this.route = this.fileRoute(this.context.workspace)
+  }
+
+  public async getSettings (dependencies: AppMetaInfo[], appAtMajor: string, params?: SettingsParams) {
+    const filtered = this.getFilteredDependencies(appAtMajor, dependencies)
+    const {pick, files} = params
+
+    return filtered.map(dependency => {
+      const [appVendorName] = appAtMajor.split('@')
+      const buildJson = useBuildJson(dependency, appVendorName)
+
+      return buildJson
+        ? this.getBuildJSONForApp(dependency, appVendorName, pick)
+        : this.getSettingsFromFilesForApp(dependency, files)
+    }
+    )
+  }
+
+  public async getBuildJSONForApp(app: AppMetaInfo, appVendorName: string, pick: string | string[] = []): Promise<Record<string, any>> {
+    const pickArray = Array.isArray(pick) ? pick : [pick]
+    const buildJson = await this.getJSON(app.id, `/dist/${appVendorName}/build.json`)
+    const result = !isEmpty(pickArray) ? ramdaPick(pickArray, buildJson) : buildJson
+    debugger
+
+    result.declarer = app.id
+    return result
+  }
+
+  public async getSettingsFromFilesForApp(app: AppMetaInfo, files: string | string[] = []): Promise<Record<string, any>> {
+    // If there's no support for build.json, then fetch individual files and zip them into an {[file]: content} object.
+    const filesArray = Array.isArray(files) ? files : [files]
+    const fetched = await Promise.all(map((file) => this.getJSON(app.id, file, true), filesArray as string[]))
+    const result = zipObj(filesArray as string[], fetched)
+    debugger
+
+    result.declarer = app.id
+    return result
+  }
+
+  public async getJSON(appId: string, file: string, nullIfNotFound?: boolean) {
+    const locator = parseAppId(appId)
+    const linked = !!locator.build
+
+    if (linked) {
+      return this.getAppJSON(appId, file, nullIfNotFound)
+    }
+    return this.getAppJSONByVendor(appId, file, nullIfNotFound)
+  }
+
+  public getFilteredDependencies(appAtMajor: string, dependencies: AppMetaInfo[]): AppMetaInfo[] {
+    const depends = dependsOnApp(appAtMajor)
+    return filter(depends, dependencies)
+  }
+
+  public getAppJSON = <T extends object | null>(app: string, path: string, nullIfNotFound?: boolean) => {
+    const locator = parseAppId(app)
+    const linked = !!locator.build
+    const inflightKey = inflightURL
+    return this.http.get<T>(this.route(this.context.account, locator, path), {
+      cacheable: linked ? CacheType.Memory : CacheType.Any,
+      inflightKey,
+      metric: linked ? 'apps-get-assets-json' : 'registry-get-assets-json',
+      nullIfNotFound,
+    } as IgnoreNotFoundRequestConfig)
+  }
+
+  public getAppJSONByVendor = <T extends object | null>(app: string, path: string, nullIfNotFound?: boolean) => {
+    const locator = parseAppId(app)
+    const vendor = locator.name.split('.')[0]
+    const linked = !!locator.build
+    const inflightKey = inflightURL
+    return linked? this.getAppJSON(app, path, nullIfNotFound):
+      this.http.get<T>(this.route(vendor, locator, path), {
+        cacheable: CacheType.Any,
+        inflightKey,
+        metric: 'registry-get-assets-json-by-vendor',
+        nullIfNotFound,
+      } as IgnoreNotFoundRequestConfig)
+  }
+
+  private fileRoute(workspace: string) {
+    const appOrRegistry = ({ name, version, build }: ParsedLocator) => build
+      ? `${workspace}/apps/${name}@${version}+${build}`
+      : `master/registry/${name}/${version}`
+
+    return (scope: string, locator: ParsedLocator, path: string) => `/${scope}/${appOrRegistry(locator)}/files/${path}`
+  }
+}
+
+

--- a/src/clients/IOClients.ts
+++ b/src/clients/IOClients.ts
@@ -1,5 +1,6 @@
 import {
   Apps,
+  Assets,
   Billing,
   BillingMetrics,
   Builder,
@@ -37,6 +38,10 @@ export class IOClients {
 
   public get apps() {
     return this.getOrSet('apps', Apps)
+  }
+
+  public get assets() {
+    return this.getOrSet('assets', Assets)
   }
 
   public get billing() {

--- a/src/clients/Settings.ts
+++ b/src/clients/Settings.ts
@@ -6,6 +6,7 @@ import { IOContext } from '../service/typings'
 import { isLinkedApp } from '../utils/app'
 
 import { AppMetaInfo } from './Apps'
+import { isArray } from 'util'
 
 const LINKED_ROUTE = 'linked'
 
@@ -55,5 +56,17 @@ export class Settings extends AppClient {
       metric: 'settings-get',
       params,
     })
+  }
+
+  public async getSettingsByVendor(dependencies: AppMetaInfo[], appAtMajor: string, params?: SettingsParams) {
+    const filtered = this.getFilteredDependencies(appAtMajor, dependencies)
+    
+    return filtered.map(dependency =>
+      this.http.get(`/settings_by_vendor/${dependency}`, {
+        inflightKey: inflightUrlWithQuery,
+        metric: 'settings-get-by-vendor',
+        params,
+      })
+    )
   }
 }

--- a/src/clients/Settings.ts
+++ b/src/clients/Settings.ts
@@ -6,7 +6,6 @@ import { IOContext } from '../service/typings'
 import { isLinkedApp } from '../utils/app'
 
 import { AppMetaInfo } from './Apps'
-import { isArray } from 'util'
 
 const LINKED_ROUTE = 'linked'
 
@@ -56,17 +55,5 @@ export class Settings extends AppClient {
       metric: 'settings-get',
       params,
     })
-  }
-
-  public async getSettingsByVendor(dependencies: AppMetaInfo[], appAtMajor: string, params?: SettingsParams) {
-    const filtered = this.getFilteredDependencies(appAtMajor, dependencies)
-    
-    return filtered.map(dependency =>
-      this.http.get(`/settings_by_vendor/${dependency}`, {
-        inflightKey: inflightUrlWithQuery,
-        metric: 'settings-get-by-vendor',
-        params,
-      })
-    )
   }
 }

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,4 +1,5 @@
 export * from './Apps'
+export * from './Assets'
 export * from './Billing'
 export * from './BillingMetrics'
 export * from './Builder'


### PR DESCRIPTION
#### What is the purpose of this pull request?
Creates new client called `Assets`.

#### What problem is this solving?
This client is supposed to be used instead of `settings-server` beacause it gets the app's assets according to the vendor and not the account (if the app is not linked) this allows for better caching and unearths the true potential of passing the depTrees from `render-server` to the other services.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
