### PR TITLE
Use remote sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Create an option to disable conditional segment/session vary
 - Set vary: x-vtex-session if the scope is private
 
+### Changed
+- [tracing:ErrorReport] Log ErrorReport errors created on `HttpClient` requests or thrown by user handlers to splunk.
+
 ## [6.28.3] - 2020-05-15
 ### Fixed
 - [ErrorReport] Update `@vtex/node-error-report` package:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [ErrorReport] Log ErrorReport errors created on `HttpClient` requests or thrown by user handlers to splunk.
 - [ErrorReport] Add error metadata on span logs instead of on span tags.
 - [tracing:entrypoint] Log incoming request headers and outgoing response headers.
+- [tracing] Use remote sampling.
 
 ### Fixed
 - [tracing:entrypoint] Fix URL tag on entrypoint span - use `ctx.request.href` instead of `ctx.request.originalUrl`.
@@ -23,9 +24,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Create an option to disable conditional segment/session vary
 - Set vary: x-vtex-session if the scope is private
-
-### Changed
-- [tracing:ErrorReport] Log ErrorReport errors created on `HttpClient` requests or thrown by user handlers to splunk.
 
 ## [6.28.3] - 2020-05-15
 ### Fixed

--- a/src/service/tracing/TracerSingleton.ts
+++ b/src/service/tracing/TracerSingleton.ts
@@ -33,8 +33,10 @@ export class TracerSingleton {
         agentHost: process.env.VTEX_OWN_NODE_IP,
       },
       sampler: {
+        host: process.env.VTEX_OWN_NODE_IP,
         param: 0.05,
-        type: 'probabilistic',
+        refreshIntervalMs: 60 * 1000,
+        type: 'remote',
       },
       serviceName,
     }


### PR DESCRIPTION
Use jaeger remote sampling. If an error occurs while communicating with the jaeger-agent the sampling fallbacks to probabilistic:0.05 (configurable by the `param` field)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
