### PR TITLE
Increase query size limit from 1mb to 3mb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Chore
+- Increase query size limit from 1mb to 3mb.
 
 ## [6.8.0] - 2020-01-23
 ### Added

--- a/src/service/worker/runtime/graphql/middlewares/query.ts
+++ b/src/service/worker/runtime/graphql/middlewares/query.ts
@@ -50,9 +50,9 @@ async function parseAndValidateQuery (ctx: GraphQLServiceContext, next: () => Pr
   if (request.is('multipart/form-data')) {
     query = (request as any).body
   } else if (request.method.toUpperCase() === 'POST') {
-    query = await json(req)
+    query = await json(req, {limit: '3mb'})
   } else {
-    query = queryFromUrl(request.url) || await json(req)
+    query = queryFromUrl(request.url) || await json(req, {limit: '3mb'})
   }
 
   // Assign the query before setting the query.document because if the


### PR DESCRIPTION
#### What is the purpose of this pull request?
Increase query size limit.

#### What problem is this solving?
Query size from render-server to pages-graphql is exceeding the current limit (1mb)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
