### PR TITLE
Tracing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.28.0] - 2020-05-04
 ### Changed
 - [tracing:init] Increase sampling rate to 5%.
 - [ErrorReport] Serialize buffer only as a `byteCount` and a `type: buffer`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.28.1] - 2020-05-05
 ### Fixed
 - [tracing:logger] Make Logger serializable again.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [tracing:init] Increase sampling rate to 5%.
+- [ErrorReport] Serialize buffer only as a `byteCount` and a `type: buffer`.
+- [ErrorReport] Increase ErrorReport serialization depth from 6 to 8.
+
+### Added
+- [tracing:entrypoint-span] Add `vtex.request_id` tag. 
+- [ErrorReport] Add `error.server.code`, `error.server.source`, `error.server.request_id` to tags added to error spans.
+- [response:headers] Add `x-trace-id` when request is traced.
+- [logger] Log `trace-id` when request is traced.
+- [tracing:tags] Use snake case to conform with OpenTracing.
+
 
 ## [6.27.0] - 2020-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [tracing:logger] Make Logger serializable again.
 
 ## [6.28.0] - 2020-05-04
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.27.0",
+  "version": "6.28.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "graphql": "^14.5.8",
     "graphql-tools": "^4.0.6",
     "graphql-upload": "^8.1.0",
-    "jaeger-client": "^3.17.2",
+    "jaeger-client": "^3.18.0",
     "js-base64": "^2.5.1",
     "koa": "^2.11.0",
     "koa-compose": "^4.1.0",

--- a/src/HttpClient/middlewares/request/setupAxios/__tests__/TestTracer.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/__tests__/TestTracer.ts
@@ -6,10 +6,17 @@ export class TestTracer implements IUserLandTracer {
   public fallbackSpan: MockSpan
   public mockTracer: MockTracer
 
+  public traceId: string
+  public isTraceSampled: boolean
+
   constructor() {
     this.mockTracer = new MockTracer()
     this.fallbackSpan = this.mockTracer.startSpan('fallback-span') as MockSpan
     this.fallbackSpan.finish()
+
+    const spanContext = this.fallbackSpan.context()
+    this.traceId = spanContext.toTraceId()
+    this.isTraceSampled = true
   }
 
   public startSpan(name: string, options?: SpanOptions) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,6 +33,7 @@ export const EVENT_HANDLER_ID_HEADER = 'x-event-handler-id'
 export const COLOSSUS_ROUTE_DECLARER_HEADER = 'x-colossus-route-declarer'
 export const COLOSSUS_ROUTE_ID_HEADER = 'x-colossus-route-id'
 export const COLOSSUS_PARAMS_HEADER = 'x-colossus-params'
+export const TRACE_ID_HEADER = 'x-trace-id'
 
 export type VaryHeaders = typeof SEGMENT_HEADER | typeof SESSION_HEADER | typeof PRODUCT_HEADER | typeof LOCALE_HEADER
 

--- a/src/service/tracing/TracerSingleton.ts
+++ b/src/service/tracing/TracerSingleton.ts
@@ -33,8 +33,8 @@ export class TracerSingleton {
         agentHost: process.env.VTEX_OWN_NODE_IP,
       },
       sampler: {
-        param: 0.01,
-        type: 'remote',
+        param: 0.05,
+        type: 'probabilistic',
       },
       serviceName,
     }

--- a/src/service/tracing/TracerSingleton.ts
+++ b/src/service/tracing/TracerSingleton.ts
@@ -34,7 +34,7 @@ export class TracerSingleton {
       },
       sampler: {
         param: 0.01,
-        type: 'probabilistic',
+        type: 'remote',
       },
       serviceName,
     }

--- a/src/service/tracing/spanSetup.ts
+++ b/src/service/tracing/spanSetup.ts
@@ -1,21 +1,16 @@
 import { Span } from 'opentracing'
 import { ErrorReport } from '../../tracing'
-import { Tags } from '../../tracing/Tags'
 
 export const injectErrorOnSpan = (span: Span, err: Error | ErrorReport) => {
-  span.setTag(Tags.ERROR, 'true')
-
   let errorReport: ErrorReport
   if (!(err instanceof ErrorReport)) {
     errorReport = ErrorReport.create({
       message: err.message,
       originalError: err,
-      tryToParseError: true,
     })
   } else {
     errorReport = err
   }
 
-  span.setTag(Tags.ERROR_KIND, errorReport.kind)
-  span.log({ event: 'error', ...errorReport.toObject() })
+  errorReport.injectOnSpan(span)
 }

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -1,5 +1,5 @@
 import { FORMAT_HTTP_HEADERS, SpanContext, Tracer } from 'opentracing'
-import { ACCOUNT_HEADER, TRACE_ID_HEADER, WORKSPACE_HEADER } from '../../constants'
+import { ACCOUNT_HEADER, REQUEST_ID_HEADER, TRACE_ID_HEADER, WORKSPACE_HEADER } from '../../constants'
 import { getTraceInfo } from '../../tracing'
 import { Tags } from '../../tracing/Tags'
 import { UserLandTracer } from '../../tracing/UserLandTracer'
@@ -23,8 +23,9 @@ export const addTracingMiddleware = (tracer: Tracer) => {
         [Tags.HTTP_URL]: ctx.request.originalUrl,
         [Tags.HTTP_METHOD]: ctx.request.method,
         [Tags.HTTP_PATH]: ctx.request.path,
-        [Tags.VTEX_WORKSPACE]: ctx.headers[WORKSPACE_HEADER],
-        [Tags.VTEX_ACCOUNT]: ctx.headers[ACCOUNT_HEADER],
+        [Tags.VTEX_REQUEST_ID]: ctx.get(REQUEST_ID_HEADER),
+        [Tags.VTEX_WORKSPACE]: ctx.get(WORKSPACE_HEADER),
+        [Tags.VTEX_ACCOUNT]: ctx.get(ACCOUNT_HEADER),
       },
     })
 

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -1,5 +1,6 @@
 import { FORMAT_HTTP_HEADERS, SpanContext, Tracer } from 'opentracing'
-import { ACCOUNT_HEADER, WORKSPACE_HEADER } from '../../constants'
+import { ACCOUNT_HEADER, TRACE_ID_HEADER, WORKSPACE_HEADER } from '../../constants'
+import { getTraceInfo } from '../../tracing'
 import { Tags } from '../../tracing/Tags'
 import { UserLandTracer } from '../../tracing/UserLandTracer'
 import { ServiceContext } from '../worker/runtime/typings'
@@ -37,6 +38,11 @@ export const addTracingMiddleware = (tracer: Tracer) => {
     } finally {
       currentSpan.setTag(Tags.HTTP_STATUS_CODE, ctx.response.status)
       currentSpan.finish()
+
+      const traceInfo = getTraceInfo(currentSpan)
+      if(traceInfo.isSampled) {
+        ctx.set(TRACE_ID_HEADER, traceInfo.traceId)
+      }
     }
   }
 }

--- a/src/service/worker/runtime/events/middlewares/context.ts
+++ b/src/service/worker/runtime/events/middlewares/context.ts
@@ -5,14 +5,13 @@ import {
   EVENT_SENDER_HEADER,
   EVENT_SUBJECT_HEADER,
 } from '../../../../../constants'
-import { UserLandTracer } from '../../../../../tracing/UserLandTracer'
 import { ParamsContext, RecorderState, ServiceContext } from '../../typings'
 import { prepareHandlerCtx } from '../../utils/context'
 
 export async function eventContextMiddleware <T extends IOClients, U extends RecorderState, V extends ParamsContext>(ctx: ServiceContext<T, U, V>, next: () => Promise<void>) {
   const { request: { header } } = ctx
   ctx.vtex = {
-    ...prepareHandlerCtx(header),
+    ...prepareHandlerCtx(header, ctx.tracing!),
     eventInfo: {
       key: header[EVENT_KEY_HEADER],
       sender: header[EVENT_SENDER_HEADER],
@@ -23,7 +22,6 @@ export async function eventContextMiddleware <T extends IOClients, U extends Rec
       params: {},
       type: 'event',
     },
-    tracer: new UserLandTracer(ctx.tracing!.tracer, ctx.tracing!.currentSpan),
   }
   await next()
 }

--- a/src/service/worker/runtime/http/middlewares/context.ts
+++ b/src/service/worker/runtime/http/middlewares/context.ts
@@ -5,7 +5,6 @@ import {
   COLOSSUS_PARAMS_HEADER,
   COLOSSUS_ROUTE_DECLARER_HEADER,
 } from '../../../../../constants'
-import { UserLandTracer } from '../../../../../tracing/UserLandTracer'
 import { prepareHandlerCtx } from '../../utils/context'
 import {
   ParamsContext,
@@ -28,14 +27,13 @@ export const createPvtContextMiddleware = (
       request: { header },
     } = ctx
     ctx.vtex = {
-      ...prepareHandlerCtx(header),
+      ...prepareHandlerCtx(header, ctx.tracing!),
       ...(smartcache && { recorder: ctx.state.recorder }),
       route: {
         id: routeId,
         params,
         type: 'private',
       },
-      tracer: new UserLandTracer(ctx.tracing!.tracer, ctx.tracing!.currentSpan),
     }
     await next()
   }
@@ -55,7 +53,7 @@ export const createPubContextMiddleware = (
     } = ctx
 
     ctx.vtex = {
-      ...prepareHandlerCtx(header),
+      ...prepareHandlerCtx(header, ctx.tracing!),
       ...(smartcache && { recorder: ctx.state.recorder }),
       route: {
         declarer: header[COLOSSUS_ROUTE_DECLARER_HEADER],
@@ -63,7 +61,6 @@ export const createPubContextMiddleware = (
         params: qsParse(header[COLOSSUS_PARAMS_HEADER]),
         type: 'public',
       },
-      tracer: new UserLandTracer(ctx.tracing!.tracer, ctx.tracing!.currentSpan),
     }
     await next()
   }

--- a/src/tracing/Tags.ts
+++ b/src/tracing/Tags.ts
@@ -2,6 +2,7 @@ import { Tags as opentracingTags } from 'opentracing'
 
 const VTEX_INCOMING_REQUEST_TAGS = {
   VTEX_ACCOUNT: 'vtex.incoming.account',
+  VTEX_REQUEST_ID: 'vtex.request-id',
   VTEX_WORKSPACE: 'vtex.incoming.workspace',
 }
 

--- a/src/tracing/Tags.ts
+++ b/src/tracing/Tags.ts
@@ -15,8 +15,15 @@ const APP_TAGS = {
   VTEX_APP_WORKSPACE: 'app.workspace',
 }
 
-export const USERLAND_TAGS = {
+const ERROR_REPORT_TAGS = {
   ERROR_KIND: 'error.kind',
+  ERROR_SERVER_CODE: 'error.server.code',
+  ERROR_SERVER_REQUEST_ID: 'error.server.request-id',
+  ERROR_SERVER_SOURCE: 'error.server.source',
+}
+
+export const USERLAND_TAGS = {
+  ...ERROR_REPORT_TAGS,
   ...opentracingTags,
 }
 

--- a/src/tracing/Tags.ts
+++ b/src/tracing/Tags.ts
@@ -2,14 +2,14 @@ import { Tags as opentracingTags } from 'opentracing'
 
 const VTEX_INCOMING_REQUEST_TAGS = {
   VTEX_ACCOUNT: 'vtex.incoming.account',
-  VTEX_REQUEST_ID: 'vtex.request-id',
+  VTEX_REQUEST_ID: 'vtex.request_id',
   VTEX_WORKSPACE: 'vtex.incoming.workspace',
 }
 
 const APP_TAGS = {
   VTEX_APP_LINKED: 'app.linked',
-  VTEX_APP_NODE_ENV: 'app.node-env',
-  VTEX_APP_NODE_VTEX_API_VERSION: 'app.node-vtex-api-version',
+  VTEX_APP_NODE_ENV: 'app.node_env',
+  VTEX_APP_NODE_VTEX_API_VERSION: 'app.node_vtex_api_version',
   VTEX_APP_PRODUCTION: 'app.production',
   VTEX_APP_REGION: 'app.region',
   VTEX_APP_VERSION: 'app.version',
@@ -19,7 +19,7 @@ const APP_TAGS = {
 const ERROR_REPORT_TAGS = {
   ERROR_KIND: 'error.kind',
   ERROR_SERVER_CODE: 'error.server.code',
-  ERROR_SERVER_REQUEST_ID: 'error.server.request-id',
+  ERROR_SERVER_REQUEST_ID: 'error.server.request_id',
   ERROR_SERVER_SOURCE: 'error.server.source',
 }
 
@@ -29,10 +29,10 @@ export const USERLAND_TAGS = {
 }
 
 export const Tags = {
-  HTTP_NO_RESPONSE: 'http.no-response',
+  HTTP_NO_RESPONSE: 'http.no_response',
   HTTP_PATH: 'http.path',
-  HTTP_RETRY_COUNT: 'http.retry-count',
-  HTTP_ROUTER_CACHE: 'http.router-cache',
+  HTTP_RETRY_COUNT: 'http.retry_count',
+  HTTP_ROUTER_CACHE: 'http.router_cache',
   ...USERLAND_TAGS,
   ...VTEX_INCOMING_REQUEST_TAGS,
   ...APP_TAGS,

--- a/src/tracing/UserLandTracer.ts
+++ b/src/tracing/UserLandTracer.ts
@@ -1,5 +1,6 @@
 import { FORMAT_HTTP_HEADERS, Span, SpanContext, SpanOptions, Tracer } from 'opentracing'
 import { TracerSingleton } from '../service/tracing/TracerSingleton'
+import { getTraceInfo } from './utils'
 
 export interface IUserLandTracer {
   traceId: string
@@ -30,7 +31,9 @@ export class UserLandTracer implements IUserLandTracer {
   private fallbackSpan: Span
   private fallbackSpanLock: boolean
 
+  // tslint:disable-next-line
   private _isSampled: boolean
+  // tslint:disable-next-line
   private _traceId: string
 
   constructor(tracer: Tracer, fallbackSpan: Span) {
@@ -38,9 +41,9 @@ export class UserLandTracer implements IUserLandTracer {
     this.fallbackSpan = fallbackSpan
     this.fallbackSpanLock = false
 
-    const spanContext = fallbackSpan.context()
-    this._traceId = spanContext.toTraceId()
-    this._isSampled = (spanContext as any)?.isSampled()
+    const { traceId, isSampled } = getTraceInfo(fallbackSpan)
+    this._traceId = traceId
+    this._isSampled = isSampled
   }
 
   get traceId() {

--- a/src/tracing/errorReporting/ErrorReport.ts
+++ b/src/tracing/errorReporting/ErrorReport.ts
@@ -10,14 +10,12 @@ interface ErrorCreationArguments {
   kind?: string
   message?: string
   originalError: Error
-  tryToParseError?: boolean
 }
 
 interface ErrorReportArguments {
   kind: string
   message: string
   originalError: Error
-  tryToParseError?: boolean
 }
 
 interface RequestErrorDetails {
@@ -39,17 +37,21 @@ interface RequestErrorDetails {
     | undefined
 }
 
+interface RequestErrorParsedInfo {
+  serverErrorCode: string
+  serverErrorSource?: string
+  serverErrorRequestId?: string
+}
+
 export class ErrorReport extends Error {
   public static create(args: ErrorCreationArguments) {
     const kind = args.kind ?? this.createGenericErrorKind(args.originalError)
     const message = args.message ?? args.originalError?.message
-    const tryToParseError = args.tryToParseError ?? true
 
     return new ErrorReport({
       kind,
       message,
       originalError: args.originalError,
-      tryToParseError,
     })
   }
 
@@ -97,22 +99,24 @@ export class ErrorReport extends Error {
 
   public readonly kind: string
   public readonly originalError: any
-  public readonly errorDetails: any
   public readonly errorId: string
+  public readonly errorDetails?: any
+  public readonly parsedInfo?: RequestErrorParsedInfo
 
-  constructor({ kind, message, originalError, tryToParseError = false }: ErrorReportArguments) {
+  constructor({ kind, message, originalError }: ErrorReportArguments) {
     super(message)
     this.kind = kind
     this.originalError = originalError
     this.errorId = randomBytes(16).toString('hex')
     this.stack = originalError.stack
+    this.message = originalError.message
 
     this.errorDetails = ErrorReport.getRequestErrorMetadata(this.originalError as AxiosError)
-    if (tryToParseError) {
-      if (this.errorDetails?.response?.data?.message) {
-        this.message = this.errorDetails.response.data.message
-      } else {
-        this.message = this.originalError.message
+    if (this.errorDetails?.response?.data?.code) {
+      this.parsedInfo = {
+        serverErrorCode: this.errorDetails.response.data.code,
+        ...(this.errorDetails.response.data.source ? { serverErrorSource: this.errorDetails.response.data.source } : null),
+        ...(this.errorDetails.response.data.requestId ? { serverErrorRequestId: this.errorDetails.response.data.requestId } : null),
       }
     }
   }
@@ -120,11 +124,11 @@ export class ErrorReport extends Error {
   public toObject(objectDepth = ErrorReport.DEFAULT_MAX_OBJECT_DEPTH) {
     return truncateStringsFromObject(
       {
-        errorDetails: this.errorDetails,
         errorId: this.errorId,
         kind: this.kind,
         message: this.message,
         stack: this.stack,
+        ...(this.errorDetails ? { errorDetails: this.errorDetails } : null),
         ...(this.originalError.code ? { code: this.originalError.code } : null),
       },
       ErrorReport.MAX_ERROR_STRING_LENGTH,
@@ -135,6 +139,19 @@ export class ErrorReport extends Error {
   public injectOnSpan(span: Span) {
     span.setTag(TracingTags.ERROR, 'true')
     span.setTag(TracingTags.ERROR_KIND, this.kind)
+
+    if (this.parsedInfo) {
+      span.setTag(TracingTags.ERROR_SERVER_CODE, this.parsedInfo.serverErrorCode)
+
+      if(this.parsedInfo.serverErrorSource) {
+        span.setTag(TracingTags.ERROR_SERVER_SOURCE, this.parsedInfo.serverErrorSource)
+      }
+
+      if(this.parsedInfo.serverErrorRequestId) {
+        span.setTag(TracingTags.ERROR_SERVER_REQUEST_ID, this.parsedInfo.serverErrorRequestId)
+      }
+    }
+
     span.log({ event: 'error', ...this.toObject() })
     return this
   }

--- a/src/tracing/errorReporting/ErrorReport.ts
+++ b/src/tracing/errorReporting/ErrorReport.ts
@@ -59,7 +59,7 @@ export class ErrorReport extends Error {
     ? parseInt(process.env.MAX_ERROR_STRING_LENGTH, 10)
     : 8 * 1024
 
-  private static readonly DEFAULT_MAX_OBJECT_DEPTH = 6
+  private static readonly DEFAULT_MAX_OBJECT_DEPTH = 8
 
   private static createGenericErrorKind(error: AxiosError | Error | any) {
     if (error.config) {

--- a/src/tracing/errorReporting/__snapshots__/utils.test.ts.snap
+++ b/src/tracing/errorReporting/__snapshots__/utils.test.ts.snap
@@ -92,3 +92,13 @@ Object {
   "b": Symbol(symbol description 2),
 }
 `;
+
+exports[`Works on testcase 11 - String limit 5 1`] = `
+Object {
+  "b": "a str[...TRUNCATED]",
+  "buf": Object {
+    "byteLength": 14,
+    "type": "buffer",
+  },
+}
+`;

--- a/src/tracing/errorReporting/utils.test.ts
+++ b/src/tracing/errorReporting/utils.test.ts
@@ -21,6 +21,7 @@ it.each([
   // tslint:disable-next-line
   [5, [() => {}]],
   [5, { a: Symbol('symbol description'), b: Symbol('symbol description 2') }],
+  [5, { buf: Buffer.from('this is a test'), b: 'a string' }],
 ])('Works on testcase %# - String limit %d', (limit: number, obj: any) => {
   expect(truncateStringsFromObject(obj, limit)).toMatchSnapshot()
 })

--- a/src/tracing/errorReporting/utils.ts
+++ b/src/tracing/errorReporting/utils.ts
@@ -10,6 +10,10 @@ export function truncateStringsFromObject(element: any, maxStrSize: number, dept
       return '[circular]'
     }
 
+    if(Buffer.isBuffer(element)) {
+      return { type: 'buffer', byteLength: Buffer.byteLength(element) } 
+    }
+
     if (depth === 0) {
       return Array.isArray(element) ? `[array]` : `[object]`
     }

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -6,4 +6,5 @@ export { createSpanReference } from './spanReference/createSpanReference'
 export { SpanReferenceTypes } from './spanReference/SpanReferenceTypes'
 export { USERLAND_TAGS as TracingTags } from './Tags'
 export { createTracingContextFromCarrier, IUserLandTracer } from './UserLandTracer'
+export { getTraceInfo, TraceInfo } from './utils'
 export { Span, FORMAT_HTTP_HEADERS }

--- a/src/tracing/utils.ts
+++ b/src/tracing/utils.ts
@@ -1,0 +1,14 @@
+import { Span } from 'opentracing'
+
+export interface TraceInfo {
+  traceId: string
+  isSampled: boolean
+}
+
+export function getTraceInfo(span: Span): TraceInfo {
+  const spanContext = span.context()
+  return {
+    isSampled: (spanContext as any).isSampled?.() ?? false,
+    traceId: spanContext.toTraceId(),
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,13 +2670,13 @@ iterall@^1.1.3, iterall@^1.2.2:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
-jaeger-client@^3.17.2:
-  version "3.17.2"
-  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.17.2.tgz#92cf26752c5c66f3e66adf595cdde2f548cc0804"
-  integrity sha512-19YloSidmKbrXHgecLWod8eXo7rm2ieUnsfg0ripTFGRCW5v2OWE96Gte4/tOQG/8N+T39VoLU2nMBdjbdMUJg==
+jaeger-client@^3.18.0:
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.18.0.tgz#95c9183e06a9b14b957bce33b5e2ddaecb2ed51f"
+  integrity sha512-xZ9WvZDWLkZFq7SObpLwu1asMCKCgBRNcDxxGSvK+ZQ7OZyJC5xPlU+rJa4+s/P6autPBVwHpqMGbOERFxWuuA==
   dependencies:
     node-int64 "^0.4.0"
-    opentracing "^0.13.0"
+    opentracing "^0.14.4"
     thriftrw "^3.5.0"
     uuid "^3.2.1"
     xorshift "^0.2.0"
@@ -3787,11 +3787,6 @@ only@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
   integrity sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=
-
-opentracing@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.13.0.tgz#6a341442f09d7d866bc11ed03de1e3828e3d6aab"
-  integrity sha1-ajQUQvCdfYZrwR7QPeHjgo49aqs=
 
 opentracing@^0.14.4, opentracing@~0.14.3:
   version "0.14.4"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Improve some aspects of tracing:

- [tracing:init] Increase sampling rate to 5% (this is default set on jaeger backend at the moment)
- [ErrorReport] Serialize buffer only as a `byteCount` and a `type: buffer`.
- [tracing:entrypoint-span] Add `vtex.request_id` tag.
- [ErrorReport] Add `error.server.code`, `error.server.request_id` and `error.server.source` to tags added to error spans. (this may be useful for infra errors)
- [response:headers] Add `x-trace-id` when request is traced.
- [logger] Log `trace-id` when request is traced.



#### How should this be manually tested?

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
