### PR TITLE
Improve HTTP request tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [clients:tracing] Create span wrapping HttpClient middlewares with information on caching and retries.
 
 ## [6.32.0] - 2020-06-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.33.0] - 2020-06-25
 ### Added
 - [clients:tracing] Create span wrapping HttpClient middlewares with information on caching and retries.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.32.0",
+  "version": "6.33.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -91,20 +91,17 @@ export const cacheMiddleware = ({ type, storage }: CacheOptions) => {
     }
 
     const span = ctx.tracing!.rootSpan
-    const isTraceSampled = ctx.tracing!.isSampled
 
     const key = cacheKey(ctx.config)
     const segmentToken = ctx.config.headers[SEGMENT_HEADER]
     const keyWithSegment = key + segmentToken
 
-    if(isTraceSampled) {
-      span.log({
-        event: HttpLogEvents.CACHE_KEY_CREATE,
-        [HttpCacheLogFields.CACHE_TYPE]: cacheType,
-        [HttpCacheLogFields.KEY]: key,
-        [HttpCacheLogFields.KEY_WITH_SEGMENT]: keyWithSegment,
-      })
-    }
+    span.log({
+      event: HttpLogEvents.CACHE_KEY_CREATE,
+      [HttpCacheLogFields.CACHE_TYPE]: cacheType,
+      [HttpCacheLogFields.KEY]: key,
+      [HttpCacheLogFields.KEY_WITH_SEGMENT]: keyWithSegment,
+    })
 
     const cacheHasWithSegment = await storage.has(keyWithSegment)
     const cached = cacheHasWithSegment ? await storage.get(keyWithSegment) : await storage.get(key)
@@ -118,16 +115,14 @@ export const cacheMiddleware = ({ type, storage }: CacheOptions) => {
 
       const now = Date.now()
 
-      if (isTraceSampled) {
-        span.log({
-          event: HttpLogEvents.LOCAL_CACHE_HIT_INFO,
-          [HttpCacheLogFields.CACHE_TYPE]: cacheType,
-          [HttpCacheLogFields.ETAG]: cachedEtag,
-          [HttpCacheLogFields.EXPIRATION_TIME]: (expiration-now)/1000,
-          [HttpCacheLogFields.RESPONSE_TYPE]: responseType,
-          [HttpCacheLogFields.RESPONSE_ENCONDING]: responseEncoding,
-        })
-      }
+      span.log({
+        event: HttpLogEvents.LOCAL_CACHE_HIT_INFO,
+        [HttpCacheLogFields.CACHE_TYPE]: cacheType,
+        [HttpCacheLogFields.ETAG]: cachedEtag,
+        [HttpCacheLogFields.EXPIRATION_TIME]: (expiration-now)/1000,
+        [HttpCacheLogFields.RESPONSE_TYPE]: responseType,
+        [HttpCacheLogFields.RESPONSE_ENCONDING]: responseEncoding,
+      })
 
       if (expiration > now) {
         ctx.response = response as AxiosResponse
@@ -173,26 +168,21 @@ export const cacheMiddleware = ({ type, storage }: CacheOptions) => {
     const {forceMaxAge} = ctx.config
     const maxAge = forceMaxAge && cacheableStatusCodes.includes(status) ? Math.max(forceMaxAge, headerMaxAge) : headerMaxAge
 
-    if (isTraceSampled) {
-      span.log({
-        event: HttpLogEvents.CACHE_CONFIG,
-        [HttpCacheLogFields.CACHE_TYPE]: cacheType,
-        [HttpCacheLogFields.AGE]: age,
-        [HttpCacheLogFields.CALCULATED_MAX_AGE]: maxAge,
-        [HttpCacheLogFields.MAX_AGE]: headerMaxAge,
-        [HttpCacheLogFields.FORCE_MAX_AGE]: forceMaxAge,
-        [HttpCacheLogFields.ETAG]: etag,
-        [HttpCacheLogFields.NO_CACHE]: noCache,
-        [HttpCacheLogFields.NO_STORE]: noStore,
-      })
-    }
+    span.log({
+      event: HttpLogEvents.CACHE_CONFIG,
+      [HttpCacheLogFields.CACHE_TYPE]: cacheType,
+      [HttpCacheLogFields.AGE]: age,
+      [HttpCacheLogFields.CALCULATED_MAX_AGE]: maxAge,
+      [HttpCacheLogFields.MAX_AGE]: headerMaxAge,
+      [HttpCacheLogFields.FORCE_MAX_AGE]: forceMaxAge,
+      [HttpCacheLogFields.ETAG]: etag,
+      [HttpCacheLogFields.NO_CACHE]: noCache,
+      [HttpCacheLogFields.NO_STORE]: noStore,
+    })
 
     // Indicates this should NOT be cached and this request will not be considered a miss.
     if (!forceMaxAge && (noStore || (noCache && !etag))) {
-      if(isTraceSampled) {
-        span.log({ event: HttpLogEvents.NO_LOCAL_CACHE_SAVE, [HttpCacheLogFields.CACHE_TYPE]: cacheType })
-      }
-
+      span.log({ event: HttpLogEvents.NO_LOCAL_CACHE_SAVE, [HttpCacheLogFields.CACHE_TYPE]: cacheType })
       return
     }
 
@@ -217,25 +207,21 @@ export const cacheMiddleware = ({ type, storage }: CacheOptions) => {
         responseType,
       })
 
-      if(isTraceSampled) {
-        span.log({
-          event: HttpLogEvents.LOCAL_CACHE_SAVED,
-          [HttpCacheLogFields.CACHE_TYPE]: cacheType,
-          [HttpCacheLogFields.KEY_SET]: setKey,
-          [HttpCacheLogFields.AGE]: currentAge,
-          [HttpCacheLogFields.ETAG]: etag,
-          [HttpCacheLogFields.EXPIRATION_TIME]: (expiration - Date.now())/1000,
-          [HttpCacheLogFields.RESPONSE_ENCONDING]: responseEncoding,
-          [HttpCacheLogFields.RESPONSE_TYPE]: responseType,
-        })
-      }
+      span.log({
+        event: HttpLogEvents.LOCAL_CACHE_SAVED,
+        [HttpCacheLogFields.CACHE_TYPE]: cacheType,
+        [HttpCacheLogFields.KEY_SET]: setKey,
+        [HttpCacheLogFields.AGE]: currentAge,
+        [HttpCacheLogFields.ETAG]: etag,
+        [HttpCacheLogFields.EXPIRATION_TIME]: (expiration - Date.now())/1000,
+        [HttpCacheLogFields.RESPONSE_ENCONDING]: responseEncoding,
+        [HttpCacheLogFields.RESPONSE_TYPE]: responseType,
+      })
 
       return
     }
 
-    if(isTraceSampled) {
-      span.log({ event: HttpLogEvents.NO_LOCAL_CACHE_SAVE, [HttpCacheLogFields.CACHE_TYPE]: cacheType })
-    }
+    span.log({ event: HttpLogEvents.NO_LOCAL_CACHE_SAVE, [HttpCacheLogFields.CACHE_TYPE]: cacheType })
   }
 }
 

--- a/src/HttpClient/middlewares/memoization.ts
+++ b/src/HttpClient/middlewares/memoization.ts
@@ -18,14 +18,11 @@ export const memoizationMiddleware = ({ memoizedCache }: MemoizationOptions) => 
     }
 
     const span = ctx.tracing!.rootSpan
-    const isTraceSampled = ctx.tracing!.isSampled
 
     const key = cacheKey(ctx.config)
     const isMemoized = !!memoizedCache.has(key)
 
-    if(isTraceSampled) {
-      span.log({ event: HttpLogEvents.CACHE_KEY_CREATE, [HttpCacheLogFields.CACHE_TYPE]: 'memoization', [HttpCacheLogFields.KEY]: key })
-    }
+    span.log({ event: HttpLogEvents.CACHE_KEY_CREATE, [HttpCacheLogFields.CACHE_TYPE]: 'memoization', [HttpCacheLogFields.KEY]: key })
 
     if (isMemoized) {
       span.setTag(CustomHttpTags.HTTP_MEMOIZATION_CACHE_RESULT, CacheResult.HIT)
@@ -43,15 +40,10 @@ export const memoizationMiddleware = ({ memoizedCache }: MemoizationOptions) => 
             response: ctx.response!,
           })
 
-          if(isTraceSampled) {
-            span.log({ event: HttpLogEvents.MEMOIZATION_CACHE_SAVED, [HttpCacheLogFields.KEY_SET]: key })
-          }
+          span.log({ event: HttpLogEvents.MEMOIZATION_CACHE_SAVED, [HttpCacheLogFields.KEY_SET]: key })
         } catch (err) {
           reject(err)
-
-          if(isTraceSampled) {
-            span.log({ event: HttpLogEvents.MEMOIZATION_CACHE_SAVED_ERROR, [HttpCacheLogFields.KEY_SET]: key })
-          }
+          span.log({ event: HttpLogEvents.MEMOIZATION_CACHE_SAVED_ERROR, [HttpCacheLogFields.KEY_SET]: key })
         }
       })
       memoizedCache.set(key, promise)

--- a/src/HttpClient/middlewares/request/index.ts
+++ b/src/HttpClient/middlewares/request/index.ts
@@ -1,8 +1,11 @@
 import { AxiosRequestConfig } from 'axios'
+import buildFullPath from 'axios/lib/core/buildFullPath'
 import { Limit } from 'p-limit'
 import { stringify } from 'qs'
-import { path, toLower } from 'ramda'
+import { toLower } from 'ramda'
 
+
+import { CustomHttpTags, OpentracingTags } from '../../../tracing/Tags'
 import { renameBy } from '../../../utils/renameBy'
 import { MiddlewareContext } from '../../typings'
 import { getConfiguredAxios } from './setupAxios'
@@ -29,7 +32,7 @@ export interface DefaultMiddlewareArgs {
 export const defaultsMiddleware = ({ baseURL, rawHeaders, params, timeout, retries, verbose, exponentialTimeoutCoefficient, initialBackoffDelay, exponentialBackoffCoefficient, httpsAgent }: DefaultMiddlewareArgs) => {
   const countByMetric: Record<string, number> = {}
   const headers = renameBy(toLower, rawHeaders)
-  return async (ctx: MiddlewareContext, next: () => Promise<void>) => {
+  return (ctx: MiddlewareContext, next: () => Promise<void>) => {
     ctx.config = {
       baseURL,
       exponentialBackoffCoefficient,
@@ -61,21 +64,34 @@ export const defaultsMiddleware = ({ baseURL, rawHeaders, params, timeout, retri
       ctx.config.label = `${ctx.config.metric}#${ctx.config.count}`
     }
 
-    await next()
+
+    if(ctx.tracing!.isSampled) {
+      const { config } = ctx
+      const fullUrl = buildFullPath(config.baseURL, http.getUri(config))
+      ctx.tracing!.rootSpan.addTags({
+        [OpentracingTags.HTTP_METHOD]: config.method || 'get',
+        [OpentracingTags.HTTP_URL]: fullUrl,
+      })
+    }
+
+    return next()
   }
 }
 
 const ROUTER_CACHE_KEY = 'x-router-cache'
 const ROUTER_CACHE_HIT = 'HIT'
 const ROUTER_CACHE_REVALIDATED = 'REVALIDATED'
-const ROUTER_CACHE_KEY_PATH = ['response', 'headers', ROUTER_CACHE_KEY]
-const ROUTER_RESPONSE_STATUS_PATH = ['response', 'status']
 
 export const routerCacheMiddleware = async (ctx: MiddlewareContext, next: () => Promise<void>) => {
   await next()
 
-  const routerCacheHit = path(ROUTER_CACHE_KEY_PATH, ctx)
-  const status = path(ROUTER_RESPONSE_STATUS_PATH, ctx)
+  const routerCacheHit = ctx.response?.headers?.[ROUTER_CACHE_KEY]
+  const status = ctx.response?.status
+
+  if(routerCacheHit) {
+    ctx.tracing!.rootSpan.setTag(CustomHttpTags.HTTP_ROUTER_CACHE_RESULT, routerCacheHit)
+  }
+
   if (routerCacheHit === ROUTER_CACHE_HIT || (routerCacheHit === ROUTER_CACHE_REVALIDATED && status !== 304)) {
     ctx.cacheHit = {
       memory: 0,

--- a/src/HttpClient/middlewares/request/setupAxios/__tests__/TracedTestRequest.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/__tests__/TracedTestRequest.ts
@@ -3,8 +3,8 @@ import { AxiosInstance, AxiosResponse } from 'axios'
 import { Span } from 'opentracing'
 import { Logger } from '../../../../../service/logger'
 import { RequestTracingConfig } from '../../../../typings'
-import { TestTracer } from './TestTracer'
 import { TraceableRequestConfig } from '../../../tracing'
+import { TestTracer } from './TestTracer'
 
 interface TracedTestRequestConfig extends RequestTracingConfig {
   url: string
@@ -65,6 +65,7 @@ export class TracedTestRequest {
         ...reqConf,
         tracing: {
           ...reqConf.tracing,
+          isSampled: true,
           logger: new Logger({
             account: 'mock-account',
             operationId: 'mock-operation-id',
@@ -74,7 +75,6 @@ export class TracedTestRequest {
           }),
           rootSpan: (this.rootSpan as unknown) as Span,
           tracer: this.tracer,
-          isSampled: true
         },
       }
 

--- a/src/HttpClient/middlewares/request/setupAxios/__tests__/TracedTestRequest.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/__tests__/TracedTestRequest.ts
@@ -2,8 +2,9 @@ import { MockReport, MockSpan } from '@tiagonapoli/opentracing-alternate-mock'
 import { AxiosInstance, AxiosResponse } from 'axios'
 import { Span } from 'opentracing'
 import { Logger } from '../../../../../service/logger'
-import { RequestTracingConfig, TraceableRequestConfig } from '../../../../typings'
+import { RequestTracingConfig } from '../../../../typings'
 import { TestTracer } from './TestTracer'
+import { TraceableRequestConfig } from '../../../tracing'
 
 interface TracedTestRequestConfig extends RequestTracingConfig {
   url: string
@@ -73,6 +74,7 @@ export class TracedTestRequest {
           }),
           rootSpan: (this.rootSpan as unknown) as Span,
           tracer: this.tracer,
+          isSampled: true
         },
       }
 

--- a/src/HttpClient/middlewares/request/setupAxios/__tests__/axiosTracingTestSuite.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/__tests__/axiosTracingTestSuite.ts
@@ -163,7 +163,7 @@ export const registerSharedTestSuite = (testSuiteConfig: TestSuiteConfig) => {
         allRequestSpans.forEach((requestSpan) => {
           expect(requestSpan!.tags()[OpentracingTags.ERROR]).toEqual('true')
           const len = (requestSpan as any)._logs.length
-          expect((requestSpan as any)._logs[len - 1].fields['event']).toEqual('error')
+          expect((requestSpan as any)._logs[len - 1].fields.event).toEqual('error')
           expect((requestSpan as any)._logs[len - 1].fields[ErrorReportLogFields.ERROR_ID]).toBeDefined()
           expect((requestSpan as any)._logs[len - 1].fields[ErrorReportLogFields.ERROR_KIND]).toBeDefined()
           expect(

--- a/src/HttpClient/middlewares/request/setupAxios/interceptors/exponentialBackoff.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/interceptors/exponentialBackoff.ts
@@ -65,9 +65,7 @@ const onResponseError = (http: AxiosInstance) => (error: any) => {
       : config.timeout
     config.transformRequest = [data => data]
 
-    if((config as TraceableRequestConfig).tracing.isSampled) {
-      config.tracing!.rootSpan!.log({ event: HttpLogEvents.SETUP_REQUEST_RETRY, [HttpRetryLogFields.RETRY_NUMBER]: config.retryCount, [HttpRetryLogFields.RETRY_IN]: delay })
-    }
+    config.tracing!.rootSpan!.log({ event: HttpLogEvents.SETUP_REQUEST_RETRY, [HttpRetryLogFields.RETRY_NUMBER]: config.retryCount, [HttpRetryLogFields.RETRY_IN]: delay })
 
     return new Promise(resolve => setTimeout(() => resolve(http(config)), delay))
   }

--- a/src/HttpClient/middlewares/request/setupAxios/interceptors/exponentialBackoff.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/interceptors/exponentialBackoff.ts
@@ -1,6 +1,9 @@
 import { AxiosInstance } from 'axios'
+import { HttpLogEvents } from '../../../../../tracing/LogEvents'
+import { HttpRetryLogFields } from '../../../../../tracing/LogFields'
 import { isAbortedOrNetworkErrorOrRouterTimeout } from '../../../../../utils/retry'
 import { RequestConfig } from '../../../../typings'
+import { TraceableRequestConfig } from '../../../tracing'
 
 function fixConfig(axiosInstance: AxiosInstance, config: RequestConfig) {
   if (axiosInstance.defaults.httpAgent === config.httpAgent) {
@@ -40,6 +43,7 @@ const onResponseError = (http: AxiosInstance) => (error: any) => {
     exponentialBackoffCoefficient = 2,
     exponentialTimeoutCoefficient,
   } = config
+
   const retryCount = config.retryCount || 0
   const shouldRetry =
     isAbortedOrNetworkErrorOrRouterTimeout(error) && retryCount < config.retries
@@ -51,6 +55,7 @@ const onResponseError = (http: AxiosInstance) => (error: any) => {
       config.retryCount
     )
 
+
     // Axios fails merging this configuration to the default configuration because it has an issue
     // with circular structures: https://github.com/mzabriskie/axios/issues/370
     fixConfig(http, config)
@@ -60,9 +65,11 @@ const onResponseError = (http: AxiosInstance) => (error: any) => {
       : config.timeout
     config.transformRequest = [data => data]
 
-    return new Promise(resolve =>
-      setTimeout(() => resolve(http(config)), delay)
-    )
+    if((config as TraceableRequestConfig).tracing.isSampled) {
+      config.tracing!.rootSpan!.log({ event: HttpLogEvents.SETUP_REQUEST_RETRY, [HttpRetryLogFields.RETRY_NUMBER]: config.retryCount, [HttpRetryLogFields.RETRY_IN]: delay })
+    }
+
+    return new Promise(resolve => setTimeout(() => resolve(http(config)), delay))
   }
   return Promise.reject(error)
 }

--- a/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/spanSetup.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/spanSetup.ts
@@ -2,37 +2,28 @@ import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import buildFullPath from 'axios/lib/core/buildFullPath'
 import { Span } from 'opentracing'
 import { ROUTER_CACHE_HEADER } from '../../../../../../constants'
-import { LOG_FIELDS } from '../../../../../../tracing/LogFields'
-import { Tags } from '../../../../../../tracing/Tags'
+import { CustomHttpTags, OpentracingTags } from '../../../../../../tracing/Tags'
 
 export const injectRequestInfoOnSpan = (span: Span, http: AxiosInstance, config: AxiosRequestConfig) => {
-  let fullUrl = null
-
-  const spanContext: any = span.context()
-  if (spanContext.isSampled == null || spanContext.isSampled()) {
-    fullUrl = buildFullPath(config.baseURL, http.getUri(config))
-  }
-
   span.addTags({
-    [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
-    [Tags.HTTP_METHOD]: config.method,
-    [Tags.HTTP_URL]: fullUrl,
-    [Tags.HTTP_RETRY_COUNT]: (config as any).retryCount || 0,
+    [OpentracingTags.SPAN_KIND]: OpentracingTags.SPAN_KIND_RPC_CLIENT,
+    [OpentracingTags.HTTP_METHOD]: config.method,
+    [OpentracingTags.HTTP_URL]: buildFullPath(config.baseURL, http.getUri(config)),
   })
 
-  span.log({ [LOG_FIELDS.EVENT]: 'request-headers', headers: config.headers })
+  span.log({ 'request-headers': config.headers })
 }
 
 // Response may be undefined in case of client timeout, invalid URL, ...
-export const injectResponseInfoOnSpan = (span: Span, response: AxiosResponse | null) => {
+export const injectResponseInfoOnSpan = (span: Span, response: AxiosResponse<any> | undefined) => {
   if (!response) {
-    span.setTag(Tags.HTTP_NO_RESPONSE, 'true')
+    span.setTag(CustomHttpTags.HTTP_NO_RESPONSE, 'true')
     return
   }
 
-  span.log({ [LOG_FIELDS.EVENT]: 'response-headers', headers: response.headers })
-  span.setTag(Tags.HTTP_STATUS_CODE, response.status)
+  span.log({ 'response-headers': response.headers })
+  span.setTag(OpentracingTags.HTTP_STATUS_CODE, response.status)
   if (response.headers[ROUTER_CACHE_HEADER]) {
-    span.setTag(Tags.HTTP_ROUTER_CACHE, response.headers[ROUTER_CACHE_HEADER])
+    span.setTag(CustomHttpTags.HTTP_ROUTER_CACHE_RESULT, response.headers[ROUTER_CACHE_HEADER])
   }
 }

--- a/src/HttpClient/middlewares/tracing.ts
+++ b/src/HttpClient/middlewares/tracing.ts
@@ -1,9 +1,9 @@
+import { MiddlewaresTracingContext, RequestConfig } from '..'
 import { IOContext } from '../../service/worker/runtime/typings'
 import { createSpanReference, ErrorReport, getTraceInfo, SpanReferenceTypes } from '../../tracing'
 import { CustomHttpTags, OpentracingTags } from '../../tracing/Tags'
 import { MiddlewareContext } from '../typings'
 import { CacheType, isLocallyCacheable } from './cache'
-import { MiddlewaresTracingContext, RequestConfig } from '..'
 
 interface HttpClientTracingMiddlewareConfig {
   clientName: string

--- a/src/HttpClient/middlewares/tracing.ts
+++ b/src/HttpClient/middlewares/tracing.ts
@@ -1,0 +1,80 @@
+import { IOContext } from '../../service/worker/runtime/typings'
+import { createSpanReference, ErrorReport, getTraceInfo, SpanReferenceTypes } from '../../tracing'
+import { CustomHttpTags, OpentracingTags } from '../../tracing/Tags'
+import { MiddlewareContext } from '../typings'
+import { CacheType, isLocallyCacheable } from './cache'
+import { MiddlewaresTracingContext, RequestConfig } from '..'
+
+interface HttpClientTracingMiddlewareConfig {
+  clientName: string
+  tracer: IOContext['tracer']
+  logger: IOContext['logger']
+  hasMemoryCacheMiddleware: boolean
+  hasDiskCacheMiddleware: boolean
+}
+
+export interface TraceableRequestConfig extends RequestConfig {
+  tracing: MiddlewaresTracingContext
+}
+
+export const createHttpClientTracingMiddleware = ({
+  tracer,
+  logger,
+  clientName,
+  hasMemoryCacheMiddleware,
+  hasDiskCacheMiddleware,
+}: HttpClientTracingMiddlewareConfig) => {
+  return async function tracingMiddleware(ctx: MiddlewareContext, next: () => Promise<void>) {
+    const { rootSpan, requestSpanNameSuffix, referenceType = SpanReferenceTypes.CHILD_OF } = ctx.config.tracing || {}
+    const spanName = requestSpanNameSuffix ? `request:${requestSpanNameSuffix}` : 'request'
+    const span = rootSpan
+      ? tracer.startSpan(spanName, {
+          references: [createSpanReference(rootSpan, referenceType)],
+        })
+      : tracer.startSpan(spanName)
+
+    ctx.tracing = {
+      ...ctx.config.tracing,
+      isSampled: getTraceInfo(span).isSampled,
+      logger,
+      rootSpan: span,
+      tracer,
+    }
+
+    // We can't pass ctx.tracing to axios, so we pass ctx.config.tracing with
+    // a reference to the ctx.tracing object (axios only receives the config object)
+    ;(ctx.config as TraceableRequestConfig).tracing = ctx.tracing
+
+    const hasMemoCache = !(!isLocallyCacheable(ctx.config, CacheType.Any) || !ctx.config.memoizable)
+    const hasMemoryCache = hasMemoryCacheMiddleware && !!isLocallyCacheable(ctx.config, CacheType.Memory)
+    const hasDiskCache = hasDiskCacheMiddleware && !!isLocallyCacheable(ctx.config, CacheType.Disk)
+
+    span.addTags({
+      [CustomHttpTags.HTTP_MEMOIZATION_CACHE_ENABLED]: hasMemoCache,
+      [CustomHttpTags.HTTP_MEMORY_CACHE_ENABLED]: hasMemoryCache,
+      [CustomHttpTags.HTTP_DISK_CACHE_ENABLED]: hasDiskCache,
+      [CustomHttpTags.HTTP_CLIENT_NAME]: clientName,
+    })
+
+    let response
+    try {
+      await next()
+      response = ctx.response
+    } catch (err) {
+      response = err.response
+      if(ctx.tracing.isSampled) {
+        ErrorReport.create({ originalError: err }).injectOnSpan(span, logger)
+      }
+      
+      throw err
+    } finally {
+      if (response) {
+        span.setTag(OpentracingTags.HTTP_STATUS_CODE, response.status)
+      } else {
+        span.setTag(CustomHttpTags.HTTP_NO_RESPONSE, true)
+      }
+
+      span.finish()
+    }
+  }
+}

--- a/src/HttpClient/typings.ts
+++ b/src/HttpClient/typings.ts
@@ -11,23 +11,14 @@ import { Cached, CacheType } from './middlewares/cache'
 
 export type InflightKeyGenerator = (x: RequestConfig) => string
 
-interface RequestTracingUserConfiguration {
+interface RequestTracingUserConfig {
   rootSpan?: Span
   referenceType?: SpanReferenceTypes
   requestSpanNameSuffix?: string
 }
 
-export interface AxiosTracingConfig extends RequestTracingUserConfiguration {
-  tracer: IUserLandTracer
-  logger: IOContext['logger']
-}
-
-export interface TraceableRequestConfig extends RequestConfig {
-  tracing?: AxiosTracingConfig
-}
-
 export interface RequestTracingConfig {
-  tracing?: RequestTracingUserConfiguration
+  tracing?: RequestTracingUserConfig
 }
 
 export interface RequestConfig extends AxiosRequestConfig, RequestTracingConfig {
@@ -61,6 +52,7 @@ export interface RequestConfig extends AxiosRequestConfig, RequestTracingConfig 
   nullIfNotFound?: boolean
   ignoreRecorder?: boolean
 }
+
 export interface CacheHit {
   disk?: 0 | 1
   memory?: 0 | 1
@@ -68,8 +60,16 @@ export interface CacheHit {
   router?: 0 | 1
 }
 
+export interface MiddlewaresTracingContext extends Omit<RequestTracingUserConfig, 'rootSpan'> {
+  tracer: IUserLandTracer
+  logger: IOContext['logger']
+  rootSpan: Span
+  isSampled: boolean
+}
+
 export interface MiddlewareContext {
   config: RequestConfig
+  tracing?: MiddlewaresTracingContext
   response?: AxiosResponse
   cacheHit?: CacheHit
   inflightHit?: boolean

--- a/src/service/tracing/TracerSingleton.ts
+++ b/src/service/tracing/TracerSingleton.ts
@@ -1,7 +1,7 @@
 import { initTracer as initJaegerTracer, TracingConfig, TracingOptions } from 'jaeger-client'
 import { Tracer } from 'opentracing'
 import { APP, LINKED, NODE_ENV, NODE_VTEX_API_VERSION, PRODUCTION, REGION, WORKSPACE } from '../../constants'
-import { Tags } from '../../tracing/Tags'
+import { AppTags } from '../../tracing/Tags'
 import { appIdToAppAtMajor } from '../../utils'
 
 export class TracerSingleton {
@@ -17,13 +17,13 @@ export class TracerSingleton {
 
   private static initServiceTracer() {
     return TracerSingleton.createJaegerTracer(appIdToAppAtMajor(APP.ID), {
-      [Tags.VTEX_APP_LINKED]: LINKED,
-      [Tags.VTEX_APP_NODE_VTEX_API_VERSION]: NODE_VTEX_API_VERSION,
-      [Tags.VTEX_APP_PRODUCTION]: PRODUCTION,
-      [Tags.VTEX_APP_REGION]: REGION,
-      [Tags.VTEX_APP_VERSION]: APP.VERSION,
-      [Tags.VTEX_APP_WORKSPACE]: WORKSPACE,
-      [Tags.VTEX_APP_NODE_ENV]: NODE_ENV ?? 'undefined',
+      [AppTags.VTEX_APP_LINKED]: LINKED,
+      [AppTags.VTEX_APP_NODE_VTEX_API_VERSION]: NODE_VTEX_API_VERSION,
+      [AppTags.VTEX_APP_PRODUCTION]: PRODUCTION,
+      [AppTags.VTEX_APP_REGION]: REGION,
+      [AppTags.VTEX_APP_VERSION]: APP.VERSION,
+      [AppTags.VTEX_APP_WORKSPACE]: WORKSPACE,
+      [AppTags.VTEX_APP_NODE_ENV]: NODE_ENV ?? 'undefined',
     })
   }
 

--- a/src/tracing/LogEvents.ts
+++ b/src/tracing/LogEvents.ts
@@ -1,0 +1,43 @@
+/* tslint:disable:object-literal-sort-keys */
+
+/**
+ * This file has all events logged by the runtime's distributed tracing
+ * instrumentation. In the code you would see something like:
+ * ```
+ * span.log({ event: HttpEvents.CACHE_KEY_CREATE })
+ * ```
+ */
+
+export const enum HttpLogEvents {
+  /** Event holding the cache key created */
+  CACHE_KEY_CREATE = 'cache-key-created',
+
+  /** Event representing that the memoization cache has just saved a response */
+  MEMOIZATION_CACHE_SAVED = 'memoization-cache-saved',
+
+  /** Event representing that the memoization cache has just saved a error response */
+  MEMOIZATION_CACHE_SAVED_ERROR = 'memoization-cache-saved-error',
+
+  /** Event holding information on a local cache hit that just happened */
+  LOCAL_CACHE_HIT_INFO = 'local-cache-hit-info',
+
+  /** Event holding information on the cache config that will be used to decide whether or not to update the local cache */
+  CACHE_CONFIG = 'cache-config',
+
+  /** Event informing the decision to not update or save to local cache */
+  NO_LOCAL_CACHE_SAVE = 'no-local-cache-save',
+
+  /** Event holding information on the local cache save that just happened */
+  LOCAL_CACHE_SAVED = 'local-cache-saved',
+
+  /** A request that is retryable just failed - this event will hold info on the retry that may happen */
+  SETUP_REQUEST_RETRY = 'setup-request-retry',
+}
+
+export const enum RuntimeLogEvents {
+  /** Event representing that userland middlewares are about to start */
+  USER_MIDDLEWARES_START = 'user-middlewares-start',
+
+  /** Event representing that userland middlewares just finished */
+  USER_MIDDLEWARES_FINISH = 'user-middlewares-finish',
+}

--- a/src/tracing/LogFields.ts
+++ b/src/tracing/LogFields.ts
@@ -8,34 +8,72 @@
  * strings and can be searched in the jaeger-ui
  */
 
-const ERROR_REPORT = {
+export const enum ErrorReportLogFields {
   /**
    * ErrorReport class has some meta info on the error
    * The following log fields hold this meta info
    */
-  ERROR_KIND: 'error.kind',
-  ERROR_ID: 'error.id',
+  ERROR_KIND = 'error.kind',
+  ERROR_ID = 'error.id',
 
   /**
    * VTEX's Infra errors adds error details to the response
    * The following log fields are supposed to hold these fields
    */
-  ERROR_SERVER_CODE: 'error.server.code',
-  ERROR_SERVER_REQUEST_ID: 'error.server.request_id',
+  ERROR_SERVER_CODE = 'error.server.code',
+  ERROR_SERVER_REQUEST_ID = 'error.server.request_id',
 }
 
-export const LOG_FIELDS = {
-  EVENT: 'event',
-  
+export const enum RuntimeLogFields {
   /** Time in ms spent to run the user middlewares */
-  USER_MIDDLEWARES_DURATION: 'user-middlewares-duration',
-  ...ERROR_REPORT,
+  USER_MIDDLEWARES_DURATION = 'user-middlewares-duration',
 }
 
-export const LOG_EVENTS = {
-  /** Event representing that userland middlewares are about to start */
-  USER_MIDDLEWARES_START: 'user-middlewares-start',
+export const enum HttpCacheLogFields {
+  /** The generated cache key for Memoization or Local caches */
+  KEY = 'key',
 
-  /** Event representing that userland middlewares just finished */
-  USER_MIDDLEWARES_FINISH: 'user-middlewares-finish',
+  /** The generated cache key for local cache with the segment added to it */
+  KEY_WITH_SEGMENT = 'key-with-segment',
+
+  /** The key that was just set on the cache */
+  KEY_SET = 'key-set',
+
+  /** The type of cache: 'disk', 'memory' or 'memoization' */
+  CACHE_TYPE = 'cache-type',
+
+  /** The etag for the current request used for caching decisions. Can be undefined. */
+  ETAG = 'etag',
+
+  /** The expiration time in seconds of the current cache entry (either just saved or fetched from the storage) */
+  EXPIRATION_TIME = 'expiration-time',
+
+  /** The http response type. Can be undefined. */
+  RESPONSE_TYPE = 'response-type',
+
+  /** The http response encoding. Can be undefined. */
+  RESPONSE_ENCONDING = 'response-encoding',
+
+  /**
+   * The forceMaxAge option on the incoming RequestConfig. This can be set to override no-cache or no-store headers.
+   * Can be undefined.
+   */
+  FORCE_MAX_AGE = 'force-max-age',
+
+  /** The calculated max-age the current response will have if stored */
+  CALCULATED_MAX_AGE = 'calculated-max-age',
+
+  /** Content parsed from the incoming response headers */
+  AGE = 'age',
+  NO_CACHE = 'no-cache',
+  NO_STORE = 'no-store',
+  MAX_AGE = 'max-age',
+}
+
+export const enum HttpRetryLogFields {
+  /** The retry number scheduled (e.g, 1, 2, meaning that is the first or second retry) */
+  RETRY_NUMBER = 'retry-number',
+
+  /** How much time in ms will be waited until this retry happens */
+  RETRY_IN = 'retry-in',
 }

--- a/src/tracing/Tags.ts
+++ b/src/tracing/Tags.ts
@@ -1,31 +1,53 @@
-import { Tags as opentracingTags } from 'opentracing'
+import { Tags as OpentracingTags } from 'opentracing'
+export { OpentracingTags }
 
-const VTEX_INCOMING_REQUEST_TAGS = {
-  VTEX_ACCOUNT: 'vtex.incoming.account',
-  VTEX_REQUEST_ID: 'vtex.request_id',
-  VTEX_WORKSPACE: 'vtex.incoming.workspace',
+/* tslint:disable:object-literal-sort-keys */
+
+export const enum VTEXIncomingRequestTags {
+  VTEX_ACCOUNT = 'vtex.incoming.account',
+  VTEX_REQUEST_ID = 'vtex.request_id',
+  VTEX_WORKSPACE = 'vtex.incoming.workspace',
 }
 
-const APP_TAGS = {
-  VTEX_APP_LINKED: 'app.linked',
-  VTEX_APP_NODE_ENV: 'app.node_env',
-  VTEX_APP_NODE_VTEX_API_VERSION: 'app.node_vtex_api_version',
-  VTEX_APP_PRODUCTION: 'app.production',
-  VTEX_APP_REGION: 'app.region',
-  VTEX_APP_VERSION: 'app.version',
-  VTEX_APP_WORKSPACE: 'app.workspace',
+export const enum AppTags {
+  VTEX_APP_LINKED = 'app.linked',
+  VTEX_APP_NODE_ENV = 'app.node_env',
+  VTEX_APP_NODE_VTEX_API_VERSION = 'app.node_vtex_api_version',
+  VTEX_APP_PRODUCTION = 'app.production',
+  VTEX_APP_REGION = 'app.region',
+  VTEX_APP_VERSION = 'app.version',
+  VTEX_APP_WORKSPACE = 'app.workspace',
 }
 
-export const USERLAND_TAGS = {
-  ...opentracingTags,
+export const enum CustomHttpTags {
+  HTTP_PATH = 'http.path',
+
+  /** Set to true when the client had no response, probably meaning that there was a client error */
+  HTTP_NO_RESPONSE = 'http.no_response',
+
+  /** The HTTP client name (e.g. Apps, Registry, Router) */
+  HTTP_CLIENT_NAME = 'http.client.name',
+
+  /**
+   * CACHE_ENABLED tags indicate if the Cache strategy is enabled
+   * for the specific request.
+   */
+  HTTP_MEMOIZATION_CACHE_ENABLED = 'http.cache.memoization.enabled',
+  HTTP_DISK_CACHE_ENABLED = 'http.cache.disk.enabled',
+  HTTP_MEMORY_CACHE_ENABLED = 'http.cache.memory.enabled',
+
+  /**
+   * CACHE_RESULT tags indicate the result for that cache strategy
+   * (HIT or MISS for example). Since there may be many layers
+   * of cache a ENABLED flag for a strategy may be 'true', but
+   * the RESULT for that strategy may not be present.
+   */
+  HTTP_MEMORY_CACHE_RESULT = 'http.cache.memory',
+  HTTP_MEMOIZATION_CACHE_RESULT = 'http.cache.memoization',
+  HTTP_DISK_CACHE_RESULT = 'http.cache.disk',
+  HTTP_ROUTER_CACHE_RESULT = 'http.cache.router',
 }
 
-export const Tags = {
-  HTTP_NO_RESPONSE: 'http.no_response',
-  HTTP_PATH: 'http.path',
-  HTTP_RETRY_COUNT: 'http.retry_count',
-  HTTP_ROUTER_CACHE: 'http.router_cache',
-  ...USERLAND_TAGS,
-  ...VTEX_INCOMING_REQUEST_TAGS,
-  ...APP_TAGS,
+export const UserlandTags = {
+  ...OpentracingTags,
 }

--- a/src/tracing/errorReporting/ErrorReport.ts
+++ b/src/tracing/errorReporting/ErrorReport.ts
@@ -8,7 +8,7 @@ import {
 import { Span } from 'opentracing'
 import { TracingTags } from '..'
 import { IOContext } from '../../service/worker/runtime/typings'
-import { LOG_FIELDS } from '../LogFields'
+import { ErrorReportLogFields } from '../LogFields'
 import { getTraceInfo } from '../utils'
 
 export class ErrorReport extends ErrorReportBase {
@@ -47,8 +47,8 @@ export class ErrorReport extends ErrorReportBase {
     span.setTag(TracingTags.ERROR, 'true')
 
     const indexedLogs: Record<string, string> = {
-      [LOG_FIELDS.ERROR_KIND]: this.kind,
-      [LOG_FIELDS.ERROR_ID]: this.metadata.errorId,
+      [ErrorReportLogFields.ERROR_KIND]: this.kind,
+      [ErrorReportLogFields.ERROR_ID]: this.metadata.errorId,
     }
 
     if (
@@ -56,12 +56,12 @@ export class ErrorReport extends ErrorReportBase {
       this.parsedInfo.response &&
       isInfraErrorData(this.parsedInfo.response?.data)
     ) {
-      indexedLogs[LOG_FIELDS.ERROR_SERVER_CODE] = this.parsedInfo.response.data.code
-      indexedLogs[LOG_FIELDS.ERROR_SERVER_REQUEST_ID] = this.parsedInfo.response.data.requestId
+      indexedLogs[ErrorReportLogFields.ERROR_SERVER_CODE] = this.parsedInfo.response.data.code
+      indexedLogs[ErrorReportLogFields.ERROR_SERVER_REQUEST_ID] = this.parsedInfo.response.data.requestId
     }
 
     const serializableError = this.toObject()
-    span.log({ [LOG_FIELDS.EVENT]: 'error', ...indexedLogs, error: serializableError })
+    span.log({ event: 'error', ...indexedLogs, error: serializableError })
 
     if (logger && this.shouldLogToSplunk(span)) {
       logger.error(serializableError)

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -4,7 +4,7 @@ export { ErrorKindsBase as ErrorKinds } from '@vtex/node-error-report'
 export { ErrorReport } from './errorReporting/ErrorReport'
 export { createSpanReference } from './spanReference/createSpanReference'
 export { SpanReferenceTypes } from './spanReference/SpanReferenceTypes'
-export { USERLAND_TAGS as TracingTags } from './Tags'
+export { UserlandTags as TracingTags } from './Tags'
 export { createTracingContextFromCarrier, IUserLandTracer } from './UserLandTracer'
 export { getTraceInfo, TraceInfo } from './utils'
 export { Span, FORMAT_HTTP_HEADERS }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR creates a span started at the client level (before running axios) that encloses all requests done by a call to a client. 

Right now I think retries on the same request are kinda difficult to spot because they are all mixed up with other requests. The new span this PR creates makes it easier to spot these cases, and also logs info on the retries and the wait time until the request will be retried on a `event: retryable-request-fail`.

The span created enclosing the retries on a request:
![Screenshot from 2020-06-22 11-43-02](https://user-images.githubusercontent.com/26463288/85301304-07534c80-b47e-11ea-824a-74ac7375ffd6.png)

Here we can see the `event: retryable-request-fail` log:
![Screenshot from 2020-06-22 11-43-54](https://user-images.githubusercontent.com/26463288/85301438-38338180-b47e-11ea-98d2-b0a3bcde37b9.png)

Unfortunately, when the request is successful right away, this span adds one more layer of complexity. To get more use on this span this PR added information on the caching middlewares implemented in the clients.

We now have tags specifying cache strategies enabled for the request and if we have miss or hit in a cache type:
![Screenshot from 2020-06-22 11-38-03](https://user-images.githubusercontent.com/26463288/85301757-9b251880-b47e-11ea-8f27-9c40ed57f0cf.png)

And we have logs on some cache middlewares events:
![Screenshot from 2020-06-22 11-38-13](https://user-images.githubusercontent.com/26463288/85301976-eb9c7600-b47e-11ea-90bd-53e5499820a0.png)

You can test all this linking the app on this repo, and following the instructions on readme (make sure to do the requests with jaeger-debug-id header):
https://github.com/tiagonapoli/vtex-io-cache-examples

You can deploy `service-runtime-node@6.24.0-beta.5` on a test cluster to test this PR as well, it will sample 100%. 
https://vtex.slack.com/archives/CMJU6HLGG/p1592935074045500

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
