### PR TITLE
Next @vtex/api release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Remove fallback to x-vtex-credential as adminUserAuthToken.
+### Added
+- Send workspace to session service.
+- Add channelPrivacy to SegmentData type.
 
 ## [6.33.0] - 2020-06-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.34.0] - 2020-07-03
 ### Fixed
 - Remove fallback to x-vtex-credential as adminUserAuthToken.
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove fallback to x-vtex-credential as adminUserAuthToken.
 
 ## [6.33.0] - 2020-06-25
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.33.0",
+  "version": "6.34.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/janus/Segment.ts
+++ b/src/clients/janus/Segment.ts
@@ -8,6 +8,7 @@ import { JanusClient } from './JanusClient'
 export interface SegmentData {
   campaigns?: any
   channel: number
+  channelPrivacy?: 'public' | 'private'
   priceTables?: any
   utm_campaign: string
   regionId?: string
@@ -77,7 +78,7 @@ export class Segment extends JanusClient {
   }
 
   private rawSegment = (token?: string | null, query?: Record<string, string>, tracingConfig?: RequestTracingConfig) => {
-    const { product } = this.context
+    const { product, workspace } = this.context
     const filteredQuery = filterAndSortQuery(query)
 
     const metric = token ? 'segment-get-token' : 'segment-get-new'
@@ -92,6 +93,7 @@ export class Segment extends JanusClient {
       params: {
         ...filteredQuery,
         session_path: product || '',
+        workspace,
       },
       tracing: {
         requestSpanNameSuffix: metric,

--- a/src/service/worker/runtime/http/middlewares/authTokens.ts
+++ b/src/service/worker/runtime/http/middlewares/authTokens.ts
@@ -12,7 +12,7 @@ export async function authTokens <
 > (ctx: ServiceContext<T, U, V>, next: () => Promise<void>) {
   const { vtex: { account } } = ctx
 
-  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY) || ctx.headers[CREDENTIAL_HEADER]
+  ctx.vtex.adminUserAuthToken = ctx.cookies.get(VTEX_ID_COOKIE_KEY)
   ctx.vtex.storeUserAuthToken = ctx.cookies.get(`${VTEX_ID_COOKIE_KEY}_${account}`)
   ctx.vtex.janusEnv = ctx.cookies.get(JANUS_ENV_COOKIE_KEY)
 


### PR DESCRIPTION
This PR includes the following changes:

#396 - Remove fallback to x-vtex-credential as adminUserAuthToken
#398 - Send workspace to session service