### PR TITLE
Support graphQL schema import cross apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.20.0] - 2020-03-04
 ### Added
 - Support for a external schema to be passed into graphql Service configuration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for a external schema to be passed into graphql Service configuration.
 
 ## [6.19.0] - 2020-03-02
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.19.0",
+  "version": "6.20.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/graphql/schema/index.ts
+++ b/src/service/worker/runtime/graphql/schema/index.ts
@@ -34,10 +34,11 @@ export const makeSchema = <
 >(options: GraphQLOptions<ClientsT, StateT, CustomT>) => {
   const {
     resolvers: appResolvers,
+    schema: appSchema,
     schemaDirectives: appDirectives,
   } = options
 
-  const appTypeDefs = readFileSync('./service/schema.graphql', 'utf8')
+  const appTypeDefs = appSchema || readFileSync('./service/schema.graphql', 'utf8')
 
   const schemaMetaData = extractSchemaMetaData(appTypeDefs!)
 

--- a/src/service/worker/runtime/typings.ts
+++ b/src/service/worker/runtime/typings.ts
@@ -88,6 +88,7 @@ export interface ClientsConfig<ClientsT extends IOClients = IOClients> {
 
 export interface GraphQLOptions<ClientsT extends IOClients = IOClients, StateT extends RecorderState = RecorderState, CustomT extends ParamsContext = ParamsContext> {
   resolvers: Record<string, Record<string, Resolver<ClientsT, StateT, CustomT>> | GraphQLScalarType>
+  schema?: string
   schemaDirectives?: Record<string, typeof SchemaDirectiveVisitor>
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow for a graphql schema imported from another App to be used

#### Types of changes
* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
