### PR TITLE
Fix/handle cancellation not as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Correctly handle errors caused by requests cancelled with cancellation token
 
 ## [3.59.0] - 2019-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.59.1] - 2019-10-18
 ### Fixed
 - Correctly handle errors caused by requests cancelled with cancellation token
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.59.0",
+  "version": "3.59.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/metrics.ts
+++ b/src/HttpClient/middlewares/metrics.ts
@@ -1,6 +1,8 @@
 import { compose, forEach, path, reduce, replace, split, values } from 'ramda'
 
+import { RequestCancelledError } from '../../errors/RequestCancelledError'
 import { MetricsAccumulator } from '../../metrics/MetricsAccumulator'
+import { cancelMessage } from '../../service/http/middlewares/requestStats'
 import { formatTimingName, hrToMillis, parseTimingName, shrinkTimings } from '../../utils'
 import { TIMEOUT_CODE } from '../../utils/retry'
 import { statusLabel } from '../../utils/status'
@@ -67,6 +69,10 @@ export const metricsMiddleware = ({metrics, serverTiming, name}: MetricsOpts) =>
         }
         else if (err.response && err.response.status) {
           status = statusLabel(err.response.status)
+        }
+        else if (err.message === cancelMessage) {
+          status = 'cancelled'
+          throw new RequestCancelledError(err.message)
         } else {
           status = 'error'
         }

--- a/src/errors/RequestCancelledError.ts
+++ b/src/errors/RequestCancelledError.ts
@@ -1,0 +1,9 @@
+export const cancelledRequestStatus = 499
+
+export class RequestCancelledError extends Error {
+  public code = 'request_cancelled'
+
+  constructor(message: string) {
+    super(message)
+  }
+}

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -1,6 +1,7 @@
 import { any, chain, compose, filter, forEach, has, map, pluck, prop, uniqBy } from 'ramda'
 
 import { LogLevel } from '../../../clients/Logger'
+import { cancelledRequestStatus, RequestCancelledError } from '../../../errors/RequestCancelledError'
 import { GraphQLServiceContext } from '../typings'
 import { toArray } from '../utils/array'
 import { generatePathName } from '../utils/pathname'
@@ -54,6 +55,10 @@ export async function graphqlError (ctx: GraphQLServiceContext, next: () => Prom
     graphQLErrors = parseErrorResponse(ctx.graphql.graphqlResponse || {})
   }
   catch (e) {
+    if (e instanceof RequestCancelledError) {
+      ctx.status = cancelledRequestStatus
+      return
+    }
     const formatError = ctx.graphql.formatters!.formatError
 
     if (e.isGraphQLError) {

--- a/src/service/http/middlewares/error.ts
+++ b/src/service/http/middlewares/error.ts
@@ -1,5 +1,6 @@
 import { IOClients } from '../../../clients/IOClients'
 import { LogLevel } from '../../../clients/Logger'
+import { cancelledRequestStatus, RequestCancelledError } from '../../../errors/RequestCancelledError'
 import { cleanError } from '../../../utils/error'
 import { ServiceContext } from '../../typings'
 
@@ -13,6 +14,10 @@ export async function error<T extends IOClients, U, V> (ctx: ServiceContext<T, U
   try {
     await next()
   } catch (e) {
+    if (e instanceof RequestCancelledError) {
+      ctx.status = cancelledRequestStatus
+      return
+    }
     console.error('[node-vtex-api error]', e)
     const err = cleanError(e)
 

--- a/src/service/http/middlewares/requestStats.ts
+++ b/src/service/http/middlewares/requestStats.ts
@@ -1,6 +1,8 @@
 import { IOClients } from '../../../clients/IOClients'
 import { ServiceContext } from '../../typings'
 
+export const cancelMessage = 'Request cancelled'
+
 class IncomingRequestStats {
   public aborted = 0
   public closed = 0
@@ -27,7 +29,7 @@ const requestClosed = <T extends IOClients, U, V>(ctx: ServiceContext<T, U, V>) 
   incomingRequestStats.closed++
 
   if (ctx.vtex.cancellation && ctx.vtex.cancellation.cancelable) {
-    ctx.vtex.cancellation.source.cancel()
+    ctx.vtex.cancellation.source.cancel(cancelMessage)
     ctx.vtex.cancellation.cancelled = true
   }
 }

--- a/src/utils/unhandled.ts
+++ b/src/utils/unhandled.ts
@@ -1,5 +1,6 @@
 import { constants } from 'os'
 
+import { RequestCancelledError } from '../errors/RequestCancelledError'
 import { Logger } from '../service/logger'
 
 const logger = new Logger({account: 'unhandled', workspace: 'unhandled', requestId: 'unhandled', operationId: 'unhandled'})
@@ -31,6 +32,9 @@ export const addProcessListeners = () => {
   })
 
   process.on('unhandledRejection', (reason: Error | any, promise: Promise<void>)  => {
+    if (reason instanceof RequestCancelledError) {
+      return
+    }
     console.error('unhandledRejection', reason, promise)
     if (reason && logger) {
       reason.type = 'unhandledRejection'


### PR DESCRIPTION
#### What is the purpose of this pull request?
Properly handle logs generated by requests cancelled with cancellation token, which should not be treated as errors in splunk.

#### How should this be manually tested?
Put this version of node-vtex-api on render-server and render-ssr and link these two apps. Refresh the page twice in sequence and watch the logs on render-server and render-ssr. The status at the cancelled request in render-ssr should be 499 and no unhandled error message should be displayed.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
