### PR TITLE
Add new Apps route to get files from an linked app by its workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.3.0] - 2020-01-08
 ### Added
 - New route to get files from Apps with only the app name, account and workspace
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- New route to get files from an app linked in a specific workspace
+- New route to get files from Apps with only the app name, account and workspace
 
 ## [6.2.2] - 2020-01-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New route to get files from an app linked in a specific workspace
 
 ## [6.2.2] - 2020-01-08
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.2.2",
+  "version": "6.3.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/infra/Apps.ts
+++ b/src/clients/infra/Apps.ts
@@ -39,6 +39,7 @@ const createRoutes = ({account, workspace}: IOContext) => {
     File: (locator: AppLocator, path: string) => `${routes.Files(locator)}/${path}`,
     Files: (locator: AppLocator) => `${routes.AppOrRegistry(locator)}/files`,
     Link: (app: string) => `${routes.Workspace}/v2/links/${app}`,
+    LinkedAppFile: (app: string, path: string) => `${routes.Workspace}/apps/${app}/files/${path}`,
     Links: () => `${routes.Workspace}/links`,
     Master: `/${account}/master`,
     Meta: () => `${routes.Workspace}/v2/apps`,
@@ -257,6 +258,16 @@ export class Apps extends InfraClient {
       cacheable: linked ? CacheType.Memory : CacheType.Any,
       inflightKey,
       metric: linked ? 'apps-get-json' : 'registry-get-json',
+      nullIfNotFound,
+    } as IgnoreNotFoundRequestConfig)
+  }
+
+  public getLinkedAppByWorkspaceJSON = <T extends object | null>(app: string, path: string, nullIfNotFound?: boolean) => {
+    const inflightKey = inflightURL
+    return this.http.get<T>(this.routes.LinkedAppFile(app, path), {
+      cacheable: CacheType.Memory,
+      inflightKey,
+      metric: 'apps-linked-app-get-json',
       nullIfNotFound,
     } as IgnoreNotFoundRequestConfig)
   }

--- a/src/clients/infra/Apps.ts
+++ b/src/clients/infra/Apps.ts
@@ -37,9 +37,9 @@ const createRoutes = ({account, workspace}: IOContext) => {
     Apps: () => `${routes.Workspace}/apps`,
     Dependencies:() => `${routes.Workspace}/dependencies`,
     File: (locator: AppLocator, path: string) => `${routes.Files(locator)}/${path}`,
+    FileFromApps: (app: string, path: string) => `${routes.Workspace}/apps/${app}/files/${path}`,
     Files: (locator: AppLocator) => `${routes.AppOrRegistry(locator)}/files`,
     Link: (app: string) => `${routes.Workspace}/v2/links/${app}`,
-    LinkedAppFile: (app: string, path: string) => `${routes.Workspace}/apps/${app}/files/${path}`,
     Links: () => `${routes.Workspace}/links`,
     Master: `/${account}/master`,
     Meta: () => `${routes.Workspace}/v2/apps`,
@@ -262,12 +262,12 @@ export class Apps extends InfraClient {
     } as IgnoreNotFoundRequestConfig)
   }
 
-  public getLinkedAppByWorkspaceJSON = <T extends object | null>(app: string, path: string, nullIfNotFound?: boolean) => {
+  public getFileFromApps = <T extends object | null>(app: string, path: string, nullIfNotFound?: boolean) => {
     const inflightKey = inflightURL
-    return this.http.get<T>(this.routes.LinkedAppFile(app, path), {
+    return this.http.get<T>(this.routes.FileFromApps(app, path), {
       cacheable: CacheType.Memory,
       inflightKey,
-      metric: 'apps-linked-app-get-json',
+      metric: 'get-file-from-apps',
       nullIfNotFound,
     } as IgnoreNotFoundRequestConfig)
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

We need a route to get files for a linked app without its build id, only with the workspace and account in which this app is linked.

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
