### PR TITLE
Do not rely on state for flushing `x-vtex-meta` headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.6.1] - 2020-01-16
 ### Fixed
 - Vbase `getJSON` typings. Do not return type `{}`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Vbase `getJSON` typings. Do not return type `{}`
+
+### Changed
+- Do not rely on state for flushing `x-vtex-meta` headers
 
 ## [6.6.0] - 2020-01-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/infra/VBase.ts
+++ b/src/clients/infra/VBase.ts
@@ -67,7 +67,7 @@ export class VBase extends InfraClient {
     return this.http.getBuffer(routes.File(bucket, path), {metric, inflightKey})
   }
 
-  public getJSON = <T>(bucket: string, path: string, nullIfNotFound?: boolean, conflictsResolver?: ConflictsResolver) => {
+  public getJSON = <T>(bucket: string, path: string, nullIfNotFound?: boolean, conflictsResolver?: ConflictsResolver<T>) => {
     const headers = conflictsResolver? {'X-Vtex-Detect-Conflicts': true}: {}
     const inflightKey = inflightURL
     const metric = 'vbase-get-json'
@@ -176,6 +176,6 @@ export interface VBaseConflict{
   content: string,
 }
 
-export interface ConflictsResolver{
-  resolve: () => {}
+export interface ConflictsResolver<T>{
+  resolve: () => T | Promise<T>
 }

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -8,9 +8,10 @@ import { createSlowRecorder, Recorder } from '../utils/recorder'
 
 export async function recorderMiddleware (ctx: ServiceContext, next: () => Promise<void>) {
   if (USE_FAST_RECORDER) {
-    ctx.state.recorder = new Recorder()
+    const recorder = new Recorder()
+    ctx.state.recorder = recorder
     await next()
-    ctx.state.recorder.flush(ctx)
+    recorder.flush(ctx)
   } else {
     ctx.state.recorder = createSlowRecorder(ctx)
     await next()

--- a/src/utils/MineWinsConflictsResolver.test.ts
+++ b/src/utils/MineWinsConflictsResolver.test.ts
@@ -6,7 +6,7 @@ import { MineWinsConflictsResolver } from './MineWinsConflictsResolver'
 describe('MineWinsConflictsResolver', () => {
   const VBaseMock = TypeMoq.Mock.ofType<VBase>()
 
-  const resolver = new (class extends MineWinsConflictsResolver {
+  const resolver = new (class extends MineWinsConflictsResolver<unknown> {
     constructor() {
       super(VBaseMock.object, 'test', '/test', ['a'])
     }

--- a/src/utils/MineWinsConflictsResolver.ts
+++ b/src/utils/MineWinsConflictsResolver.ts
@@ -13,7 +13,7 @@ import {
 type Configuration = Record<string, ConfigurationData | ConfigurationData[] | object> | ConfigurationData[]
 type ConfigurationData = Record<string, object>
 
-export class MineWinsConflictsResolver implements ConflictsResolver {
+export class MineWinsConflictsResolver<T> implements ConflictsResolver<T> {
   /***
    * Take mine and merge with master keys that have no conflict
    * We use base to decide wether a key was deleted or not
@@ -36,14 +36,14 @@ export class MineWinsConflictsResolver implements ConflictsResolver {
       const { data: conflicts }: { data: VBaseConflictData[] } = data
       const selectedConflict = conflicts.find(conflict => conflict.path === this.filePath)
       if (!selectedConflict) {
-        return {}
+        return {} as T
       }
 
       selectedConflict.base.parsedContent = this.parseConflict(selectedConflict.base)
       selectedConflict.master.parsedContent = this.parseConflict(selectedConflict.master)
       selectedConflict.mine.parsedContent = this.parseConflict(selectedConflict.mine)
       const resolved = this.resolveConflictMineWins(selectedConflict)
-      return resolved
+      return resolved as T
     })
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Some apps clear their state, making the flush of `x-vtex-meta` headers impossible.

This PR fixes this problem by not relying on the state for flusing `x-vtex-meta` headers

Also, this PR fixes an annoying typing problem with `getJSON` method in Vbase client

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
