### PR TITLE
fixed `sort` typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Masterdata sort typing
+
 ## [6.30.0] - 2020-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Masterdata sort typing
+- Masterdata sort typing and scroll pagination
 
 ## [6.30.0] - 2020-05-20
 

--- a/src/clients/external/Masterdata.ts
+++ b/src/clients/external/Masterdata.ts
@@ -285,7 +285,7 @@ interface SearchInput {
   where?: string
   pagination: PaginationArgs
   schema?: string
-  sort?: 'ASC' | 'DESC'
+  sort?: string
 }
 
 interface ScrollInput {
@@ -293,7 +293,7 @@ interface ScrollInput {
   fields: string[]
   pagination: PaginationArgs
   schema?: string
-  sort?: 'ASC' | 'DESC'
+  sort?: string
 }
 
 interface DeleteInput {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix masterdata client sort type

#### What problem is this solving?

Sort is not an enum, it's rather a string field that you have to say which field you want to sort by and the order (e.g. `count DESC`) 🤦🏽‍♂️

#### How should this be manually tested?

Use `searchDocuments` or `scrolDocuments` endpoint of the client

#### Screenshots or example usage

```
 masterdata.scrollDocuments(
    {
      dataEntity: COURSE_ENTITY,
      fields: ['count', 'slug'],
      pagination: { 
        page: 1,
        pageSize: topN
      },
      schema: 'v1',
      sort: 'count DESC',
    }
  )
```

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
