### PR TITLE
Fix/configs filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Filter empty service configurations.
 
 ## [6.34.0] - 2020-07-03
 ### Fixed


### PR DESCRIPTION
#### What is the purpose of this pull request?
Let's say that we have an app X called `vtex.service-example` that accepts configurations using [Service Configurations Apps](https://vtex.io/docs/recipes/development/developing-service-configuration-apps/). 
This means that if we create an app (let's call it `vtex.config-app`) that declares a builder called `vtex.sevice-example`, create a folder called `vtex.service-example` and inside that folder a file called `configuration.json`, when those two apps are installed on the same workspace, the configurations declared on `vtex.config-app` should be injected on `vtex.service-example`. 
Everything working as expected, but if we have another app installed in that same workspace, let's call it `vtex.dependant-app`, that depends on `vtex.service-example`, the `vtex.service-configuration` will also receive the configurations from `vtex.dependant-app`, even if it does not declare that it exports configs to `vtex.service-example`, the configuration will be empty but this is unwanted behavior.

Digging a little deeper, I've found out that the only criteria for the runtime to inject a configuration from another app on the current service is this other app to depend on the current service.

Since we don't have a way to tell wich dependant app exports config for the service on the apps metainfo (the list of declared builders would be useful), I added a filter that removes all the empty configurations from the list that is injected on the `ctx.vtex.settings`.

#### How should this be manually tested?
To test my solution, I've created the environment detailed above in two different workspaces inside storecomponents: `configsfromdependencies1` and `configsfromdependencies2`.  

In the first one, I simply liked `vtex.service-example`, `vtex.config-app` and `vtex.dependant-app`. 
The `vtex.service-example` has an [endpoint that returns the content from `ctx.vtex.settings`](https://configsfromdependencies1--storecomponents.myvtex.com/_v/cofigs3) and the returned value is:
```JSON
[
    {
        "declarer": "vtex.dependant-app@0.0.1+build1594155636"
    },
    {
        "vtex.config-app": {
            "id": 100,
            "name": "hello"
        },
        "declarer": "vtex.config-app@0.0.1+build1594155436"
    }
]
```
as we can see, the config from `vtex.dependant-app` was injected on `vtex.service-example`

In the second one, I also liked `vtex.service-example`, `vtex.config-app` and `vtex.dependant-app`. But have I've linked the changes from this PR to the `vtex.service-example/node` using `yarn link @vtex/api`.
The `vtex.service-example` also has an [endpoint that returns the content from `ctx.vtex.settings`](https://configsfromdependencies2--storecomponents.myvtex.com/_v/cofigs) and the returned value is:
```JSON
[
    {
        "vtex.config-app": {
            "id": 100,
            "name": "hello"
        },
        "declarer": "vtex.config-app@0.0.1+build1594155941"
    }
]
```
in which the config from `vtex.dependant-app` was not injected.
#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
