### PR TITLE
Feature/add extensions to graphql client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.25.0] - 2020-04-15
 ### Added
 - Extensions field to graphql client.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Extensions field to graphql client.
 
 ## [6.24.4] - 2020-04-08
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.24.4",
+  "version": "6.25.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/GraphQLClient.ts
+++ b/src/HttpClient/GraphQLClient.ts
@@ -10,6 +10,7 @@ interface QueryOptions<Variables extends object> {
   variables: Variables
   inflight?: boolean
   throwOnError?: boolean
+  extensions?: Record<string, any>
 }
 
 interface MutateOptions<Variables extends object> {
@@ -39,11 +40,11 @@ export class GraphQLClient {
   ) {}
 
   public query = <Data extends Serializable, Variables extends object>(
-    { query, variables, inflight, throwOnError }: QueryOptions<Variables>,
+    { query, variables, inflight, extensions, throwOnError }: QueryOptions<Variables>,
     config: RequestConfig = {}
   ): Promise<GraphQLResponse<Data>> => this.http.getWithBody<GraphQLResponse<Data>>(
     config.url || '',
-    { query, variables },
+    { query, variables, extensions },
     {
       inflightKey: inflight !== false ? inflightUrlWithQuery : undefined,
       ...config,


### PR DESCRIPTION
#### What is the purpose of this pull request?
I was trying to create a client to make queries to graphql-server, but in order to bypass these queries, we need to add some extensions to it. This PR allows this.
