### PR TITLE
Messages batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Batches messages to be translated
 
 ## [6.1.7] - 2020-01-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.2.0] - 2020-01-07
 ### Added
 - Batches messages to be translated
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.1.7",
+  "version": "6.2.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/apps/MessagesGraphQL.ts
+++ b/src/clients/apps/MessagesGraphQL.ts
@@ -97,9 +97,9 @@ export class MessagesGraphQL extends AppGraphQLClient {
   public translateV2 = (args: TranslateInputV2) => {
     const { indexedByFrom, ...rest } = args
 
-    const allMessages: Array<{from: string, message: IOMessageInputV2}> = flatten(indexedByFrom.map(({ from, messages }) =>
-      messages.map(message => ({from, message}))
-    ))
+    const allMessages: Array<{from: string, message: IOMessageInputV2}> = indexedByFrom.reduce((acc, {from, messages}) => {
+      return acc.concat(messages.map(message => ({from, message})))
+    }, [] as Array<{from: string, message: IOMessageInputV2}>)
 
     const batchedMessages = splitEvery(MAX_BATCH_SIZE, allMessages)
     return Promise.all(batchedMessages.map(batch => {

--- a/src/clients/apps/MessagesGraphQL.ts
+++ b/src/clients/apps/MessagesGraphQL.ts
@@ -76,7 +76,7 @@ interface TranslatedV2 {
   translate: string[]
 }
 
-const MAX_BATCH_SIZE = 650
+const MAX_BATCH_SIZE = 500
 
 export class MessagesGraphQL extends AppGraphQLClient {
   constructor(vtex: IOContext, options?: InstanceOptions) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Batches messages sent to `MessagesGraphql` Client to be translated.

#### What problem is this solving?

This avoids messages timeout due to too many messages in the request.

#### How should this be manually tested?

Problematic route is `/account` in a language that will use automatic translation

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
