### PR TITLE
Log incoming and outgoing headers on span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - [ErrorReport] Log ErrorReport errors created on `HttpClient` requests or thrown by user handlers to splunk.
 - [ErrorReport] Add error metadata on span logs instead of on span tags.
+- [tracing:entrypoint] Log incoming request headers and outgoing response headers.
+
+### Fixed
+- [tracing:entrypoint] Fix URL tag on entrypoint span - use `ctx.request.href` instead of `ctx.request.originalUrl`.
 
 ## [6.30.0] - 2020-05-20
 

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -31,6 +31,8 @@ export const addTracingMiddleware = (tracer: Tracer) => {
 
     ctx.tracing = { currentSpan, tracer }
 
+    currentSpan.log({ event: 'request-headers', headers: ctx.request.headers })
+
     try {
       await next()
     } catch (err) {
@@ -38,6 +40,7 @@ export const addTracingMiddleware = (tracer: Tracer) => {
       throw err
     } finally {
       currentSpan.setTag(Tags.HTTP_STATUS_CODE, ctx.response.status)
+      currentSpan.log({ event: 'response-headers', headers: ctx.response.headers })
       currentSpan.finish()
 
       const traceInfo = getTraceInfo(currentSpan)

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -20,7 +20,7 @@ export const addTracingMiddleware = (tracer: Tracer) => {
       childOf: rootSpan,
       tags: {
         [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_SERVER,
-        [Tags.HTTP_URL]: ctx.request.originalUrl,
+        [Tags.HTTP_URL]: ctx.request.href,
         [Tags.HTTP_METHOD]: ctx.request.method,
         [Tags.HTTP_PATH]: ctx.request.path,
         [Tags.VTEX_REQUEST_ID]: ctx.get(REQUEST_ID_HEADER),


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Log incoming and outgoing headers on entrypoint span
- Fix `http.url` tag on entrypoint span (`ctx.request.originalUrl` had only the `path`, `ctx.request.href` has the full url)

#### How should this be manually tested?
- Link an app with this @vtex/api
- Do a request with `jaeger-debug-id: anyStringHere` header
- Check the request to your app on http://jaeger.devs-b.ingress.vtex.io
- Open the first span created and check its logs and `http.url` tag

#### Screenshots or example usage

![Screenshot from 2020-05-18 14-20-39](https://user-images.githubusercontent.com/26463288/82241584-cb731780-9912-11ea-8596-7ebb54b7cee0.png)


#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
