### PR TITLE
Add deterministicVary to ServiceDescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.74.1] - 2020-05-14
 ### Fixed
 - Add deterministicVary to ServiceDescriptor interface.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add deterministicVary to ServiceDescriptor interface.
 
 ## [3.74.0] - 2020-05-14
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.74.0",
+  "version": "3.74.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/typings.ts
+++ b/src/service/typings.ts
@@ -154,6 +154,7 @@ export interface ServiceDescriptor {
       subject?: string,
     },
   },
+  deterministicVary?: boolean
 }
 
 export type JanusEnv = string


### PR DESCRIPTION
It should not be an option to developers add to theirs service.json, it should be automatically set by builder-hub in the future.