### PR TITLE
Recorder Performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- There was a HUGE performance drop when setting `x-vtex-meta` header via `ctx.set` using an array. Joining in a single string solved the problem 
+- There was a HUGE performance drop when setting `x-vtex-meta` header via `ctx.set` using an array. Joining in a single string solved the problem
 
 ## [6.2.0] - 2020-01-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.2.1] - 2020-01-08
 ### Fixed
 - There was a HUGE performance drop when setting `x-vtex-meta` header via `ctx.set` using an array. Joining in a single string solved the problem
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- There was a HUGE performance drop when setting `x-vtex-meta` header via `ctx.set` using an array. Joining in a single string solved the problem 
 
 ## [6.2.0] - 2020-01-07
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/utils/recorder.ts
+++ b/src/service/worker/runtime/utils/recorder.ts
@@ -1,15 +1,17 @@
 import { Context } from 'koa'
 import { trim, uniqWith } from 'ramda'
 
+import { toArray } from './toArray'
+
 // uniqWith is way faster than ramda's uniq
 const uniqStr = uniqWith((a: string, b: string) => a === b)
 
 const appendResponseHeader = (ctx: Context, responseHeaders: any, targetHeader: string) => {
   const headerValue = responseHeaders[targetHeader]
   if (headerValue) {
-    const currentValue = ctx.response.get(targetHeader) || []
+    const currentValue = toArray(ctx.response.get(targetHeader) || [])
     const newValue = headerValue.split(',').map(trim)
-    ctx.set(targetHeader, uniqStr([...currentValue, ...newValue]))
+    ctx.set(targetHeader, uniqStr([...currentValue, ...newValue]).join(','))
   }
 }
 

--- a/src/service/worker/runtime/utils/recorder.ts
+++ b/src/service/worker/runtime/utils/recorder.ts
@@ -11,7 +11,8 @@ const appendResponseHeader = (ctx: Context, responseHeaders: any, targetHeader: 
   if (headerValue) {
     const currentValue = toArray(ctx.response.get(targetHeader) || [])
     const newValue = headerValue.split(',').map(trim)
-    ctx.set(targetHeader, uniqStr([...currentValue, ...newValue]).join(','))
+    const deduped = uniqStr([...currentValue, ...newValue])
+    ctx.set(targetHeader, deduped.join(','))
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
There was a HUGE performance drop when setting `x-vtex-meta` header via `ctx.set` using an array. Joining in a single string solved the problem

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
