### PR TITLE
Add Jaeger Prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [metrics] Export jaeger metrics.
 
 ### Fixed
-- [metrics] Typo on event listened by to increment `runtime_http_aborted_requests_total`.
-- [tracing:entrypoint] Fix listening for response stream to finish. 
+- [metrics] Typo on event listened to increment `runtime_http_aborted_requests_total`.
+- [tracing:entrypoint] Fix waiting for response stream to finish. 
 
 ## [6.35.0] - 2020-07-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [metrics] Export jaeger metrics.
+
+### Fixed
+- [metrics] Typo on event listened by to increment `runtime_http_aborted_requests_total`.
+- [tracing:entrypoint] Fix listening for response stream to finish. 
 
 ## [6.35.0] - 2020-07-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.35.1] - 2020-07-22
 ### Added
 - [metrics] Export jaeger metrics.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.35.0",
+  "version": "6.35.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/tracing/TracerSingleton.ts
+++ b/src/service/tracing/TracerSingleton.ts
@@ -1,5 +1,6 @@
-import { initTracer as initJaegerTracer, TracingConfig, TracingOptions } from 'jaeger-client'
+import { initTracer as initJaegerTracer, PrometheusMetricsFactory, TracingConfig, TracingOptions } from 'jaeger-client'
 import { Tracer } from 'opentracing'
+import promClient from 'prom-client'
 import { APP, LINKED, NODE_ENV, NODE_VTEX_API_VERSION, PRODUCTION, REGION, WORKSPACE } from '../../constants'
 import { AppTags } from '../../tracing/Tags'
 import { appIdToAppAtMajor } from '../../utils'
@@ -42,6 +43,13 @@ export class TracerSingleton {
     }
 
     const options: TracingOptions = {
+      /**
+       * Jaeger metric names are available in:
+       * https://github.com/jaegertracing/jaeger-client-node/blob/master/src/metrics/metrics.js
+       *
+       * Runtime will prefix these metrics with 'runtime:'
+       */
+      metrics: new PrometheusMetricsFactory(promClient as any, 'runtime'),
       tags: defaultTags,
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Add Jaeger Prometheus metrics (https://github.com/jaegertracing/jaeger-client-node/blob/master/src/metrics/metrics.js)
- Fix typo on request abort event (the event is `'aborted'`, not `'abort'`).
- Fix waiting for outgoing response to finish: The current node implementation for stream.finish doesn't detect a destroyed `ServerResponse` - if the request is aborted, the response stream will be destroyed and then calling stream.finish with a destroyed ServerResponse won't trigger the callback. I opened a issue on NodeJS and hopefully we will get this feature in the next major :D (https://github.com/nodejs/node/issues/34301 https://github.com/nodejs/node/pull/34313), but for now I created a workaround 

#### What problem is this solving?

We don't have metrics on spans and traces generation per service. This will help us to detect if a service is overflowing Jaeger.

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
