### PR TITLE
Get VtexIdclientAutCookie from headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.19.0] - 2020-03-02
 ### Added
 - Get `adminUserAuthToken` from header `X-Vtex-Credential`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Get `adminUserAuthToken` from header `VtexIdclientAutCookie`.
 
 ## [6.18.0] - 2020-02-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Get `adminUserAuthToken` from header `VtexIdclientAutCookie`.
+- Get `adminUserAuthToken` from header `X-Vtex-Credential`.
 
 ## [6.18.0] - 2020-02-27
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.18.0",
+  "version": "6.19.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/http/middlewares/authTokens.ts
+++ b/src/service/worker/runtime/http/middlewares/authTokens.ts
@@ -1,9 +1,9 @@
 import { IOClients } from '../../../../../clients/IOClients'
+import { CREDENTIAL_HEADER } from '../../../../../constants'
 import { ParamsContext, RecorderState, ServiceContext } from '../../typings'
 
 const JANUS_ENV_COOKIE_KEY = 'vtex-commerce-env'
 const VTEX_ID_COOKIE_KEY = 'VtexIdclientAutCookie'
-const VTEX_ID_HEADER_KEY = 'x-vtex-credential'
 
 export async function authTokens <
   T extends IOClients,
@@ -12,7 +12,7 @@ export async function authTokens <
 > (ctx: ServiceContext<T, U, V>, next: () => Promise<void>) {
   const { vtex: { account } } = ctx
 
-  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY) || ctx.headers[VTEX_ID_HEADER_KEY]
+  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY) || ctx.headers[CREDENTIAL_HEADER]
   ctx.vtex.storeUserAuthToken = ctx.cookies.get(`${VTEX_ID_COOKIE_KEY}_${account}`)
   ctx.vtex.janusEnv = ctx.cookies.get(JANUS_ENV_COOKIE_KEY)
 

--- a/src/service/worker/runtime/http/middlewares/authTokens.ts
+++ b/src/service/worker/runtime/http/middlewares/authTokens.ts
@@ -3,6 +3,7 @@ import { ParamsContext, RecorderState, ServiceContext } from '../../typings'
 
 const JANUS_ENV_COOKIE_KEY = 'vtex-commerce-env'
 const VTEX_ID_COOKIE_KEY = 'VtexIdclientAutCookie'
+const VTEX_ID_HEADER_KEY = 'x-vtex-credential'
 
 export async function authTokens <
   T extends IOClients,
@@ -11,7 +12,7 @@ export async function authTokens <
 > (ctx: ServiceContext<T, U, V>, next: () => Promise<void>) {
   const { vtex: { account } } = ctx
 
-  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY) || ctx.headers[VTEX_ID_COOKIE_KEY.toLocaleLowerCase()]
+  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY) || ctx.headers[VTEX_ID_HEADER_KEY]
   ctx.vtex.storeUserAuthToken = ctx.cookies.get(`${VTEX_ID_COOKIE_KEY}_${account}`)
   ctx.vtex.janusEnv = ctx.cookies.get(JANUS_ENV_COOKIE_KEY)
 

--- a/src/service/worker/runtime/http/middlewares/authTokens.ts
+++ b/src/service/worker/runtime/http/middlewares/authTokens.ts
@@ -11,7 +11,7 @@ export async function authTokens <
 > (ctx: ServiceContext<T, U, V>, next: () => Promise<void>) {
   const { vtex: { account } } = ctx
 
-  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY)
+  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY) || ctx.headers.get(VTEX_ID_COOKIE_KEY)
   ctx.vtex.storeUserAuthToken = ctx.cookies.get(`${VTEX_ID_COOKIE_KEY}_${account}`)
   ctx.vtex.janusEnv = ctx.cookies.get(JANUS_ENV_COOKIE_KEY)
 

--- a/src/service/worker/runtime/http/middlewares/authTokens.ts
+++ b/src/service/worker/runtime/http/middlewares/authTokens.ts
@@ -11,7 +11,7 @@ export async function authTokens <
 > (ctx: ServiceContext<T, U, V>, next: () => Promise<void>) {
   const { vtex: { account } } = ctx
 
-  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY) || ctx.headers.get(VTEX_ID_COOKIE_KEY)
+  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY) || ctx.headers[VTEX_ID_COOKIE_KEY.toLocaleLowerCase()]
   ctx.vtex.storeUserAuthToken = ctx.cookies.get(`${VTEX_ID_COOKIE_KEY}_${account}`)
   ctx.vtex.janusEnv = ctx.cookies.get(JANUS_ENV_COOKIE_KEY)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Getting auth token from header `x-vtex-credential`. Before the token was only got from the cookie `VtexIdclientAutCookie`, but the proxy to IO use the header format and not the cookie.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
