### PR TITLE
Fix/fire event flag should be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Flag `fireEvent` in Messages `saveV2` should be optional
 
 ## [3.66.1] - 2019-11-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.66.2] - 2019-11-26
 ### Fixed
 - Flag `fireEvent` in Messages `saveV2` should be optional
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.66.1",
+  "version": "3.66.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/MessagesGraphQL.ts
+++ b/src/clients/MessagesGraphQL.ts
@@ -62,7 +62,7 @@ export interface SaveArgs {
 }
 
 export interface SaveArgsV2 {
-  fireEvent: boolean
+  fireEvent?: boolean
   to: string
   messages: MessageSaveInputV2[]
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

`fireEvent` flag in Messages `saveV2` should be optional (have default value true in Messages)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
