### PR TITLE
Fix revalidation for cached buffer responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Exponential timneout and backoff variables can now be set by request and not only by client.
+- Exponential timeout and backoff variables can now be set by request and not only by client.
+### Fixed
+- Fix revalidation for cached buffer responses.
 
 ## [6.16.0] - 2020-02-13
 ### Changed

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -77,12 +77,13 @@ export const cacheMiddleware = ({type, storage}: CacheOptions) => {
     const cacheHasWithSegment = await storage.has(keyWithSegment)
     const cached = cacheHasWithSegment ? await storage.get(keyWithSegment) : await storage.get(key)
 
-    if (cached) {
+    if (cached && cached.response) {
       const {etag: cachedEtag, response, expiration, responseType, responseEncoding} = cached as Cached
-      if (expiration > Date.now() && response) {
-        if (type === CacheType.Disk && responseType === 'arraybuffer') {
-          response.data = Buffer.from(response.data, responseEncoding)
-        }
+      if (type === CacheType.Disk && responseType === 'arraybuffer') {
+        response.data = Buffer.from(response.data, responseEncoding)
+      }
+
+      if (expiration > Date.now()) {
         ctx.response = response as AxiosResponse
         ctx.cacheHit = {
           memory: 1,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix revalidation for cached buffer responses

#### What problem is this solving?
When revalidating a cached response of type 'arraybuffer', the response was not being transformed from string to Buffer. 

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
