### PR TITLE
Meta infos stale while revalidating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Makes getAppsMetaInfos return stale while revalidating
 
 ## [3.69.1] - 2019-12-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.70.0] - 2019-12-10
 ### Changed
 - Makes getAppsMetaInfos return stale while revalidating
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.69.1",
+  "version": "3.70.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Apps.ts
+++ b/src/clients/Apps.ts
@@ -306,9 +306,7 @@ export class Apps extends InfraClient {
     const key = getMetaInfoKey(account)
 
     const cachedResponse: {appsMetaInfo: AppMetaInfo[], headers: any} | undefined = this.diskCache && await this.diskCache.get(key)
-    if (!this.context.recorder) {
-      logger.warn('Context without recorder, the etag will not be recorded')
-    } else if (cachedResponse){
+    if (cachedResponse && this.context.recorder) {
       this.context.recorder(cachedResponse.headers)
     }
 

--- a/src/clients/Apps.ts
+++ b/src/clients/Apps.ts
@@ -1,10 +1,9 @@
 import archiver from 'archiver'
 import { IncomingMessage } from 'http'
-import { filter as ramdaFilter, path as ramdaPath, prop } from 'ramda'
+import { path as ramdaPath } from 'ramda'
 import { Readable, Writable } from 'stream'
 import { extract } from 'tar-fs'
 import { createGunzip, ZlibOptions } from 'zlib'
-import { PICKED_AXIOS_PROPS } from './../utils/error'
 
 import { CacheLayer } from '..'
 import { CacheType, inflightURL, inflightUrlWithQuery, InfraClient, InstanceOptions } from '../HttpClient'
@@ -328,7 +327,7 @@ export class Apps extends InfraClient {
       : await metaInfoPromise.then(response => response.data.apps)
 
     if (filter) {
-      return ramdaFilter(appMeta => !!ramdaPath(['_resolvedDependencies', filter], appMeta), appsMetaInfo)
+      return appsMetaInfo.filter(appMeta => !!ramdaPath(['_resolvedDependencies', filter], appMeta), appsMetaInfo)
     }
 
     return appsMetaInfo

--- a/src/clients/Apps.ts
+++ b/src/clients/Apps.ts
@@ -300,7 +300,7 @@ export class Apps extends InfraClient {
   }
 
   public getAppsMetaInfos = async (filter?: string, staleWhileRevalidate: boolean = true) => {
-    const { account, logger, production} = this.context
+    const { account, production} = this.context
     const metric = 'get-apps-meta'
     const inflightKey = inflightURL
     const key = getMetaInfoKey(account)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Makes `Apps.getAppsMetaInfos` return stale and then validate and update the cache

#### What problem is this solving?
This will allow pages to be rendered without Apps

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
