### PR TITLE
Adding timestamp field to billing log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `timestamp` field to VTEX IO Billing log.
 
 ## [6.35.1] - 2020-07-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.35.2] - 2020-07-24
 ### Added
 - `timestamp` field to VTEX IO Billing log.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.35.1",
+  "version": "6.35.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/http/middlewares/timings.ts
+++ b/src/service/worker/runtime/http/middlewares/timings.ts
@@ -42,13 +42,13 @@ const logBillingInfo = (
   millis: number
 ) => JSON.stringify({
   '__VTEX_IO_BILLING': 'true',
-  'timestamp': new Date().getTime(),
   'account': account,
   'app': APP.ID,
   'handler': id,
   'isLink': LINKED,
   'production': production,
   'routeType': type === 'public' ? 'public_route' : 'private_route',
+  'timestamp': new Date().getTime(),
   'type': 'process-time',
   'value': millis,
   'vendor': APP.VENDOR,

--- a/src/service/worker/runtime/http/middlewares/timings.ts
+++ b/src/service/worker/runtime/http/middlewares/timings.ts
@@ -48,7 +48,7 @@ const logBillingInfo = (
   'isLink': LINKED,
   'production': production,
   'routeType': type === 'public' ? 'public_route' : 'private_route',
-  'timestamp': new Date().getTime(),
+  'timestamp': Date.now(),
   'type': 'process-time',
   'value': millis,
   'vendor': APP.VENDOR,

--- a/src/service/worker/runtime/http/middlewares/timings.ts
+++ b/src/service/worker/runtime/http/middlewares/timings.ts
@@ -42,6 +42,7 @@ const logBillingInfo = (
   millis: number
 ) => JSON.stringify({
   '__VTEX_IO_BILLING': 'true',
+  'timestamp': new Date().getTime(),
   'account': account,
   'app': APP.ID,
   'handler': id,


### PR DESCRIPTION
As of now, our VTEX IO Billing log **doesn't** add a timestamp, what makes it really hard to use the data on Elastic Search.

Elasticsearch used to support automatically adding timestamps to documents being indexed, but [deprecated this feature](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/mapping-timestamp-field.html) in 2.0.0