### PR TITLE
Send events using Courier instead of Colossus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.24.0] - 2020-03-31
+## Changed
+- Send events using `Courier` instead of `Colossus`.
+
 ## [6.23.1] - 2020-03-26
 ### Fixed
 - Trace only 1% of the requests.

--- a/src/clients/infra/Events.ts
+++ b/src/clients/infra/Events.ts
@@ -6,10 +6,17 @@ const eventRoute = (route: string) => `/events/${route}`
 
 export class Events extends InfraClient {
   constructor(context: IOContext, options?: InstanceOptions) {
-    super('colossus@0.x', {...context, recorder: undefined}, options)
+    super('courier@0.x', { ...context, recorder: undefined }, options)
   }
 
   public sendEvent = (subject: string, route: string, message?: any) => {
-    return this.http.put(eventRoute(route), message, {params: {subject}, metric: 'events-send'})
+    const resource =
+      subject === ''
+        ? ''
+        : `vrn:apps:aws-us-east-1:${this.context.account}:${this.context.workspace}:/apps/${subject}`
+    return this.http.put(eventRoute(route), message, {
+      metric: 'events-send',
+      params: { resource },
+    })
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Send events using Courier instead of Colossus.

#### What problem is this solving?
Stop using Colossus.

#### How should this be manually tested?
1. `yarn link` this version.
2. Go to `/node` in an app and `yarn link "@vtex/api"`.
3. (Perhaps you may want to `rm -rf node_modules` and `yarn install`, just in case).
4. Send an event using `@vtex/api` client. It's something like this:
```ts
const res = await ctx.clients.events.sendEvent(
    "vtex.service-example@0.0.6",
    "im-a-topic",
    '{"my":"body"}'
  );

console.log("res: ", res);
````
5. 🎉 
#### Screenshots or example usage

<img width="1055" alt="Screen Shot 2020-03-23 at 6 15 04 PM" src="https://user-images.githubusercontent.com/39948893/77364048-8e374280-6d32-11ea-91db-850f3b4a6115.png">

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
