### PR TITLE
Remove fallback to x-vtex-credential as adminUserAuthToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove fallback to x-vtex-credential as adminUserAuthToken.
 
 ## [6.33.0] - 2020-06-25
 ### Added

--- a/src/service/worker/runtime/http/middlewares/authTokens.ts
+++ b/src/service/worker/runtime/http/middlewares/authTokens.ts
@@ -12,7 +12,7 @@ export async function authTokens <
 > (ctx: ServiceContext<T, U, V>, next: () => Promise<void>) {
   const { vtex: { account } } = ctx
 
-  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY) || ctx.headers[CREDENTIAL_HEADER]
+  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY)
   ctx.vtex.storeUserAuthToken = ctx.cookies.get(`${VTEX_ID_COOKIE_KEY}_${account}`)
   ctx.vtex.janusEnv = ctx.cookies.get(JANUS_ENV_COOKIE_KEY)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove fallback to x-vtex-credential as adminUserAuthToken

#### What problem is this solving?
> the ctx.adminUserToken is using the app token instead of using the user token or undefined, even though there's no authorization present, this might become a silent security bug, that might lead to untraceability of user actions

&minus; Muniz, Sávio

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
