### PR TITLE
Feature/event settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.27.0] - 2020-04-28
+
 ## [6.26.2-beta] - 2020-04-28
 
 ## [6.26.1-beta] - 2020-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.26.2-beta] - 2020-04-28
+
 ## [6.26.1-beta] - 2020-04-27
 
 ## [6.25.1-beta] - 2020-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.25.1-beta] - 2020-04-27
 ### Added
 - Settings from settings builder to events.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.26.1-beta] - 2020-04-27
+
 ## [6.25.1-beta] - 2020-04-27
 ### Added
 - Settings from settings builder to events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Settings from settings builder to events.
 
 ## [6.26.0] - 2020-04-22
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.26.2-beta",
+  "version": "6.27.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.26.1-beta",
+  "version": "6.26.2-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.26.0",
+  "version": "6.26.1-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/index.ts
+++ b/src/service/worker/index.ts
@@ -151,12 +151,13 @@ const createAppGraphQLHandler = (
 }
 
 const createAppEventHandlers = (
-  { config: { events, clients } }: Service<IOClients, RecorderState, ParamsContext>
+  { config: { events, clients } }: Service<IOClients, RecorderState, ParamsContext>,
+  serviceJSON: ServiceJSON
 ) => {
   if (events && clients) {
     return Object.keys(events).reduce(
       (acc, eventId) => {
-        acc[eventId] = createEventHandler(clients, eventId, events[eventId])
+        acc[eventId] = createEventHandler(clients, eventId, events[eventId], serviceJSON.events)
         return acc
       },
       {} as Record<string, RouteHandler>
@@ -224,7 +225,7 @@ export const startWorker = (serviceJSON: ServiceJSON) => {
 
   const appHttpHandlers = createAppHttpHandlers(service, serviceJSON)
   const appGraphQLHandlers = createAppGraphQLHandler(service, serviceJSON)
-  const appEventHandlers = createAppEventHandlers(service)
+  const appEventHandlers = createAppEventHandlers(service, serviceJSON)
   const runtimeHttpHandlers = createRuntimeHttpHandlers(appEventHandlers, serviceJSON)
   const httpHandlers = [
     appHttpHandlers,

--- a/src/service/worker/index.ts
+++ b/src/service/worker/index.ts
@@ -157,7 +157,8 @@ const createAppEventHandlers = (
   if (events && clients) {
     return Object.keys(events).reduce(
       (acc, eventId) => {
-        acc[eventId] = createEventHandler(clients, eventId, events[eventId], serviceJSON.events)
+        const serviceEvent = serviceJSON.events?.[eventId]
+        acc[eventId] = createEventHandler(clients, eventId, events[eventId], serviceEvent)
         return acc
       },
       {} as Record<string, RouteHandler>

--- a/src/service/worker/runtime/events/index.ts
+++ b/src/service/worker/runtime/events/index.ts
@@ -1,5 +1,5 @@
 import { IOClients } from '../../../../clients/IOClients'
-import { insertUserLandTracer, nameSpanOperationMiddleware, traceUserLandRemainingPipelineMiddleware } from '../../../tracing/tracingMiddlewares'
+import { nameSpanOperationMiddleware, traceUserLandRemainingPipelineMiddleware } from '../../../tracing/tracingMiddlewares'
 import { clients } from '../http/middlewares/clients'
 import { error } from '../http/middlewares/error'
 import { getServiceSettings } from '../http/middlewares/settings'
@@ -29,7 +29,6 @@ export const createEventHandler = <T extends IOClients, U extends RecorderState,
     nameSpanOperationMiddleware('event-handler', eventId),
     eventContextMiddleware,
     parseBodyMiddleware,
-    insertUserLandTracer,
     clients<T, U, V>(implementation!, options),
     ...(serviceEvent?.settingsType === 'workspace' || serviceEvent?.settingsType === 'userAndWorkspace' ? [getServiceSettings()] : []),
     timings,

--- a/src/service/worker/runtime/events/index.ts
+++ b/src/service/worker/runtime/events/index.ts
@@ -9,28 +9,19 @@ import {
   EventHandler,
   ParamsContext,
   RecorderState,
-  RouteSettingsType,
   ServiceContext,
+  ServiceEvent,
 } from '../typings'
 import { compose, composeForEvents } from '../utils/compose'
 import { toArray } from '../utils/toArray'
 import { parseBodyMiddleware } from './middlewares/body'
 import { eventContextMiddleware } from './middlewares/context'
 
-interface ServiceEvent {
-  [handler: string]: {
-    keys?: string[] | undefined
-    sender?: string | undefined
-    subject?: string | undefined
-    settingsType?: RouteSettingsType
-  }
-}
-
 export const createEventHandler = <T extends IOClients, U extends RecorderState, V extends ParamsContext>(
   clientsConfig: ClientsConfig<T>,
   eventId: string,
   handler: EventHandler<T, U> | Array<EventHandler<T, U>>,
-  serviceEvents?: ServiceEvent
+  serviceEvent: ServiceEvent | undefined
 ) => {
   const { implementation, options } = clientsConfig
   const middlewares = toArray(handler)
@@ -40,7 +31,7 @@ export const createEventHandler = <T extends IOClients, U extends RecorderState,
     parseBodyMiddleware,
     insertUserLandTracer,
     clients<T, U, V>(implementation!, options),
-    ...(serviceEvents?.settingsType === 'workspace' || serviceEvents?.settingsType === 'userAndWorkspace' ? [getServiceSettings()] : []),
+    ...(serviceEvent?.settingsType === 'workspace' || serviceEvent?.settingsType === 'userAndWorkspace' ? [getServiceSettings()] : []),
     timings,
     error,
     traceUserLandRemainingPipelineMiddleware(`user-event-handler:${eventId}`),

--- a/src/service/worker/runtime/typings.ts
+++ b/src/service/worker/runtime/typings.ts
@@ -169,6 +169,13 @@ export interface ServiceRoute {
   settingsType?: RouteSettingsType
 }
 
+export interface ServiceEvent {
+  keys?: string[],
+  sender?: string,
+  subject?: string,
+  settingsType?: RouteSettingsType,
+}
+
 export interface RawServiceJSON {
   stack: 'nodejs',
   memory: number,
@@ -176,13 +183,7 @@ export interface RawServiceJSON {
   timeout?: number,
  runtimeArgs?: string[],
   routes?: Record<string, ServiceRoute>,
-  events?: {
-    [handler: string]: {
-      keys?: string[],
-      sender?: string,
-      subject?: string,
-    },
-  },
+  events?: Record<string, ServiceEvent>,
   minReplicas?: number,
   maxReplicas?: number,
   workers?: number


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add settings to events. Settings builder already works for routes, we are lauching the same feature for events declared in `service.json`! 🎉

#### What problem is this solving?
Lack of parallelism between the routes and events API. Now, they look more alike!
![](https://media.giphy.com/media/xk0vJLeQvzaes/giphy.gif)

#### How should this be manually tested?
Testing is not so difficult, but will require some of your patience 🙈. First choose your favorite app that listens to an event (or simply create a new one! 💪). In my case, my favorite one is [`notification-generator`](https://github.com/vtex/notification-generator). In this app, go to `service.json` and, in the event configurations, add this:
```diff
"eventId": {
      "keys": ["key"],
+     "settingsType": "workspace"
    },
```
I've done this for `notification-generator` in [this branch](https://github.com/vtex/notification-generator/tree/feature/configurable-channels). The next step, in order to test this version of `@vtex/api` is to link it to your app. In one window of your terminal:
```
git clone https://github.com/vtex/node-vtex-api.git
cd node-vtex-api
git checkout feature/event-settings
yarn && yarn watch
```
Open another terminal window and go to your favorite app folder:
```
cd node
yarn link @vtex/api
cd ..
vtex link --verbose
```

Now that's running you're all set and in position to test it! Just fire the event now! this should work normally. If you want to add settings, you can and [the API is the same as for the routes](https://vtex.io/docs/recipes/development/developing-service-configuration-apps/)! What about printing the configurations you receive in your favorite app? 🌝

Other useful tests are the ones with other apps, just to see if something breaks (we hope it doesn't)

If you tested everything THANK YOU! You deserve an awesome day 🏆 
#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
