### PR TITLE
Remove tracing from graphql runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.62.4-beta.2] - 2019-11-04
+
 ## [3.62.4-beta.1] - 2019-11-04
 
 ## [3.62.4-beta.0] - 2019-11-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.62.4-beta] - 2019-11-04
+
 ## [3.62.3] - 2019-10-30
 ### Fixed 
 - stale getAppFile accepts MAJOR.x app name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [3.62.4-beta.2] - 2019-11-04
-
-## [3.62.4-beta.1] - 2019-11-04
-
-## [3.62.4-beta.0] - 2019-11-04
-
-## [3.62.4-beta] - 2019-11-04
+### Changed
+- Removes tracing from graphql runtime
 
 ## [3.62.3] - 2019-10-30
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.62.4] - 2019-11-04
 ### Changed
 - Removes tracing from graphql runtime
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.62.4-beta.0] - 2019-11-04
+
 ## [3.62.4-beta] - 2019-11-04
 
 ## [3.62.3] - 2019-10-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.62.4-beta.1] - 2019-11-04
+
 ## [3.62.4-beta.0] - 2019-11-04
 
 ## [3.62.4-beta] - 2019-11-04

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.62.4-beta",
+  "version": "3.62.4-beta.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.62.4-beta.0",
+  "version": "3.62.4-beta.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.62.4-beta.1",
+  "version": "3.62.4-beta.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.62.4-beta.2",
+  "version": "3.62.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.62.3",
+  "version": "3.62.4-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/Runtime.ts
+++ b/src/service/Runtime.ts
@@ -3,9 +3,13 @@ import { map } from 'ramda'
 import { ClientsImplementation, IOClients } from '../clients/IOClients'
 import { EnvMetric, MetricsAccumulator } from '../metrics/MetricsAccumulator'
 import { addProcessListeners } from '../utils/unhandled'
-
 import { createEventHandler } from './events'
-import { createGraphQLRoute, GRAPHQL_ROUTE, GRAPHQL_ROUTE_LEGACY } from './graphql'
+import {
+  cacheStorage,
+  createGraphQLRoute,
+  GRAPHQL_ROUTE,
+  GRAPHQL_ROUTE_LEGACY,
+} from './graphql'
 import { createHttpRoute } from './http'
 import { Service } from './Service'
 import { ClientsConfig, RouteHandler, ServiceDescriptor } from './typings'
@@ -74,6 +78,8 @@ export class Runtime<ClientsT extends IOClients = IOClients, StateT = void, Cust
 }
 
 global.metrics = new MetricsAccumulator()
+
+metrics.trackCache('graphql-runtime', cacheStorage)
 
 declare global {
   namespace NodeJS {

--- a/src/service/Runtime.ts
+++ b/src/service/Runtime.ts
@@ -5,10 +5,10 @@ import { EnvMetric, MetricsAccumulator } from '../metrics/MetricsAccumulator'
 import { addProcessListeners } from '../utils/unhandled'
 import { createEventHandler } from './events'
 import {
-  cacheStorage,
   createGraphQLRoute,
   GRAPHQL_ROUTE,
   GRAPHQL_ROUTE_LEGACY,
+  graphqlRuntimeCacheStorage,
 } from './graphql'
 import { createHttpRoute } from './http'
 import { Service } from './Service'
@@ -79,7 +79,7 @@ export class Runtime<ClientsT extends IOClients = IOClients, StateT = void, Cust
 
 global.metrics = new MetricsAccumulator()
 
-metrics.trackCache('graphql-runtime', cacheStorage)
+metrics.trackCache('graphql-runtime', graphqlRuntimeCacheStorage)
 
 declare global {
   namespace NodeJS {

--- a/src/service/graphql/index.ts
+++ b/src/service/graphql/index.ts
@@ -6,7 +6,7 @@ import { graphqlError } from './middlewares/error'
 import { createFormatters } from './middlewares/formatters'
 import { parseQuery } from './middlewares/query'
 import { response } from './middlewares/response'
-import { run, cacheStorage } from './middlewares/run'
+import { run } from './middlewares/run'
 import { injectSchema } from './middlewares/schema'
 import { graphqlTimings } from './middlewares/timings'
 import { upload } from './middlewares/upload'
@@ -39,4 +39,4 @@ export const createGraphQLRoute = <ClientsT extends IOClients, StateT, CustomT>(
     ]) as RouteHandler<ClientsT, StateT, CustomT>
 }
 
-export { cacheStorage } from './middlewares/run'
+export { graphqlRuntimeCacheStorage } from './middlewares/run'

--- a/src/service/graphql/index.ts
+++ b/src/service/graphql/index.ts
@@ -6,7 +6,7 @@ import { graphqlError } from './middlewares/error'
 import { createFormatters } from './middlewares/formatters'
 import { parseQuery } from './middlewares/query'
 import { response } from './middlewares/response'
-import { run } from './middlewares/run'
+import { run, cacheStorage } from './middlewares/run'
 import { injectSchema } from './middlewares/schema'
 import { graphqlTimings } from './middlewares/timings'
 import { upload } from './middlewares/upload'
@@ -38,3 +38,5 @@ export const createGraphQLRoute = <ClientsT extends IOClients, StateT, CustomT>(
       response,
     ]) as RouteHandler<ClientsT, StateT, CustomT>
 }
+
+export { cacheStorage } from './middlewares/run'

--- a/src/service/graphql/middlewares/run.ts
+++ b/src/service/graphql/middlewares/run.ts
@@ -4,12 +4,12 @@ import { LRUCache } from '../../../caches'
 import { GraphQLServiceContext } from '../typings'
 import { defaultMaxAgeFromCtx } from '../utils/maxAgeEnum'
 
-export const cacheStorage = new LRUCache<string, string>({
+export const graphqlRuntimeCacheStorage = new LRUCache<string, string>({
   max: 100,
 })
 
 const persistedQueries = {
-  cache: cacheStorage,
+  cache: graphqlRuntimeCacheStorage,
 }
 
 const linked = !!process.env.VTEX_APP_LINK
@@ -49,7 +49,7 @@ export async function run (ctx: GraphQLServiceContext, next: () => Promise<void>
         context: ctx,
         dataSources,
         debug: linked,
-        documentStore: cacheStorage,
+        documentStore: graphqlRuntimeCacheStorage,
         formatError,
         formatResponse,
         parseOptions: {

--- a/src/service/graphql/middlewares/run.ts
+++ b/src/service/graphql/middlewares/run.ts
@@ -4,11 +4,8 @@ import { LRUCache } from '../../../caches'
 import { GraphQLServiceContext } from '../typings'
 import { defaultMaxAgeFromCtx } from '../utils/maxAgeEnum'
 
-const ONE_HOUR_MS = 60 * 60 * 1e3
-
 const cacheStorage = new LRUCache<string, string>({
-  max: 50,
-  maxAge: ONE_HOUR_MS,
+  max: 100,
 })
 
 metrics.trackCache('graphql-runtime', cacheStorage)

--- a/src/service/graphql/middlewares/run.ts
+++ b/src/service/graphql/middlewares/run.ts
@@ -13,6 +13,8 @@ const persistedQueries = {
   }),
 }
 
+const linked = !!process.env.VTEX_APP_LINK
+
 export async function run (ctx: GraphQLServiceContext, next: () => Promise<void>) {
   const {
     method,
@@ -48,12 +50,12 @@ export async function run (ctx: GraphQLServiceContext, next: () => Promise<void>
         },
         context: ctx,
         dataSources,
-        debug: !production,
+        debug: linked,
         formatError,
         formatResponse,
         persistedQueries,
         schema,
-        tracing: true,
+        tracing: linked,
       } as any,
       query: query!,
       request,

--- a/src/service/graphql/middlewares/run.ts
+++ b/src/service/graphql/middlewares/run.ts
@@ -53,7 +53,7 @@ export async function run (ctx: GraphQLServiceContext, next: () => Promise<void>
         formatError,
         formatResponse,
         parseOptions: {
-          noLocation: true,
+          noLocation: !linked,
         },
         persistedQueries,
         schema,

--- a/src/service/graphql/middlewares/run.ts
+++ b/src/service/graphql/middlewares/run.ts
@@ -8,7 +8,7 @@ const cacheStorage = new LRUCache<string, string>({
   max: 100,
 })
 
-metrics.trackCache('graphql-runtime', cacheStorage)
+// metrics.trackCache('graphql-runtime', cacheStorage)
 
 const persistedQueries = {
   cache: cacheStorage,

--- a/src/service/graphql/middlewares/run.ts
+++ b/src/service/graphql/middlewares/run.ts
@@ -4,11 +4,9 @@ import { LRUCache } from '../../../caches'
 import { GraphQLServiceContext } from '../typings'
 import { defaultMaxAgeFromCtx } from '../utils/maxAgeEnum'
 
-const cacheStorage = new LRUCache<string, string>({
+export const cacheStorage = new LRUCache<string, string>({
   max: 100,
 })
-
-// metrics.trackCache('graphql-runtime', cacheStorage)
 
 const persistedQueries = {
   cache: cacheStorage,

--- a/src/service/graphql/middlewares/timings.ts
+++ b/src/service/graphql/middlewares/timings.ts
@@ -1,40 +1,4 @@
-import { any, path, propEq } from 'ramda'
-
 import { GraphQLServiceContext } from '../typings'
-import { generatePathName } from '../utils/pathname'
-
-interface ResolverTracing {
-  duration: number,
-  fieldName: string,
-  parentType: string,
-  path: [string | number],
-  returnType: string,
-  startOffset: number,
-}
-
-const nanoToMillis = (nanoseconds: number) => Math.round((nanoseconds / 1e6))
-
-const hasErrorForPathName = (pathName: string, graphQLErrors?: any[]) => {
-  return graphQLErrors && any(propEq('pathName', pathName), graphQLErrors) || false
-}
-
-const batchResolversTracing = (resolvers: ResolverTracing[], graphQLErrors?: any[]) => {
-  resolvers.forEach(resolver => {
-    const pathName = generatePathName(resolver.path)
-    const status = hasErrorForPathName(pathName, graphQLErrors)
-      ? 'error'
-      : 'success'
-    const extensions = {
-      fieldName: resolver.fieldName,
-      parentType: resolver.parentType,
-      pathName,
-      returnType: resolver.returnType,
-    }
-    if (resolver.parentType === 'Query') {
-      metrics.batchMetric(`graphql-resolver-${status}-${pathName}`, nanoToMillis(resolver.duration), extensions)
-    }
-  })
-}
 
 export async function graphqlTimings (ctx: GraphQLServiceContext, next: () => Promise<void>) {
   const start = process.hrtime()
@@ -44,10 +8,4 @@ export async function graphqlTimings (ctx: GraphQLServiceContext, next: () => Pr
 
   // Batch success or error metric for entire operation
   metrics.batch(`graphql-operation-${ctx.graphql.status}`, process.hrtime(start))
-
-  // Batch timings for individual resolvers
-  const resolverTimings = path<ResolverTracing[] | undefined>(['extensions', 'tracing', 'execution', 'resolvers'], ctx.graphql.graphqlResponse!)
-  if (resolverTimings) {
-    batchResolversTracing(resolverTimings, ctx.graphql.graphQLErrors)
-  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR removes the tracing capabilities from the graphql runtime while in production. Also, this pr adds a cache for caching parsed queries after validation

#### How should this be manually tested?
As you can see in [this query](https://splunk72.vtex.com/en-US/app/vtex_io_apps/search?q=search%20index%3Dio_vtex_logs%20app%3Dvtex.search-graphql%400.8.3%20OR%20vtex.search-graphql%400.8.4-beta.2%20graphql-operation-success%20%7C%20timechart%20minspan%3D1m%20max(status.percentile99)%20as%20percentile99%2C%20max(status.median)%20as%20median%20by%20app&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&earliest=1572895556&latest=1572896456&display.general.type=visualizations&display.page.search.tab=visualizations&sid=1572896566.580257_3DDE77BC-1901-4189-B912-ADE751E100F6), the average latency of search-graphql `beta` is much lower than the stable version. 

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
