### PR TITLE
Feature/log deprecated directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.7.0] - 2020-01-22
 ### Added
 - `@deprecated` directive logs to Splunk when used. To avoid overflowing splunk with useless logs, we only log once at every minute
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `@deprecated` directive logs to Splunk when used. To avoid overflowing splunk with useless logs, we only log once at every minute
 
 ## [6.6.2] - 2020-01-16
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.6.2",
+  "version": "6.7.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/Deprecated.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/Deprecated.ts
@@ -1,3 +1,73 @@
+import {
+  defaultFieldResolver,
+  GraphQLArgument,
+  GraphQLField,
+  GraphQLInputField,
+  print,
+} from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+
+import { Logger } from '../../../../../logger/logger'
+import { logger as globalLogger } from '../../../../listeners'
+import { GraphQLServiceContext } from '../../typings'
+
+let lastLog = process.hrtime()
+
+const LOG_PERIOD_S = 60
+
+interface DeprecatedOptions {
+  reason?: string
+}
+
+const hrtimeToS = (time: [number, number]) => time[0] + (time[1] / 1e9)
+
+export class Deprecated extends SchemaDirectiveVisitor {
+  public visitArgumentDefinition (argument: GraphQLArgument) {
+    this.maybeLogToSplunk({
+      description: argument.description,
+      name: argument.name,
+    })
+  }
+
+  public visitInputFieldDefinition (field: GraphQLInputField) {
+    this.maybeLogToSplunk({
+      description: field.description,
+      name: field.name,
+    })
+  }
+
+  public visitFieldDefinition (field: GraphQLField<any, GraphQLServiceContext>) {
+    const { resolve = defaultFieldResolver, name, type } = field
+    const { reason }: DeprecatedOptions = this.args
+
+    field.resolve = (root, args, ctx, info) => {
+      this.maybeLogToSplunk({
+        headers: ctx.request.headers,
+        name,
+        query: ctx.graphql.query?.document && print(ctx.graphql.query?.document),
+        reason,
+        variables: ctx.graphql.query?.variables,
+      }, ctx.vtex.logger)
+      return resolve(root, args, ctx, info)
+    }
+  }
+
+  protected maybeLogToSplunk <T>(payload: T, logger: Logger = globalLogger) {
+    const now = process.hrtime()
+    const timeSinceLastLog = hrtimeToS([
+      now[0] - lastLog[0],
+      now[1] - lastLog[1]
+    ])
+    if (timeSinceLastLog > LOG_PERIOD_S) {
+      lastLog = now
+      logger.warn({
+        message: 'Deprecated field in use',
+        ...payload,
+      })
+    }
+  }
+}
+
 export const deprecatedDirectiveTypeDefs = `
 directive @deprecated(
   reason: String = "No longer supported"

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
@@ -1,6 +1,6 @@
 import { Auth, authDirectiveTypeDefs } from './Auth'
 import { CacheControl, cacheControlDirectiveTypeDefs } from './CacheControl'
-import { deprecatedDirectiveTypeDefs } from './Deprecated'
+import { Deprecated, deprecatedDirectiveTypeDefs } from './Deprecated'
 import { SanitizeDirective, sanitizeDirectiveTypeDefs } from './Sanitize'
 import {
   SmartCacheDirective,
@@ -16,6 +16,7 @@ export { parseTranslatableStringV2, formatTranslatableStringV2 } from './Transla
 export const nativeSchemaDirectives = {
   auth: Auth,
   cacheControl: CacheControl,
+  deprecated: Deprecated,
   sanitize: SanitizeDirective,
   smartcache: SmartCacheDirective,
   translatableV2: TranslatableV2,
@@ -24,8 +25,8 @@ export const nativeSchemaDirectives = {
 export const nativeSchemaDirectivesTypeDefs = [
   authDirectiveTypeDefs,
   cacheControlDirectiveTypeDefs,
+  deprecatedDirectiveTypeDefs,
   sanitizeDirectiveTypeDefs,
   smartCacheDirectiveTypeDefs,
   translatableV2DirectiveTypeDefs,
-  deprecatedDirectiveTypeDefs,
 ].join('\n\n')


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add log capabilities to `@deprecated` directive. This will allow us to not need to implement logs whenever we want to deprecate a field in a graphql app. 
To avoid overflowing Splunk with useless logs, we only log once at every minute

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
