### PR TITLE
[3.x] Send events with Courier instead of Colossus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.73.0] - 2020-04-08
+## Changed
+- Send events using `Courier` instead of `Colossus`.
+
 ## [3.72.2] - 2020-04-08
 ### Fixed
 - Adds missng `@` to BillingMetrics client

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.72.2",
+  "version": "3.73.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/Events.ts
+++ b/src/clients/Events.ts
@@ -1,14 +1,21 @@
-import { InfraClient, InstanceOptions} from '../HttpClient'
+import { InfraClient, InstanceOptions } from '../HttpClient'
 import { IOContext } from '../service/typings'
 
 const eventRoute = (route: string) => `/events/${route}`
 
 export class Events extends InfraClient {
   constructor(context: IOContext, options?: InstanceOptions) {
-    super('colossus@0.x', {...context, recorder: undefined}, options)
+    super('courier@0.x', { ...context, recorder: undefined }, options)
   }
 
   public sendEvent = (subject: string, route: string, message?: any) => {
-    return this.http.put(eventRoute(route), message, {params: {subject}, metric: 'events-send'})
+    const resource =
+      subject === '' || subject === '-'
+        ? ''
+        : `vrn:apps:aws-us-east-1:${this.context.account}:${this.context.workspace}:/apps/${subject}`
+    return this.http.put(eventRoute(route), message, {
+      metric: 'events-send',
+      params: { resource },
+    })
   }
 }


### PR DESCRIPTION
Same as [this](https://github.com/vtex/node-vtex-api/pull/314), but for `3.x`.

There's just a small difference: I also check if `subject` equals `-`, because some apps send events with undefined `subject` that way.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
