### PR TITLE
Fixes stale getAppFile bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- stale getAppFile accepts MAJOR.x app name
 
 ## [3.62.2] - 2019-10-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.62.3] - 2019-10-30
 ### Fixed 
 - stale getAppFile accepts MAJOR.x app name
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.62.2",
+  "version": "3.62.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/utils/appsStaleIfError.ts
+++ b/src/utils/appsStaleIfError.ts
@@ -41,7 +41,7 @@ export const saveVersion = async (app: string, cacheStorage: CacheLayer<string, 
   const fallbackKey = getFallbackKey(appName, major)
   if (cacheStorage.has(fallbackKey)) {
     const savedVersion = await cacheStorage.get(fallbackKey)
-    if (savedVersion && semver.gt(version, savedVersion)) {
+    if (savedVersion && (version === `${major}.x` || semver.gt(version, savedVersion))) {
       await cacheStorage.set(fallbackKey, version)
     }
   } else {


### PR DESCRIPTION
#### What is the purpose of this pull request?
`getAppFile` with stale if error was throwing a semVer error because the case where the app version had a `.x` was not handled.

#### What problem is this solving?

Handles app version had a `.x` as the newest version.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
