### PR TITLE
[WIP] Add region header when it's provided on context

### DIFF
--- a/src/HttpClient/AppClient.ts
+++ b/src/HttpClient/AppClient.ts
@@ -2,6 +2,7 @@ import { IOContext } from '../service/typings'
 
 import { IOClient } from './IOClient'
 import { AuthType, InstanceOptions } from './typings'
+import { REGION_HEADER } from '../constants'
 
 const useHttps = !process.env.VTEX_IO
 
@@ -28,6 +29,10 @@ export class AppClient extends IOClient {
       context,
       {
         ...options,
+        headers: {
+          ... options?.headers,
+          ... region ? { [REGION_HEADER]: region } : null,
+        },
         authType: AuthType.bearer,
         baseURL,
         name,

--- a/src/HttpClient/AppGraphQLClient.ts
+++ b/src/HttpClient/AppGraphQLClient.ts
@@ -1,6 +1,7 @@
 import { IOContext } from '../service/typings'
 import { IOGraphQLClient } from './IOGraphQLClient'
 import { AuthType, InstanceOptions } from './typings'
+import { REGION_HEADER } from '../constants'
 
 const useHttps = !process.env.VTEX_IO
 /**
@@ -26,6 +27,10 @@ export class AppGraphQLClient extends IOGraphQLClient {
       context,
       {
         ...options,
+        headers: {
+          ... options?.headers,
+          ... region ? { [REGION_HEADER]: region } : null,
+        },
         authType: AuthType.bearer,
         baseURL,
         name,

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -13,6 +13,7 @@ import {
   SEGMENT_HEADER,
   SESSION_HEADER,
   TENANT_HEADER,
+  REGION_HEADER,
 } from '../constants'
 import { IOContext } from '../service/typings'
 import { formatBindingHeaderValue } from '../utils/binding'
@@ -67,6 +68,7 @@ export class HttpClient {
       binding,
       verbose,
       cancellation,
+      region
     } = opts
     this.name = name || baseURL || 'unknown'
     const limit = concurrency && concurrency > 0 && pLimit(concurrency) || undefined
@@ -80,6 +82,7 @@ export class HttpClient {
       ... locale ? {[LOCALE_HEADER]: locale} : null,
       ... operationId ? {'x-vtex-operation-id': operationId} : null,
       ... product ? {[PRODUCT_HEADER]: product} : null,
+      ... region ? { [REGION_HEADER]: region } : null,
       ... segmentToken ? {[SEGMENT_HEADER]: segmentToken} : null,
       ... sessionToken ? {[SESSION_HEADER]: sessionToken} : null,
     }

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -13,7 +13,6 @@ import {
   SEGMENT_HEADER,
   SESSION_HEADER,
   TENANT_HEADER,
-  REGION_HEADER,
 } from '../constants'
 import { IOContext } from '../service/typings'
 import { formatBindingHeaderValue } from '../utils/binding'
@@ -68,7 +67,6 @@ export class HttpClient {
       binding,
       verbose,
       cancellation,
-      region
     } = opts
     this.name = name || baseURL || 'unknown'
     const limit = concurrency && concurrency > 0 && pLimit(concurrency) || undefined
@@ -82,7 +80,6 @@ export class HttpClient {
       ... locale ? {[LOCALE_HEADER]: locale} : null,
       ... operationId ? {'x-vtex-operation-id': operationId} : null,
       ... product ? {[PRODUCT_HEADER]: product} : null,
-      ... region ? { [REGION_HEADER]: region } : null,
       ... segmentToken ? {[SEGMENT_HEADER]: segmentToken} : null,
       ... sessionToken ? {[SESSION_HEADER]: sessionToken} : null,
     }

--- a/src/HttpClient/InfraClient.ts
+++ b/src/HttpClient/InfraClient.ts
@@ -2,6 +2,7 @@ import { IOContext } from '../service/typings'
 
 import { IOClient } from './IOClient'
 import { AuthType, InstanceOptions } from './typings'
+import { REGION_HEADER } from '../constants'
 
 const useHttps = !process.env.VTEX_IO
 /**
@@ -27,6 +28,10 @@ export class InfraClient extends IOClient {
       context,
       {
         ...options,
+        headers: {
+          ... options?.headers,
+          ... region ? { [REGION_HEADER]: region } : null,
+        },
         authType: AuthType.bearer,
         baseURL,
       }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_WORKSPACE = 'master'
 
+export const REGION_HEADER = 'x-vtex-upstream-target'
 export const SEGMENT_HEADER = 'x-vtex-segment'
 export const SESSION_HEADER = 'x-vtex-session'
 export const PRODUCT_HEADER = 'x-vtex-product'


### PR DESCRIPTION
#### What is the purpose of this pull request?

@vtex/io-infra reported that after changing to the new URLs format changing the region via `VTEX_REGION` env variable on toolbelt stopped working. That's because now to set the region it's necessary to set the `x-vtex-upstream-target` header.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
