### PR TITLE
Changes __SKIDDER_TOPIC_<n> on logs from account to vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.72.1] - 2020-03-20
 ### Changed
 - Skidder topic names on logs are not based on account anymore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Skidder topic names on logs are not based on account anymore
 
 ## [3.72.0] - 2020-02-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.72.0",
+  "version": "3.72.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/logger/index.ts
+++ b/src/service/logger/index.ts
@@ -60,8 +60,8 @@ export class Logger {
 
     if (this.isThirdPartyApp()) {
       Object.assign(inflatedLog, {
-        __SKIDDER_TOPIC_1: `skidder.acc.${this.account}`,
-        __SKIDDER_TOPIC_2: `skidder.app.${this.account}.${vendor}.${appName}`,
+        __SKIDDER_TOPIC_1: `skidder.vendor.${vendor}`,
+        __SKIDDER_TOPIC_2: `skidder.app.${vendor}.${appName}`,
       })
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Changes the pattern of the skidder topics to consider the vendors and not the account of the apps.
* **__SKIDDER_TOPIC_1** changed from `skidder.acc.{{account}}` to `skidder.vendor.{{vendor}}`
* **__SKIDDER_TOPIC_2** changed from `skidder.app.{{account}}.{{vendor}}.{{app}}` to `skidder.app.{{vendor}}.{{app}}`

#### What problem is this solving?
The logs have a lot more value to the vendor who created the apps

#### How should this be manually tested?
Releasing and installing a beta version in a workspace, linking a app with any non-vtex vendor and see on Splunk the new format.

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
