### PR TITLE
Remove `serverTiming` metrics from client headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.30.1] - 2020-05-21
 ### Changed
 - Remove `serverTiming` metrics from client headers.
 - Add `serverTiming` metrics on error report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove `serverTiming` metrics from client headers.
+- Add `serverTiming` metrics on error report.
 
 ## [6.30.0] - 2020-05-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.30.0",
+  "version": "6.30.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/metrics.ts
+++ b/src/HttpClient/middlewares/metrics.ts
@@ -8,31 +8,11 @@ import {
 import {
   formatTimingName,
   hrToMillis,
-  parseTimingName,
   shrinkTimings,
 } from '../../utils'
 import { TIMEOUT_CODE } from '../../utils/retry'
 import { statusLabel } from '../../utils/status'
 import { MiddlewareContext } from '../typings'
-
-const parseServerTiming = (serverTimingsHeaderValue: string) => compose<string, string, string[], Array<[string, string]>>(
-  reduce((acc, rawHeader) => {
-    const [name, durStr] = rawHeader.split(';')
-    const [_, dur] = durStr ? durStr.split('=') : [null, null]
-    const {hopNumber, source, target} = parseTimingName(name)
-    const formatted = formatTimingName({
-      hopNumber: Number.isNaN(hopNumber as any) ? null : hopNumber! + 1,
-      source,
-      target,
-    })
-    if (dur && formatted) {
-      acc.push([formatted, dur])
-    }
-    return acc
-  }, [] as Array<[string, string]>),
-  split(','),
-  replace(/\s/g, '')
-)(serverTimingsHeaderValue)
 
 interface MetricsOpts {
   metrics?: MetricsAccumulator
@@ -147,20 +127,6 @@ export const metricsMiddleware = ({metrics, serverTiming, name}: MetricsOpts) =>
         const dur = hrToMillis(process.hrtime(serverTimingStart))
         if (!serverTiming[serverTimingLabel] || Number(serverTiming[serverTimingLabel]) < dur) {
           serverTiming[serverTimingLabel] = `${dur}`
-        }
-
-        // Forward server timings
-        const serverTimingsHeader = path<string>(['response', 'headers', 'server-timing'], ctx)
-        if (!ctx.cacheHit && !ctx.inflightHit && !ctx.memoizedHit && serverTimingsHeader) {
-          const parsedServerTiming = parseServerTiming(serverTimingsHeader)
-          forEach(
-            ([timingsName, timingsDur]) => {
-              if (!serverTiming[timingsName] || Number(serverTiming[timingsName]) < Number(timingsDur)) {
-                serverTiming[timingsName] = timingsDur
-              }
-            },
-            parsedServerTiming
-          )
         }
       }
     }

--- a/src/service/worker/runtime/http/middlewares/error.ts
+++ b/src/service/worker/runtime/http/middlewares/error.ts
@@ -72,6 +72,7 @@ export async function error<
           id,
           params,
         },
+        serverTiming,
       },
       headers: {
         'x-forwarded-path': forwardedPath,
@@ -105,6 +106,7 @@ export async function error<
       query,
       requestId,
       routeId: id,
+      serverTiming,
       status,
     }
 

--- a/src/service/worker/runtime/http/middlewares/timings.ts
+++ b/src/service/worker/runtime/http/middlewares/timings.ts
@@ -70,9 +70,4 @@ export async function timings <
   const status = statusLabel(statusCode)
   // Only batch successful responses so metrics don't consider errors
   metrics.batch(`http-handler-${id}`, status === 'success' ? total : undefined, { [status]: 1 })
-
-  if (ctx.serverTiming){
-    ctx.serverTiming[APP_ELAPSED_TIME_LOCATOR] = `${totalMillis}`
-    ctx.set('Server-Timing', reduceTimings(ctx.serverTiming!))
-  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove `serverTiming` metrics from client headers

<!--- Describe your changes in detail. -->
https://app.clubhouse.io/vtex/story/36442/remove-server-timing-header
There is a security report from samsung asking to remove this header from render. As we already have a way to measure this through jaeger spans we are removing them now.

I didn't completely remove the timing calculation because jaeger traces are sampled and those timings might be useful in case of rare errors  that might not appear on jaeger samples. So, we are keeping those server timings on errors logs.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Open the workspace https://jey--storecomponents.myvtex.com with devtools network tab running.

Detailed timings info should be gone.

#### Screenshots or example usage

**Before**
<img width="1678" alt="Screen Shot 2020-05-21 at 16 53 13" src="https://user-images.githubusercontent.com/1594322/82600050-a3d6b600-9b83-11ea-8e5e-21fa737aeac9.png">

**After**
<img width="1674" alt="Screen Shot 2020-05-21 at 16 40 30" src="https://user-images.githubusercontent.com/1594322/82599908-6eca6380-9b83-11ea-9550-5eb83de2ca6a.png">

**Timings sent to splunk**
<img width="1317" alt="Screen Shot 2020-05-21 at 16 38 44" src="https://user-images.githubusercontent.com/1594322/82600072-ac2ef100-9b83-11ea-88e0-aa438b8f20d1.png">

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
