### PR TITLE
Add '__bindingId' to segment allowed query prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.4.0] - 2020-01-09
 ### Added
 - Allow getting segment data with default locale and currency from binding instead of tenant.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow getting segment data with default locale and currency from binding instead of tenant.
 
 ## [6.3.0] - 2020-01-08
 ### Added
@@ -81,7 +83,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allows filter dependencies from app list
 
 ## [3.65.2] - 2019-11-25
-### Added 
+### Added
 - New attribute to messages API
 
 ## [3.65.1] - 2019-11-21

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/janus/Segment.ts
+++ b/src/clients/janus/Segment.ts
@@ -22,7 +22,7 @@ export interface SegmentData {
 
 const SEGMENT_COOKIE = 'vtex_segment'
 const SEGMENT_MAX_AGE_S = 60 * 60 // 60 minutes - segment is actually immutable
-const ALLOWED_QUERY_PREFIXES = ['utm', 'cultureInfo', 'supportedLocales']
+const ALLOWED_QUERY_PREFIXES = ['utm', 'cultureInfo', 'supportedLocales', '__bindingId']
 
 const filterAndSortQuery = (query?: Record<string, string>) => {
   if (!query) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow sending `__bindingId` query string to segment

#### What problem is this solving?
We are receiving wrong `currencyCode ` and `cultureInfo` from `/api/segment`.  It's coming from *tenant* defaults instead of *binding* defaults.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
