### PR TITLE
Injects skidder topics into logs to be processed by fluentd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.17.0] - 2020-02-18
 ### Added
 - Injects `__SKIDDER_TOPIC_1` and `__SKIDDER_TOPIC_2` keys in logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Injects `__SKIDDER_TOPIC_1` and `__SKIDDER_TOPIC_2` keys in logs
 
 ## [6.16.1] - 2020-02-17
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.16.1",
+  "version": "6.17.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,6 +54,9 @@ export const APP = {
   NAME: process.env.VTEX_APP_NAME as string,
   VENDOR: process.env.VTEX_APP_VENDOR as string,
   VERSION: process.env.VTEX_APP_VERSION as string,
+  IS_THIRD_PARTY() {
+    return 'vtex' !== this.VENDOR && 'gocommerce' !== this.VENDOR
+  },
 }
 export const NODE_ENV = process.env.NODE_ENV as string
 export const ACCOUNT = process.env.VTEX_ACCOUNT as string

--- a/src/service/logger/logger.ts
+++ b/src/service/logger/logger.ts
@@ -1,9 +1,10 @@
 import { cleanError } from '../../utils/error'
 import { IOContext } from '../worker/runtime/typings'
 import { logOnceToDevConsole } from './console'
+import { APP } from '../../constants'
 
 const linked = !!process.env.VTEX_APP_LINK
-const app = process.env.VTEX_APP_ID
+const app = APP.ID
 const EMPTY_MESSAGE = 'Logger.log was called with null or undefined message'
 
 export enum LogLevel {
@@ -45,6 +46,8 @@ export class Logger {
     /* tslint:disable:object-literal-sort-keys */
     console.log(JSON.stringify({
       __VTEX_IO_LOG: true,
+      __SKIDDER_TOPIC_1: `skidder.acc.${this.account}`,
+      __SKIDDER_TOPIC_2: `skidder.app.${this.account}.${APP.VENDOR}.${APP.NAME}`,
       level,
       app,
       account: this.account,


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds **__SKIDDER_TOPIC_1** and **__SKIDDER_TOPIC_2** keys into logs to indicate which topics in *kafka* the logs should be sent by *fluentd*.

#### What problem is this solving?

We are going to send logs from *fluentd* to *Kafka* (to be consumed by *skidder*) and would be great if the logs arrived in *fluentd* with the topic names, similar to the **SPLUNK_INDEX** injected by *kube-router* in the container metadata section.
I also changed to get the APP_ID from the constants import.

#### How should this be manually tested?
An application should log something with the logger and in *splunk* we should see the log with the new keys.
An app called `vtex.foo` installed in the account `bar` should have the values:
__SKIDDER_TOPIC_1: "skidder.acc.bar"
__SKIDDER_TOPIC_2: "skidder.app.bar.vtex.foo"

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
