### PR TITLE
Fix logic to get cancellable methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.2.2] - 2020-01-08
 ### Fixed
 - Logic to get cancellable methods for cancellation token
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Logic to get cancellable methods for cancellation token
 
 ## [6.2.1] - 2020-01-08
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/cancellationToken.ts
+++ b/src/HttpClient/middlewares/cancellationToken.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { cancellableMethods } from '../../constants'
 import { Cancellation } from '../../service/worker/runtime/typings'
 import { MiddlewareContext } from '../typings'
 
@@ -44,7 +45,6 @@ export const cancellationToken = (cancellation?: Cancellation) => async (ctx: Mi
     return await next()
   }
 
-  const cancellableMethods = new Set(['GET', 'OPTIONS', 'HEAD'])
   if (method && !cancellableMethods.has(method.toUpperCase())) {
     cancellation.cancelable = false
   }

--- a/src/HttpClient/middlewares/cancellationToken.ts
+++ b/src/HttpClient/middlewares/cancellationToken.ts
@@ -44,7 +44,8 @@ export const cancellationToken = (cancellation?: Cancellation) => async (ctx: Mi
     return await next()
   }
 
-  if (method && method.toUpperCase() !== 'GET') {
+  const cancellableMethods = new Set(['GET', 'OPTIONS', 'HEAD'])
+  if (method && !cancellableMethods.has(method.toUpperCase())) {
     cancellation.cancelable = false
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,3 +57,6 @@ export const WORKSPACE = process.env.VTEX_WORKSPACE as string
 export const PRODUCTION = process.env.VTEX_PRODUCTION === 'true'
 
 export const INSPECT_DEBUGGER_PORT = 5858
+
+export const cancellableMethods = new Set(['GET', 'OPTIONS', 'HEAD'])
+

--- a/src/service/worker/runtime/http/middlewares/cancellationToken.ts
+++ b/src/service/worker/runtime/http/middlewares/cancellationToken.ts
@@ -8,7 +8,8 @@ export async function cancellationToken<
   U extends RecorderState,
   V extends ParamsContext
 >(ctx: ServiceContext<T, U, V>, next: () => Promise<void>) {
-  if (ctx.method.toUpperCase() === ('GET' || 'OPTIONS' || 'HEAD')) {
+  const cancellableMethods = new Set(['GET', 'OPTIONS', 'HEAD'])
+  if (cancellableMethods.has(ctx.method.toUpperCase())) {
     ctx.vtex.cancellation = {
       cancelable: true,
       cancelled: false,

--- a/src/service/worker/runtime/http/middlewares/cancellationToken.ts
+++ b/src/service/worker/runtime/http/middlewares/cancellationToken.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 
 import { IOClients } from '../../../../../clients/IOClients'
+import { cancellableMethods } from '../../../../../constants'
 import { ParamsContext, RecorderState, ServiceContext } from '../../typings'
 
 export async function cancellationToken<
@@ -8,7 +9,6 @@ export async function cancellationToken<
   U extends RecorderState,
   V extends ParamsContext
 >(ctx: ServiceContext<T, U, V>, next: () => Promise<void>) {
-  const cancellableMethods = new Set(['GET', 'OPTIONS', 'HEAD'])
   if (cancellableMethods.has(ctx.method.toUpperCase())) {
     ctx.vtex.cancellation = {
       cancelable: true,


### PR DESCRIPTION
#### What is the purpose of this pull request?

When deciding if a request can be cancelled with cancellation token we need to know which methods are cancellable. This PR solves a mistake in the logic to check if a method is cancellable or not.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
