### PR TITLE
Fix unecessary translatableV2 throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.60.0] - 2019-10-28
+
 ## [3.59.2] - 2019-10-24
 ### Fixed
 - Handle nullable arrays passed to MineWinsConflictsResolver

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.59.2",
+  "version": "3.60.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
+++ b/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
@@ -65,13 +65,13 @@ const handleSingleString = (ctx: IOContext, messagesV2: MessagesLoaderV2 , behav
   }
 
   if (to == null) {
-    throw new Error('@translatableV2 directive needs the locale variable available in IOContext. You can do it by either setting ctx.vtex.locale directly or calling this app with x-vtex-locale header')
+    throw new Error('@translatableV2 directive needs the locale variable available in IOContext. You can do this by either setting \`ctx.vtex.locale\` directly or calling this app with \`x-vtex-locale\` header')
   }
 
   const from = maybeFrom || (tenant && tenant.locale)
 
   if (from == null) {
-    throw new Error('@translatableV2 directive needs a source language to translate from. You can do this by either setting ctx.vtex.tenant variable, call this app with the header x-vtex-tenant or format the string with the formatTranslatableStringV2 function with the from option set')
+    throw new Error('@translatableV2 directive needs a source language to translate from. You can do this by either setting \`ctx.vtex.tenant\` variable, call this app with the header \`x-vtex-tenant\` or format the string with the \`formatTranslatableStringV2\` function with the \`from\` option set')
   }
 
   // If the message is already in the target locale, return the content.

--- a/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
+++ b/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
@@ -64,11 +64,15 @@ const handleSingleString = (ctx: IOContext, messagesV2: MessagesLoaderV2 , behav
     throw new Error(`@translatableV2 directive needs a content to translate, but received ${JSON.stringify(rawMessage)}`)
   }
 
-  if (to == null || tenant == null) {
-    throw new Error('@translatableV2 directive needs the locale and tenant variables available in IOContext, but none was found')
+  if (to == null) {
+    throw new Error('@translatableV2 directive needs the locale variable available in IOContext. You can do it by either setting ctx.vtex.locale directly or calling this app with x-vtex-locale header')
   }
 
-  const from = maybeFrom || tenant.locale
+  const from = maybeFrom || (tenant && tenant.locale)
+
+  if (from == null) {
+    throw new Error('@translatableV2 directive needs a source language to translate from. You can do this by either setting ctx.vtex.tenant variable, call this app with the header x-vtex-tenant or format the string with the formatTranslatableStringV2 function with the from option set')
+  }
 
   // If the message is already in the target locale, return the content.
   if (!to || from === to) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Currently, when there is no tenant set in IOContext, the `@translatableV2` directive throws. It throws because it thinks it won't be possible to find the source language of a string. However, it's possible to set the source language of a string by using `formatTranslatableStringV2 ` function with the `from` parameter set. 

This PR addresses this problem by only throwing if the runtime finds no `from` variable.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
