### PR TITLE
Changes __SKIDDER_TOPIC_<n> on logs from account to vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Apps' Install API response type
+- Skidder topic names on logs are not based on account anymore
 
 ## [6.21.0] - 2020-03-05
 ### Added

--- a/src/service/logger/logger.ts
+++ b/src/service/logger/logger.ts
@@ -60,8 +60,8 @@ export class Logger {
     // Mark third-party apps logs to send to skidder
     if (APP.IS_THIRD_PARTY()) {
       Object.assign(inflatedLog, {
-        __SKIDDER_TOPIC_1: `skidder.acc.${this.account}`,
-        __SKIDDER_TOPIC_2: `skidder.app.${this.account}.${APP.VENDOR}.${APP.NAME}`,
+        __SKIDDER_TOPIC_1: `skidder.vendor.${APP.VENDOR}`,
+        __SKIDDER_TOPIC_2: `skidder.app.${APP.VENDOR}.${APP.NAME}`,
       })
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Changes the pattern of the skidder topics to consider the vendors and not the account of the apps.
* **__SKIDDER_TOPIC_1** changed from `skidder.acc.{{account}}` to `skidder.vendor.{{vendor}}`
* **__SKIDDER_TOPIC_2** changed from `skidder.app.{{account}}.{{vendor}}.{{app}}` to `skidder.app.{{vendor}}.{{app}}`

#### What problem is this solving?
The logs have a lot more value to the vendor who created the apps

#### How should this be manually tested?
Releasing and installing a beta version in a workspace, linking a app with any non-vtex vendor and see on Splunk the new format.

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
