### PR TITLE
[3.x] Adds skidder topics into 3p logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.72.0] - 2020-02-20
+
 ## [3.72.0-beta] - 2020-02-19
 
 ## [3.71.1] - 2020-01-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.72.0-beta] - 2020-02-19
+
 ## [3.71.1] - 2020-01-09
 
 ## [3.71.0] - 2020-01-02

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.72.0-beta",
+  "version": "3.72.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.71.1",
+  "version": "3.72.0-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds `__SKIDDER_TOPIC_1` and `__SKIDDER_TOPIC_2` keys into third-party logs to indicate which topics in kafka the logs should be sent by fluentd.

#### What problem is this solving?

This was changed in 6.x (https://github.com/vtex/node-vtex-api/pull/340), but third-party applications are in 3.x. 

#### How should this be manually tested?

Seeing logs (with `vtex link` or via splunk) and checking if vtex or go commerce logs are unchanged, while 3p apps are with the new `__SKIDDER_TOPIC_<n>` keys

#### Screenshots or example usage

- `storecomponents` app
![image](https://user-images.githubusercontent.com/58983768/74942594-f2cd4d80-53d2-11ea-995f-c951429a7a71.png)

- `vtex` app
![image](https://user-images.githubusercontent.com/58983768/74943444-26a87300-53d3-11ea-9186-54eb85da7add.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
