### PR TITLE
Remove unnecessary span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [tracing] Remove span wrapping user middlewares.
 
 ## [6.31.1] - 2020-06-05
 ### Fixed

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -1,8 +1,10 @@
 import { FORMAT_HTTP_HEADERS, SpanContext, Tracer } from 'opentracing'
 import { ACCOUNT_HEADER, REQUEST_ID_HEADER, TRACE_ID_HEADER, WORKSPACE_HEADER } from '../../constants'
 import { ErrorReport, getTraceInfo } from '../../tracing'
+import { LOG_EVENTS } from '../../tracing/LogFields'
 import { Tags } from '../../tracing/Tags'
 import { UserLandTracer } from '../../tracing/UserLandTracer'
+import { hrToMillis } from '../../utils'
 import { ServiceContext } from '../worker/runtime/typings'
 
 const PATHS_BLACKLISTED_FOR_TRACING = ['/metrics', '/_status', '/healthcheck']
@@ -57,24 +59,26 @@ export const nameSpanOperationMiddleware = (operationType: string, operationName
   }
 }
 
-export const traceUserLandRemainingPipelineMiddleware = (spanName: string, tags: Record<string, string> = {}) => {
+export const traceUserLandRemainingPipelineMiddleware = () => {
   return async function traceUserLandRemainingPipeline(ctx: ServiceContext, next: () => Promise<void>) {
     const tracingCtx = ctx.tracing!
     ctx.tracing = undefined
 
-    const span = tracingCtx.tracer.startSpan(spanName, { childOf: tracingCtx.currentSpan, tags })
+    const span = tracingCtx.currentSpan
     const userLandTracer = ctx.vtex.tracer! as UserLandTracer
     userLandTracer.setFallbackSpan(span)
     userLandTracer.lockFallbackSpan()
+    const startTime = process.hrtime()
 
     try {
+      span.log({ event: LOG_EVENTS.USER_MIDDLEWARES_START })
       await next()
     } catch (err) {
       ErrorReport.create({ originalError: err }).injectOnSpan(span, ctx.vtex.logger)
       throw err
     } finally {
+      span.log({ event: LOG_EVENTS.USER_MIDDLEWARES_FINISH, 'duration-ms': hrToMillis(process.hrtime(startTime)) })
       ctx.tracing = tracingCtx
-      span.finish()
     }
   }
 }

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -1,7 +1,7 @@
 import { FORMAT_HTTP_HEADERS, SpanContext, Tracer } from 'opentracing'
 import { ACCOUNT_HEADER, REQUEST_ID_HEADER, TRACE_ID_HEADER, WORKSPACE_HEADER } from '../../constants'
 import { ErrorReport, getTraceInfo } from '../../tracing'
-import { LOG_EVENTS } from '../../tracing/LogFields'
+import { LOG_EVENTS, LOG_FIELDS } from '../../tracing/LogFields'
 import { Tags } from '../../tracing/Tags'
 import { UserLandTracer } from '../../tracing/UserLandTracer'
 import { hrToMillis } from '../../utils'
@@ -77,7 +77,7 @@ export const traceUserLandRemainingPipelineMiddleware = () => {
       ErrorReport.create({ originalError: err }).injectOnSpan(span, ctx.vtex.logger)
       throw err
     } finally {
-      span.log({ event: LOG_EVENTS.USER_MIDDLEWARES_FINISH, 'duration-ms': hrToMillis(process.hrtime(startTime)) })
+      span.log({ event: LOG_EVENTS.USER_MIDDLEWARES_FINISH, [LOG_FIELDS.USER_MIDDLEWARES_DURATION]: hrToMillis(process.hrtime(startTime)) })
       ctx.tracing = tracingCtx
     }
   }

--- a/src/service/worker/runtime/events/index.ts
+++ b/src/service/worker/runtime/events/index.ts
@@ -33,7 +33,7 @@ export const createEventHandler = <T extends IOClients, U extends RecorderState,
     ...(serviceEvent?.settingsType === 'workspace' || serviceEvent?.settingsType === 'userAndWorkspace' ? [getServiceSettings()] : []),
     timings,
     error,
-    traceUserLandRemainingPipelineMiddleware(`user-event-handler:${eventId}`),
+    traceUserLandRemainingPipelineMiddleware(),
     contextAdapter<T, U, V>(middlewares),
   ]
   return compose(pipeline)

--- a/src/service/worker/runtime/http/index.ts
+++ b/src/service/worker/runtime/http/index.ts
@@ -42,7 +42,7 @@ export const createPrivateHttpRoute = <T extends IOClients, U extends RecorderSt
     ...(serviceRoute.settingsType === 'workspace' || serviceRoute.settingsType === 'userAndWorkspace' ? [getServiceSettings()] : []),
     timings,
     error,
-    traceUserLandRemainingPipelineMiddleware(`user-private-handler:${routeId}`),
+    traceUserLandRemainingPipelineMiddleware(),
     ...middlewares,
   ]
   return compose(pipeline)
@@ -68,7 +68,7 @@ export const createPublicHttpRoute = <T extends IOClients, U extends RecorderSta
     removeSetCookie,
     timings,
     error,
-    traceUserLandRemainingPipelineMiddleware(`user-public-handler:${routeId}`),
+    traceUserLandRemainingPipelineMiddleware(),
     ...middlewares,
   ]
   return compose(pipeline)

--- a/src/tracing/LogFields.ts
+++ b/src/tracing/LogFields.ts
@@ -1,19 +1,25 @@
 /* tslint:disable:object-literal-sort-keys */
 
-// When using span.log({ field1: string1, field2: object2, ... })
-// The jaeger backend indexes for search the first-level fields that hold strings
-// These fields then can be searched on jaeger-ui using: 'field1=string'
-// This file concentrates all log fields used in node-vtex-api that hold
-// strings and can be searched in the jaeger-ui
+/**
+ * When using span.log({ field1: string1, field2: object2, ... })
+ * The jaeger backend indexes for search the first-level fields that hold strings
+ * These fields then can be searched on jaeger-ui using: 'field1=string'
+ * This file concentrates all log fields used in node-vtex-api that hold
+ * strings and can be searched in the jaeger-ui
+ */
 
 const ERROR_REPORT = {
-  // ErrorReport class has some meta info on the error
-  // The following log fields hold this meta info
+  /**
+   * ErrorReport class has some meta info on the error
+   * The following log fields hold this meta info
+   */
   ERROR_KIND: 'error.kind',
   ERROR_ID: 'error.id',
 
-  // VTEX's Infra errors adds error details to the response
-  // The following log fields are supposed to hold these fields
+  /**
+   * VTEX's Infra errors adds error details to the response
+   * The following log fields are supposed to hold these fields
+   */
   ERROR_SERVER_CODE: 'error.server.code',
   ERROR_SERVER_REQUEST_ID: 'error.server.request_id',
 }
@@ -21,4 +27,12 @@ const ERROR_REPORT = {
 export const LOG_FIELDS = {
   EVENT: 'event',
   ...ERROR_REPORT,
+}
+
+export const LOG_EVENTS = {
+  /** Event representing that userland middlewares are about to start */
+  USER_MIDDLEWARES_START: 'user-middlewares-start',
+
+  /** Event representing that userland middlewares just finished */
+  USER_MIDDLEWARES_FINISH: 'user-middlewares-finish',
 }

--- a/src/tracing/LogFields.ts
+++ b/src/tracing/LogFields.ts
@@ -26,6 +26,9 @@ const ERROR_REPORT = {
 
 export const LOG_FIELDS = {
   EVENT: 'event',
+  
+  /** Time in ms spent to run the user middlewares */
+  USER_MIDDLEWARES_DURATION: 'user-middlewares-duration',
   ...ERROR_REPORT,
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

In the initial runtime native instrumentation a span wrapping the user middlewares was created, however no useful tags or logs was added to it, so I think it just added complexity to the traces, by adding an additional parent-child relationship. The useful thing about this span was to observe the runtime's middlewares overhead, but this could be solved by adding logs to the entrypoint span - and this overhead in many times was negligble compared to the full tracing, so the entrypoint span and the span wrapping the user middlewares often appeared to have almost the same sizes:

![Screenshot from 2020-06-12 20-54-18](https://user-images.githubusercontent.com/26463288/84554686-67fcbf80-acef-11ea-9193-6a76386c8f8e.png)

![Screenshot from 2020-06-12 20-54-28](https://user-images.githubusercontent.com/26463288/84554688-692dec80-acef-11ea-8729-d8ccd1fa4bc9.png)

![Screenshot from 2020-06-12 20-54-47](https://user-images.githubusercontent.com/26463288/84554693-71862780-acef-11ea-9edc-1f1291a1afc5.png)

This PR proposes to remove this span and add logs onto the entrypoint span marking the moments in which the user middlewares started and finished:

![Screenshot from 2020-06-12 20-59-26](https://user-images.githubusercontent.com/26463288/84554740-b1e5a580-acef-11ea-9f68-e39107af6f30.png)

The runtime overhead is easily calculated by subtracting the `duration-ms` from the entrypoint span duration.

#### Types of changes
* [X] Refactor
* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
