### PR TITLE
Translates directive with options for depending on Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Translate directive call messages without Apps
+- TranslateV2 directive call messages depending on Apps
 
 ## [3.67.1] - 2019-12-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.68.0] - 2019-12-09
 ### Changed
 - Translate directive call messages without Apps
 - TranslateV2 directive call messages depending on Apps

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.67.1",
+  "version": "3.68.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/graphql/schema/messagesLoaderV2.ts
+++ b/src/service/graphql/schema/messagesLoaderV2.ts
@@ -32,7 +32,7 @@ const indexMessagesByFrom = (messages: IOMessageV2[]) => messages.reduce(
   [] as IndexedMessageV2[]
 )
 
-export const messagesLoaderV2 = (clients: IOClients) =>
+export const messagesLoaderV2 = (clients: IOClients, withAppsMetaInfo?: boolean) =>
   new DataLoader<IOMessageV2, string>(async (messages: IOMessageV2[]) => {
     const to = messages[0].to!
     const indexedMessages = toPairs(messages) as Array<[string, IOMessageV2]>
@@ -40,7 +40,9 @@ export const messagesLoaderV2 = (clients: IOClients) =>
     const originalIndexes = pluck(0, sortedIndexedMessages) as string[]
     const sortedMessages = pluck(1, sortedIndexedMessages) as IOMessageV2[]
     const indexedByFrom = indexMessagesByFrom(sortedMessages)
+    const depTree = withAppsMetaInfo ? JSON.stringify(await clients.apps.getAppsMetaInfos()) : ''
     const translations = await clients.messagesGraphQL.translateV2({
+      depTree,
       indexedByFrom,
       to,
     })

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -11,7 +11,8 @@ export class Translatable extends SchemaDirectiveVisitor {
     const { resolve = defaultFieldResolver } = field
     const { behavior = 'FULL' } = this.args
     field.resolve = async (root, args, context, info) => {
-      const { clients: { segment }, clients } = context
+      const { clients: { segment }, clients, vtex: { logger }} = context
+      logger.warn(`Translatable directive in use by: ${context.vtex.account} (Operation Id: ${context.vtex.operationId})`)
       if (!context.loaders || !context.loaders.messages) {
         context.loaders = {
           ...context.loaders,

--- a/src/service/graphql/schema/schemaDirectives/Translatable.ts
+++ b/src/service/graphql/schema/schemaDirectives/Translatable.ts
@@ -12,7 +12,9 @@ export class Translatable extends SchemaDirectiveVisitor {
     const { behavior = 'FULL' } = this.args
     field.resolve = async (root, args, context, info) => {
       const { clients: { segment }, clients, vtex: { logger }} = context
-      logger.warn(`Translatable directive in use by: ${context.vtex.account} (Operation Id: ${context.vtex.operationId})`)
+      if (Math.random() < 0.1) {
+        logger.warn(`Translatable directive in use by: ${context.vtex.account} (Operation Id: ${context.vtex.operationId})`)
+      }
       if (!context.loaders || !context.loaders.messages) {
         context.loaders = {
           ...context.loaders,

--- a/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
+++ b/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
@@ -1,5 +1,4 @@
 import { map } from 'bluebird'
-import DataLoader from 'dataloader' // eslint-disable-line no-unused-vars
 import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 import { path } from 'ramda'
@@ -52,7 +51,7 @@ export const parseTranslatableStringV2 = (rawMessage: string): TranslatableMessa
 export const formatTranslatableStringV2 = ({from, content, context}: TranslatableMessageV2): string =>
   `${content} ${context ? `(((${context})))` : ''} ${from ? `<<<${from}>>>` : ''}`
 
-export const handleSingleString = (ctx: IOContext, messagesV2: MessagesLoaderV2, behavior: Behavior) => async (rawMessage: string | null) => {
+const handleSingleString = (ctx: IOContext, messagesV2: MessagesLoaderV2, behavior: Behavior) => async (rawMessage: string | null) => {
   // Messages only knows how to process non empty strings.
   if (rawMessage == null) {
     return rawMessage

--- a/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
+++ b/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
@@ -14,7 +14,7 @@ const CONTENT_REGEX = /\(\(\((?<context>(.)*)\)\)\)|\<\<\<(?<from>(.)*)\>\>\>/g
 export class TranslatableV2 extends SchemaDirectiveVisitor {
   public visitFieldDefinition (field: GraphQLField<any, ServiceContext>) {
     const { resolve = defaultFieldResolver } = field
-    const { behavior = 'FULL', withAppsMetaInfo = true} = this.args
+    const { behavior = 'FULL', withAppsMetaInfo = false} = this.args
     field.resolve = async (root, args, ctx, info) => {
       if (!ctx.loaders || !ctx.loaders.messagesV2) {
         ctx.loaders = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
* Adds log to Translate directive 

* Adds parameter to  TranslateV2 directive, that gets apps meta info and passes to Messages

#### What problem is this solving?

This allows the store rendering to be independent of Apps being up.

#### How should this be manually tested?

Just add: `withAppsMetaInfo: false` to the directives of `search-graphql`, the string should still bet translated since pages passes the dependency tree to messages.

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
