### PR TITLE
Only use `comparableKeys` when objects owns them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.65.4] - 2019-11-25
 ### Fixed
 - Conflicts Resolver only use `comparableKeys` when objects owns them
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Conflicts Resolver only use `comparableKeys` when objects owns them
 
 ## [3.65.3] - 2019-11-25
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.65.3",
+  "version": "3.65.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/utils/MineWinsConflictsResolver.test.ts
+++ b/src/utils/MineWinsConflictsResolver.test.ts
@@ -70,9 +70,24 @@ describe('MineWinsConflictsResolver', () => {
     const base = [{}]
     const mine = [{ b: 2 }]
     const expected = [{ b: 2 }, { a: 1 }]
-
     const result = resolver.mergeMineWins(base, master, mine)
     expect(result).toEqual(expected)
+
+    const master1 = { a: [{ z: [{ stuff0: 0 }, { stuff1: 1 }] }] }
+    const base1 = { a: [{ z: [{ stuff0: 0 }] }] }
+    const mine1 = { a: [{ z: [{ stuff0: 0 }] }] }
+    const expected1 = { a: [{ z: [{ stuff0: 0 }, { stuff1: 1 }] }] }
+
+    const result1 = resolver.mergeMineWins(base1, master1, mine1)
+    expect(result1).toEqual(expected1)
+
+    const master2 = { b: [{ z: [{ stuff0: 0 }, { stuff1: 1 }] }] }
+    const base2 = { b: [{ z: [{ stuff0: 0 }] }] }
+    const mine2 = { b: [{ z: [{ stuff0: 0 }] }] }
+    const expected2 = { b: [{ z: [{ stuff0: 0 }, { stuff1: 1 }] }] }
+
+    const result2 = resolver.mergeMineWins(base2, master2, mine2)
+    expect(result2).toEqual(expected2)
   })
 
   it('Should not append master array values when they already exist in mine', async () => {

--- a/src/utils/MineWinsConflictsResolver.ts
+++ b/src/utils/MineWinsConflictsResolver.ts
@@ -92,7 +92,7 @@ export class MineWinsConflictsResolver implements ConflictsResolver {
     master: ConfigurationData,
     mine: ConfigurationData
   ) {
-    const merged = { ...master, ...mine }
+    const merged = { ...master, ...mine}
 
     Object.entries(merged).forEach(([key, value]) => {
       if (master[key] == null && base && base[key] != null && equals(value, base[key])) {
@@ -139,17 +139,14 @@ export class MineWinsConflictsResolver implements ConflictsResolver {
     })
   }
 
-  private shouldAddToMine(item: Configuration, base: ConfigurationData[], mine: ConfigurationData[]) {
-    if (this.comparableKeys) {
+  private shouldAddToMine(item: ConfigurationData, base: ConfigurationData[], mine: ConfigurationData[]) {
+    if (this.comparableKeys && Object.keys(item).some(key => this.comparableKeys!.includes(key))) {  
       return (
         !mine.some(mineItem => this.comparableKeys!.some(key => eqProps(key, item, mineItem))) &&
         !base.some(baseItem => this.comparableKeys!.some(key => eqProps(key, item, baseItem)))
       )
     }
 
-    return (
-      !mine.some(mineItem => equals(mineItem, item)) &&
-      !base.some(baseItem => equals(baseItem, item))
-    )
+    return !mine.some(mineItem => equals(mineItem, item)) && !base.some(baseItem => equals(baseItem, item))
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?
We were expecting to have comparable keys on all objects, what is not true when the recursion goes on. We now only consider `comparableKeys` if the object owns them.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
