### PR TITLE
Add support for router binding header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for router binding header.
 
 ## [6.14.0] - 2020-02-06
 
 ## [6.13.1] - 2020-02-04
-### Fixed 
+### Fixed
 - Adds catalog Graphql client to IOClients
 
 ## [6.13.0] - 2020-02-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.15.0] - 2020-02-06
 ### Added
 - Add support for router binding header.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.14.0",
+  "version": "6.15.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslatableV2.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslatableV2.ts
@@ -70,13 +70,13 @@ const handleSingleString = (ctx: IOContext, messagesV2: MessagesLoaderV2 , behav
   }
 
   const { content, context, from: maybeFrom } = parseTranslatableStringV2(rawMessage)
-  const { tenant } = ctx
+  const { binding, tenant } = ctx
 
   if (content == null) {
     throw new Error(`@translatableV2 directive needs a content to translate, but received ${JSON.stringify(rawMessage)}`)
   }
 
-  const from = maybeFrom || tenant?.locale
+  const from = maybeFrom || binding?.locale || tenant?.locale
 
   if (from == null) {
     throw new Error('@translatableV2 directive needs a source language to translate from. You can do this by either setting \`ctx.vtex.tenant\` variable, call this app with the header \`x-vtex-tenant\` or format the string with the \`formatTranslatableStringV2\` function with the \`from\` option set')

--- a/src/utils/binding.ts
+++ b/src/utils/binding.ts
@@ -1,14 +1,50 @@
 export interface BindingHeader {
   id?: string
+  rootPath?: string
   locale: string
+  currency?: string
 }
 
-export const formatBindingHeaderValue = (binding: BindingHeader): string => {
-  const jsonString = JSON.stringify(binding)
-  return Buffer.from(jsonString, 'utf8').toString('base64')
+enum BindingHeaderFormat {
+  webframework0='v0+webframework',
+  kuberouter0='v0+kuberouter'
+}
+
+export const formatBindingHeaderValue = (
+  binding: BindingHeader,
+  format: BindingHeaderFormat = BindingHeaderFormat.webframework0
+): string => {
+  if (format === BindingHeaderFormat.webframework0) {
+    const jsonString = JSON.stringify(binding)
+    return Buffer.from(jsonString, 'utf8').toString('base64')
+  }
+
+  if (format === BindingHeaderFormat.kuberouter0) {
+    return [
+      '0',
+      binding.id || '',
+      binding.rootPath || '',
+      binding.locale || '',
+      binding.currency || ''
+    ].join(',')
+  }
+
+  throw new Error(`Unkown binding format: ${format}`)
 }
 
 export const parseBindingHeaderValue = (value: string): BindingHeader => {
+  if (value[0] === '0' && value[1] === ',') {
+    // v0+kuberouter
+    const [, id, rootPath, locale, currency] = value.split(',')
+    return {
+      id: id || undefined,
+      rootPath: rootPath || undefined,
+      locale: locale,
+      currency: currency || undefined,
+    }
+  }
+
+  // v0+webframework
   const jsonString = Buffer.from(value, 'base64').toString('utf8')
   return JSON.parse(jsonString)
 }

--- a/src/utils/binding.ts
+++ b/src/utils/binding.ts
@@ -37,10 +37,10 @@ export const parseBindingHeaderValue = (value: string): BindingHeader => {
     // v0+kuberouter
     const [, id, rootPath, locale, currency] = value.split(',')
     return {
-      id: id || undefined,
-      rootPath: rootPath || undefined,
-      locale: locale,
       currency: currency || undefined,
+      id: id || undefined,
+      locale: locale,
+      rootPath: rootPath || undefined,
     }
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add support for router binding header

#### What problem is this solving?
kube-router will add a `x-vtex-binding` header in a format our current runtime do not understand.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
