### PR TITLE
Fix/masterdata client issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [tracing:entrypoint] Fix URL tag on entrypoint span - use `ctx.request.href` instead of `ctx.request.originalUrl`.
 
+### Fixed
+
+- Masterdata sort typing
+
 ## [6.30.0] - 2020-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - [tracing:entrypoint] Fix URL tag on entrypoint span - use `ctx.request.href` instead of `ctx.request.originalUrl`.
-
-### Fixed
-
-- Masterdata sort typing
+- Masterdata sort typing and scroll pagination.
 
 ## [6.30.0] - 2020-05-20
 

--- a/src/clients/external/Masterdata.ts
+++ b/src/clients/external/Masterdata.ts
@@ -183,7 +183,7 @@ export class MasterData extends ExternalClient {
   }
 
   public scrollDocuments<T>(
-    { dataEntity, fields, schema, size, sort, token }: ScrollInput,
+    { dataEntity, fields, mdToken, schema, size, sort, }: ScrollInput,
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'masterdata-scrollDocuments'
@@ -194,13 +194,13 @@ export class MasterData extends ExternalClient {
         _schema: schema,
         _size: size,
         _sort: sort,
-        _token: token,
+        _token: mdToken,
       },
       tracing: {
         requestSpanNameSuffix: metric,
         ...tracingConfig?.tracing,
       },
-    }).then(({headers: {'x-vtex-md-token': resToken}, data}) => ({token: resToken, data}))
+    }).then(({headers: {'x-vtex-md-token': resToken}, data}) => ({mdToken: resToken, data}))
   }
 
   public deleteDocument({ dataEntity, id }: DeleteInput, tracingConfig?: RequestTracingConfig) {
@@ -295,7 +295,7 @@ interface ScrollInput {
   schema?: string
   sort?: string
   size?: number
-  token?: string
+  mdToken?: string
 }
 
 interface DeleteInput {
@@ -305,5 +305,5 @@ interface DeleteInput {
 
 interface ScrollResponse<T> {
   data: T[]
-  token: string
+  mdToken: string
 }

--- a/src/clients/external/Masterdata.ts
+++ b/src/clients/external/Masterdata.ts
@@ -292,7 +292,6 @@ interface SearchInput {
 interface ScrollInput {
   dataEntity: string
   fields: string[]
-  pagination: PaginationArgs
   schema?: string
   sort?: string
   size?: number

--- a/src/clients/external/Masterdata.ts
+++ b/src/clients/external/Masterdata.ts
@@ -285,7 +285,7 @@ interface SearchInput {
   where?: string
   pagination: PaginationArgs
   schema?: string
-  sort?: 'ASC' | 'DESC'
+  sort?: string
 }
 
 interface ScrollInput {
@@ -293,7 +293,7 @@ interface ScrollInput {
   fields: string[]
   pagination: PaginationArgs
   schema?: string
-  sort?: 'ASC' | 'DESC'
+  sort?: string
 }
 
 interface DeleteInput {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix masterdata client sort type and scroll api

#### What problem is this solving?

Sort is not an enum, it's rather a string field that you have to say which field you want to sort by and the order (e.g. `count DESC`) 🤦🏽‍♂️, also there was a problem on scroll api documentation, and pagination was wrong

#### How should this be manually tested?

Use `searchDocuments` or `scrolDocuments` endpoint of the client

#### Screenshots or example usage

```
 masterdata.scrollDocuments(
    {
      dataEntity: COURSE_ENTITY,
      fields: ['count', 'slug'],
      size: 4,
      token: '{your_token}',
      schema: 'v1',
      sort: 'count DESC',
    }
  )
```

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
