### PR TITLE
Log ErrorReports created on HttpClient or thrown by user handlers to splunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- [tracing:ErrorReport] Log ErrorReport errors created on `HttpClient` requests or thrown by user handlers to splunk.
+
 ## [6.28.3] - 2020-05-15
 ### Fixed
 - [ErrorReport] Update `@vtex/node-error-report` package:

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -36,7 +36,8 @@ type ClientOptions = IOContext & Partial<InstanceOptions>
 export class HttpClient {
   public name: string
 
-  private tracer?: IUserLandTracer
+  private tracer: IOContext['tracer']
+  private logger: IOContext['logger']
   private runMiddlewares: compose.ComposedMiddleware<MiddlewareContext>
 
   public constructor(opts: ClientOptions) {
@@ -70,10 +71,13 @@ export class HttpClient {
       exponentialBackoffCoefficient,
       httpsAgent,
       tracer,
+      logger,
     } = opts
     this.name = name || baseURL || 'unknown'
 
     this.tracer = tracer
+    this.logger = logger
+
     const limit = concurrency && concurrency > 0 && pLimit(concurrency) || undefined
     const headers: Record<string, string> = {
       ...defaultHeaders,
@@ -177,6 +181,7 @@ export class HttpClient {
   protected request = async (config: RequestConfig): Promise<AxiosResponse> => {
     (config as TraceableRequestConfig).tracing = this.tracer ? { 
       ...config.tracing,
+      logger: this.logger,
       tracer: this.tracer,
     } : undefined
 

--- a/src/HttpClient/middlewares/request/setupAxios/__tests__/TracedTestRequest.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/__tests__/TracedTestRequest.ts
@@ -1,6 +1,7 @@
 import { MockReport, MockSpan } from '@tiagonapoli/opentracing-alternate-mock'
 import { AxiosInstance, AxiosResponse } from 'axios'
 import { Span } from 'opentracing'
+import { Logger } from '../../../../../service/logger'
 import { RequestTracingConfig, TraceableRequestConfig } from '../../../../typings'
 import { TestTracer } from './TestTracer'
 
@@ -63,6 +64,13 @@ export class TracedTestRequest {
         ...reqConf,
         tracing: {
           ...reqConf.tracing,
+          logger: new Logger({
+            account: 'mock-account',
+            operationId: 'mock-operation-id',
+            production: false,
+            requestId: 'mock-request-id',
+            workspace: 'mock-workspace',
+          }),
           rootSpan: (this.rootSpan as unknown) as Span,
           tracer: this.tracer,
         },

--- a/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/index.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/index.ts
@@ -67,7 +67,7 @@ const onResponseError = (err: any) => {
 
   const { requestSpan } = err.config.tracing
   injectResponseInfoOnSpan(requestSpan, err.response)
-  injectErrorOnSpan(requestSpan, err)
+  injectErrorOnSpan(requestSpan, err, err.config.tracing.logger)
   requestSpan.finish()
   return Promise.reject(err)
 }

--- a/src/HttpClient/typings.ts
+++ b/src/HttpClient/typings.ts
@@ -4,6 +4,7 @@ import { Span } from 'opentracing'
 
 import { CacheLayer } from '../caches/CacheLayer'
 import { MetricsAccumulator } from '../metrics/MetricsAccumulator'
+import { IOContext } from '../service/worker/runtime/typings'
 import { SpanReferenceTypes } from '../tracing'
 import { IUserLandTracer } from '../tracing/UserLandTracer'
 import { Cached, CacheType } from './middlewares/cache'
@@ -18,6 +19,7 @@ interface RequestTracingUserConfiguration {
 
 export interface AxiosTracingConfig extends RequestTracingUserConfiguration {
   tracer: IUserLandTracer
+  logger: IOContext['logger']
 }
 
 export interface TraceableRequestConfig extends RequestConfig {

--- a/src/service/tracing/spanSetup.ts
+++ b/src/service/tracing/spanSetup.ts
@@ -1,7 +1,8 @@
 import { Span } from 'opentracing'
 import { ErrorReport } from '../../tracing'
+import { IOContext } from '../worker/runtime/typings'
 
-export const injectErrorOnSpan = (span: Span, err: Error | ErrorReport) => {
+export const injectErrorOnSpan = (span: Span, err: Error | ErrorReport, logger: IOContext['logger'] | undefined) => {
   let errorReport: ErrorReport
   if (!(err instanceof ErrorReport)) {
     errorReport = ErrorReport.create({
@@ -12,5 +13,5 @@ export const injectErrorOnSpan = (span: Span, err: Error | ErrorReport) => {
     errorReport = err
   }
 
-  errorReport.injectOnSpan(span)
+  errorReport.injectOnSpan(span, logger)
 }

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -34,14 +34,14 @@ export const addTracingMiddleware = (tracer: Tracer) => {
     try {
       await next()
     } catch (err) {
-      injectErrorOnSpan(currentSpan, err)
+      injectErrorOnSpan(currentSpan, err, ctx.vtex?.logger)
       throw err
     } finally {
       currentSpan.setTag(Tags.HTTP_STATUS_CODE, ctx.response.status)
       currentSpan.finish()
 
       const traceInfo = getTraceInfo(currentSpan)
-      if(traceInfo.isSampled) {
+      if (traceInfo.isSampled) {
         ctx.set(TRACE_ID_HEADER, traceInfo.traceId)
       }
     }
@@ -68,7 +68,7 @@ export const traceUserLandRemainingPipelineMiddleware = (spanName: string, tags:
     try {
       await next()
     } catch (err) {
-      injectErrorOnSpan(span, err)
+      injectErrorOnSpan(span, err, ctx.vtex.logger)
       throw err
     } finally {
       ctx.tracing = tracingCtx

--- a/src/tracing/errorReporting/ErrorReport.ts
+++ b/src/tracing/errorReporting/ErrorReport.ts
@@ -40,6 +40,6 @@ export class ErrorReport extends ErrorReportBase {
   }
 
   private shouldLogToSplunk(span: Span) {
-    return this.isErrorReported() && getTraceInfo(span).isSampled
+    return !this.isErrorReported() && getTraceInfo(span).isSampled
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Log errors thrown by user handlers to node-vtex-api to splunk (when the request is traced and after converting these errors to ErrorReport).
- Log errors thrown by `HttpClient` requests to splunk (when the request is traced and after converting these errors to ErrorReport) 

This will allow to use splunk to search for these errors.

#### How should this be manually tested?
- Link this @vtex/api
- Create an app with a handler that throws an error
- Send a request to this app with the header `jaeger-debug-id: anyStringHere`
- Search `index=io_vtex_logs app=yourApp level=error` and check if the errorReport is there:

#### Screenshots or example usage

![Screenshot from 2020-05-18 16-35-34](https://user-images.githubusercontent.com/26463288/82252577-a20fb700-9925-11ea-9957-94c16e4eca10.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
