### PR TITLE
Make entrypoint span headers searcheable on Jaeger

### DIFF
--- a/src/utils/addPrefixOntoObjectKeys.ts
+++ b/src/utils/addPrefixOntoObjectKeys.ts
@@ -1,0 +1,8 @@
+export const addPrefixOntoObjectKeys = (prefix: string, obj: Record<string, string>) => {
+  const ret: Record<string, string> = {}
+  const entries = Object.entries(obj)
+  for (const [key, val] of entries) {
+    ret[`${prefix}.${key}`] = val
+  }
+  return ret
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Log fields can be searched on Jaeger UI, however object log entries can't be searched, only string/number and boolean entries. Currently the entrypoint headers are logged in the format:

![Screenshot from 2020-06-17 16-00-08](https://user-images.githubusercontent.com/26463288/84938681-de187200-b0b3-11ea-82de-2dd98dcf9dc4.png)

Then you can't search for `headers.vary="Accept-Encoding"` for example. This PR proposes to change the format to:

![Screenshot from 2020-06-17 16-05-01](https://user-images.githubusercontent.com/26463288/84939181-54b56f80-b0b4-11ea-90ef-7a3ff0791f38.png)

Then one can search for `res.headers.cache-control="no-cache, no-store"` - searching for headers can be useful in cases we know the exact value we want to search for - unfortunately jaeger doesn't support regex searches yet, but there are already issues on the jaegertracing repo.

A decision I made that can be discussed is: Add the headers as tags or logs? 

I think that semantically maybe it would be better to add as tags, since maybe it doesn't make much sense to assign a timestamp to these headers. However, when I tested them as tags it seemed too messy and cluttered to analyze them - using them as logs we can separate them into two logs, one just for incoming headers and one for outgoing headers.

Another thing this PR does is change the moment the Tags and Logs are assigned to the entrypoint Span. They are now assigned just before finishing the span, after running all the middlewares. 
I based this decision on the fact that if the trace is decided not to be sampled the operations to add tags and logs to a span are no-op for better performance. However some apps (builder-hub and monitoring-proxy) override in the user middlewares the sampling decision, using the `SAMPLING_PRIORITY = 1`, and then their traces didn't have some important tags on the entrypoint span. Changing the order of assigning tags and logs solved this issue.

A trace example using this PR is: http://jaeger.devs-b.ingress.vtex.io/trace/e03ddf59405ff6c7

#### Types of changes
?

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
