### PR TITLE
Allow more errors per span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- [tracing:ErrorReport] Log ErrorReport errors created on `HttpClient` requests or thrown by user handlers to splunk.
+- [ErrorReport] Log ErrorReport errors created on `HttpClient` requests or thrown by user handlers to splunk.
+- [ErrorReport] Add error metadata on span logs instead of on span tags.
 
 ## [6.30.0] - 2020-05-20
 

--- a/src/HttpClient/middlewares/request/setupAxios/__tests__/axiosTracingTestSuite.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/__tests__/axiosTracingTestSuite.ts
@@ -3,6 +3,7 @@ import { AxiosError, AxiosInstance } from 'axios'
 import { REFERENCE_CHILD_OF, REFERENCE_FOLLOWS_FROM } from 'opentracing'
 import { ROUTER_CACHE_HEADER } from '../../../../../constants'
 import { SpanReferenceTypes } from '../../../../../tracing'
+import { LOG_FIELDS } from '../../../../../tracing/LogFields'
 import { Tags } from '../../../../../tracing/Tags'
 import { requestSpanPrefix } from '../interceptors/tracing'
 import { TestServer } from './TestServer'
@@ -107,9 +108,9 @@ export const registerSharedTestSuite = (testSuiteConfig: TestSuiteConfig) => {
 
     allRequestSpans.forEach((requestSpan) => {
       expect((requestSpan as any)._logs.length).toEqual(expectedLen)
-      expect((requestSpan as any)._logs[0].fields.event).toEqual('request-headers')
+      expect((requestSpan as any)._logs[0].fields[LOG_FIELDS.EVENT]).toEqual('request-headers')
       if (!testSuiteConfig.expects.error?.isClientError) {
-        expect((requestSpan as any)._logs[1].fields.event).toEqual('response-headers')
+        expect((requestSpan as any)._logs[1].fields[LOG_FIELDS.EVENT]).toEqual('response-headers')
       }
     })
   })
@@ -188,9 +189,10 @@ export const registerSharedTestSuite = (testSuiteConfig: TestSuiteConfig) => {
         allRequestSpans.forEach((requestSpan) => {
           expect(requestSpan!.tags()[Tags.ERROR]).toEqual('true')
           const len = (requestSpan as any)._logs.length
-          expect((requestSpan as any)._logs[len - 1].fields.event).toEqual('error')
-          expect((requestSpan as any)._logs[len - 1].fields.stack).toBeDefined()
-          expect((requestSpan as any)._logs[len - 1].fields.message).toEqual(
+          expect((requestSpan as any)._logs[len - 1].fields[LOG_FIELDS.EVENT]).toEqual('error')
+          expect((requestSpan as any)._logs[len - 1].fields[LOG_FIELDS.ERROR_ID]).toBeDefined()
+          expect((requestSpan as any)._logs[len - 1].fields[LOG_FIELDS.ERROR_KIND]).toBeDefined()
+          expect((requestSpan as any)._logs[len - 1].fields.error.message).toEqual(
             testSuiteConfig.expects.error!.errorMessage
           )
         })

--- a/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/spanSetup.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/spanSetup.ts
@@ -2,6 +2,7 @@ import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import buildFullPath from 'axios/lib/core/buildFullPath'
 import { Span } from 'opentracing'
 import { ROUTER_CACHE_HEADER } from '../../../../../../constants'
+import { LOG_FIELDS } from '../../../../../../tracing/LogFields'
 import { Tags } from '../../../../../../tracing/Tags'
 
 export const injectRequestInfoOnSpan = (span: Span, http: AxiosInstance, config: AxiosRequestConfig) => {
@@ -19,7 +20,7 @@ export const injectRequestInfoOnSpan = (span: Span, http: AxiosInstance, config:
     [Tags.HTTP_RETRY_COUNT]: (config as any).retryCount || 0,
   })
 
-  span.log({ event: 'request-headers', headers: config.headers })
+  span.log({ [LOG_FIELDS.EVENT]: 'request-headers', headers: config.headers })
 }
 
 // Response may be undefined in case of client timeout, invalid URL, ...
@@ -29,7 +30,7 @@ export const injectResponseInfoOnSpan = (span: Span, response: AxiosResponse | n
     return
   }
 
-  span.log({ event: 'response-headers', headers: response.headers })
+  span.log({ [LOG_FIELDS.EVENT]: 'response-headers', headers: response.headers })
   span.setTag(Tags.HTTP_STATUS_CODE, response.status)
   if (response.headers[ROUTER_CACHE_HEADER]) {
     span.setTag(Tags.HTTP_ROUTER_CACHE, response.headers[ROUTER_CACHE_HEADER])

--- a/src/tracing/LogFields.ts
+++ b/src/tracing/LogFields.ts
@@ -3,15 +3,13 @@
 // When using span.log({ field1: string1, field2: object2, ... })
 // The jaeger backend indexes for search the first-level fields that hold strings
 // These fields then can be searched on jaeger-ui using: 'field1=string'
-// This file concentrates all log fieds used in node-vtex-api that hold
+// This file concentrates all log fields used in node-vtex-api that hold
 // strings and can be searched in the jaeger-ui
 
 const ERROR_REPORT = {
   // ErrorReport class has some meta info on the error
-  // The following log fieds hold this meta info
+  // The following log fields hold this meta info
   ERROR_KIND: 'error.kind',
-  // tslint:disable-
-
   ERROR_ID: 'error.id',
 
   // VTEX's Infra errors adds error details to the response

--- a/src/tracing/LogFields.ts
+++ b/src/tracing/LogFields.ts
@@ -1,0 +1,26 @@
+/* tslint:disable:object-literal-sort-keys */
+
+// When using span.log({ field1: string1, field2: object2, ... })
+// The jaeger backend indexes for search the first-level fields that hold strings
+// These fields then can be searched on jaeger-ui using: 'field1=string'
+// This file concentrates all log fieds used in node-vtex-api that hold
+// strings and can be searched in the jaeger-ui
+
+const ERROR_REPORT = {
+  // ErrorReport class has some meta info on the error
+  // The following log fieds hold this meta info
+  ERROR_KIND: 'error.kind',
+  // tslint:disable-
+
+  ERROR_ID: 'error.id',
+
+  // VTEX's Infra errors adds error details to the response
+  // The following log fields are supposed to hold these fields
+  ERROR_SERVER_CODE: 'error.server.code',
+  ERROR_SERVER_REQUEST_ID: 'error.server.request_id',
+}
+
+export const LOG_FIELDS = {
+  EVENT: 'event',
+  ...ERROR_REPORT,
+}

--- a/src/tracing/Tags.ts
+++ b/src/tracing/Tags.ts
@@ -16,15 +16,7 @@ const APP_TAGS = {
   VTEX_APP_WORKSPACE: 'app.workspace',
 }
 
-const ERROR_REPORT_TAGS = {
-  ERROR_KIND: 'error.kind',
-  ERROR_SERVER_CODE: 'error.server.code',
-  ERROR_SERVER_REQUEST_ID: 'error.server.request_id',
-  ERROR_SERVER_SOURCE: 'error.server.source',
-}
-
 export const USERLAND_TAGS = {
-  ...ERROR_REPORT_TAGS,
   ...opentracingTags,
 }
 

--- a/src/tracing/errorReporting/ErrorReport.ts
+++ b/src/tracing/errorReporting/ErrorReport.ts
@@ -8,6 +8,7 @@ import {
 import { Span } from 'opentracing'
 import { TracingTags } from '..'
 import { IOContext } from '../../service/worker/runtime/typings'
+import { LOG_FIELDS } from '../LogFields'
 import { getTraceInfo } from '../utils'
 
 export class ErrorReport extends ErrorReportBase {
@@ -17,22 +18,26 @@ export class ErrorReport extends ErrorReportBase {
 
   public injectOnSpan(span: Span, logger?: IOContext['logger']) {
     span.setTag(TracingTags.ERROR, 'true')
-    span.setTag(TracingTags.ERROR_KIND, this.kind)
+
+    const indexedLogs: Record<string, string> = {
+      [LOG_FIELDS.ERROR_KIND]: this.kind,
+      [LOG_FIELDS.ERROR_ID]: this.metadata.errorId,
+    }
 
     if (
       isRequestInfo(this.parsedInfo) &&
       this.parsedInfo.response &&
       isInfraErrorData(this.parsedInfo.response?.data)
     ) {
-      span.setTag(TracingTags.ERROR_SERVER_CODE, this.parsedInfo.response.data.code)
-      span.setTag(TracingTags.ERROR_SERVER_SOURCE, this.parsedInfo.response.data.source)
-      span.setTag(TracingTags.ERROR_SERVER_REQUEST_ID, this.parsedInfo.response.data.requestId)
+      indexedLogs[LOG_FIELDS.ERROR_SERVER_CODE] = this.parsedInfo.response.data.code
+      indexedLogs[LOG_FIELDS.ERROR_SERVER_REQUEST_ID] = this.parsedInfo.response.data.requestId
     }
 
-    span.log({ event: 'error', ...this.toObject() })
+    const serializableError = this.toObject()
+    span.log({ [LOG_FIELDS.EVENT]: 'error', ...indexedLogs, error: serializableError })
 
     if (logger && this.shouldLogToSplunk(span)) {
-      logger.error(this.toObject())
+      logger.error(serializableError)
       this.markErrorAsReported()
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Previously error metadata was added to the span tags - this wouldn't allow more than one error ocurring in an span. This was chosen because these tags are indexed for search in jaeger, but log fields are indexed as well, so we can move this data to span logs.

Also added documentation on these log fields.

#### How should this be manually tested?
Send a request with `jaeger-debug-id: anything` header to an endpoint that will error. Search this error on jaeger-ui and check the error log.

#### Types of changes
* [X] Minor improvement
* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
