### PR TITLE
Adds new attribute to messages translate resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- New attribute to messages API
 
 ## [3.65.1] - 2019-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.65.2] - 2019-11-25
 ### Added 
 - New attribute to messages API
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.65.1",
+  "version": "3.65.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -50,6 +50,7 @@ export interface Translate {
 export interface TranslateInputV2 {
   indexedByFrom: IndexedMessageV2[]
   to: string
+  depTree?: string
 }
 
 export interface SaveArgs {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates node-vtex-api with the new messages API

#### What problem is this solving?

The new api allows passing the dep tree to messages, making rendering of pages independent to Apps being up.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
