### PR TITLE
Add support for router binding header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.75.0] - 2020-05-28
 ### Added
 - Add support for router binding header format.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for router binding header format.
+
+### Changed
+- Use binding locale in TranslatableV2 directive if present.
 
 ## [3.74.1] - 2020-05-14
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.74.1",
+  "version": "3.75.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
+++ b/src/service/graphql/schema/schemaDirectives/TranslatableV2.ts
@@ -58,7 +58,7 @@ const handleSingleString = (ctx: IOContext, messagesV2: MessagesLoaderV2, behavi
   }
 
   const { content, context, from: maybeFrom } = parseTranslatableStringV2(rawMessage)
-  const { locale: to, tenant } = ctx
+  const { binding, locale: to, tenant } = ctx
 
   if (content == null) {
     throw new Error(`@translatableV2 directive needs a content to translate, but received ${JSON.stringify(rawMessage)}`)
@@ -68,7 +68,7 @@ const handleSingleString = (ctx: IOContext, messagesV2: MessagesLoaderV2, behavi
     throw new Error('@translatableV2 directive needs the locale variable available in IOContext. You can do this by either setting \`ctx.vtex.locale\` directly or calling this app with \`x-vtex-locale\` header')
   }
 
-  const from = maybeFrom || (tenant && tenant.locale)
+  const from = maybeFrom || (binding && binding.locale) || (tenant && tenant.locale)
 
   if (from == null) {
     throw new Error('@translatableV2 directive needs a source language to translate from. You can do this by either setting \`ctx.vtex.tenant\` variable, call this app with the header \`x-vtex-tenant\` or format the string with the \`formatTranslatableStringV2\` function with the \`from\` option set')

--- a/src/utils/binding.ts
+++ b/src/utils/binding.ts
@@ -1,14 +1,50 @@
 export interface Binding {
   id?: string
+  rootPath?: string
   locale: string
+  currency?: string
 }
 
-export const formatBindingHeaderValue = (binding: Binding): string => {
-  const jsonString = JSON.stringify(binding)
-  return Buffer.from(jsonString, 'utf8').toString('base64')
+enum BindingHeaderFormat {
+  webframework0='v0+webframework',
+  kuberouter0='v0+kuberouter'
+}
+
+export const formatBindingHeaderValue = (
+  binding: Binding,
+  format: BindingHeaderFormat = BindingHeaderFormat.webframework0
+): string => {
+  if (format === BindingHeaderFormat.webframework0) {
+    const jsonString = JSON.stringify(binding)
+    return Buffer.from(jsonString, 'utf8').toString('base64')
+  }
+
+  if (format === BindingHeaderFormat.kuberouter0) {
+    return [
+      '0',
+      binding.id || '',
+      binding.rootPath || '',
+      binding.locale || '',
+      binding.currency || ''
+    ].join(',')
+  }
+
+  throw new Error(`Unkown binding format: ${format}`)
 }
 
 export const parseBindingHeaderValue = (value: string): Binding => {
+  if (value[0] === '0' && value[1] === ',') {
+    // v0+kuberouter
+    const [, id, rootPath, locale, currency] = value.split(',')
+    return {
+      currency: currency || undefined,
+      id: id || undefined,
+      locale: locale,
+      rootPath: rootPath || undefined,
+    }
+  }
+
+  // v0+webframework
   const jsonString = Buffer.from(value, 'base64').toString('utf8')
   return JSON.parse(jsonString)
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add support for router binding header.

#### What problem is this solving?
It was already done here: https://github.com/vtex/node-vtex-api/pull/332

This PR is a backport to fix an error when parsing the new value on service-node 5.x apps.

```
SyntaxError: Unexpected token ѯ in JSON at position 0
at JSON.parse (<anonymous>)
at Object.exports.parseBindingHeaderValue (/usr/local/app/node_modules/@vtex/api/lib/utils/binding.js:9:17)
```

It also uses binding locale in the TranslatableV2 directive. It is something that was done in the same PR and was not here.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
