### PR TITLE
Add If-Match support to VBase client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support to `If-Match` header usage on VBase client.
+
 ### Changed
 - [ErrorReport] Log ErrorReport errors created on `HttpClient` requests or thrown by user handlers to splunk.
 - [ErrorReport] Add error metadata on span logs instead of on span tags.


### PR DESCRIPTION
#### What is the purpose of this pull request?
To allow all the creatures of this mighty land to use VBase's `If-Match` feature when developing node apps.

On this PR I basically:
- Introduce `getRawJSON` so people can get a `JSON` as response and the respective headers.
- Add a `ifMatch?: string` param to all save/delete functions of the client.

I know it sucks to add an the extra optional parameter and would be much better to have a "options object", but I didn't want to break compatibility with the current API. If you have any idea of how to have both, please let me know.

#### What problem is this solving?
People not being able to use `If-Match` logic on node apps.

#### How should this be manually tested?
I created a simple app which receives a `GET` or `PUT` request and proxies it through the VBase client. I've linked `node-vtex-api` with the app and made sure the `If-Match` logic worked.

#### Screenshots or example usage
:not-sure:

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which hasn't been updated accordingly.
