### PR TITLE
Add between scrapes event loop metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.36.0] - 2020-07-30
 ### Added
 - [metric] Created new Prometheus metrics related to Event Loop Lag between scrapes:
   - runtime_event_loop_lag_max_between_scrapes_seconds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [metric] Created new Prometheus metrics related to Event Loop Lag between scrapes:
+  - runtime_event_loop_lag_max_between_scrapes_seconds
+  - runtime_event_loop_lag_percentiles_between_scrapes_seconds
 
 ## [6.35.2] - 2020-07-24
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.35.2",
+  "version": "6.36.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/tracing/metrics/MetricNames.ts
+++ b/src/service/tracing/metrics/MetricNames.ts
@@ -1,12 +1,3 @@
-/* tslint:disable:object-literal-sort-keys */
-export const enum MetricLabels {
-  /** The status code for the HTTP request */
-  STATUS_CODE = 'status_code',
-
-  /** The service.json handler name for the current request (e.g. 'public-handler:render') */
-  REQUEST_HANDLER = 'handler',
-}
-
 const enum METRIC_TYPES {
   /** Counter is monotonic */
   COUNTER = 'counter',
@@ -14,6 +5,20 @@ const enum METRIC_TYPES {
   GAUGE = 'gauge',
   /** Histogram creates a counter timeseries for each bucket specified */
   HISTOGRAM = 'histogram',
+}
+
+/* tslint:disable:object-literal-sort-keys */
+export const enum RequestsMetricLabels {
+  /** The status code for the HTTP request */
+  STATUS_CODE = 'status_code',
+
+  /** The service.json handler name for the current request (e.g. 'public-handler:render') */
+  REQUEST_HANDLER = 'handler',
+}
+
+/* tslint:disable:object-literal-sort-keys */
+export const enum EventLoopMetricLabels {
+  PERCENTILE = 'percentile',
 }
 
 export const CONCURRENT_REQUESTS = {
@@ -25,21 +30,21 @@ export const CONCURRENT_REQUESTS = {
 export const REQUESTS_TOTAL = {
   name: 'runtime_http_requests_total',
   help: 'The total number of HTTP requests.',
-  labelNames: [MetricLabels.STATUS_CODE, MetricLabels.REQUEST_HANDLER],
+  labelNames: [RequestsMetricLabels.STATUS_CODE, RequestsMetricLabels.REQUEST_HANDLER],
   type: METRIC_TYPES.COUNTER,
 }
 
 export const REQUESTS_ABORTED = {
   name: 'runtime_http_aborted_requests_total',
   help: 'The total number of HTTP requests aborted.',
-  labelNames: [MetricLabels.REQUEST_HANDLER],
+  labelNames: [RequestsMetricLabels.REQUEST_HANDLER],
   type: METRIC_TYPES.COUNTER,
 }
 
 export const REQUEST_TIMINGS = {
   name: 'runtime_http_requests_duration_milliseconds',
   help: 'The incoming http requests total duration.',
-  labelNames: [MetricLabels.REQUEST_HANDLER],
+  labelNames: [RequestsMetricLabels.REQUEST_HANDLER],
   buckets: [10, 20, 40, 80, 160, 320, 640, 1280, 2560, 5120],
   type: METRIC_TYPES.HISTOGRAM,
 }
@@ -47,7 +52,20 @@ export const REQUEST_TIMINGS = {
 export const REQUEST_RESPONSE_SIZES = {
   name: 'runtime_http_response_size_bytes',
   help: `The outgoing response sizes (only applicable when the response isn't a stream).`,
-  labelNames: [MetricLabels.REQUEST_HANDLER],
+  labelNames: [RequestsMetricLabels.REQUEST_HANDLER],
   buckets: [500, 2000, 8000, 16000, 64000, 256000, 1024000, 4096000],
   type: METRIC_TYPES.HISTOGRAM,
+}
+
+export const BETWEEN_SCRAPES_EVENT_LOOP_LAG_MAX = {
+  name: 'runtime_event_loop_lag_max_between_scrapes_seconds',
+  help: 'The max event loop lag that occurred between this and the previous scrape',
+  type: METRIC_TYPES.GAUGE,
+}
+
+export const BETWEEN_SCRAPES_EVENT_LOOP_LAG_PERCENTILES = {
+  name: 'runtime_event_loop_lag_percentiles_between_scrapes_seconds',
+  help: 'The mean event loop lag that occurred between this and the previous scrape',
+  labelNames: [EventLoopMetricLabels.PERCENTILE],
+  type: METRIC_TYPES.GAUGE,
 }

--- a/src/service/tracing/metrics/MetricNames.ts
+++ b/src/service/tracing/metrics/MetricNames.ts
@@ -65,7 +65,7 @@ export const BETWEEN_SCRAPES_EVENT_LOOP_LAG_MAX = {
 
 export const BETWEEN_SCRAPES_EVENT_LOOP_LAG_PERCENTILES = {
   name: 'runtime_event_loop_lag_percentiles_between_scrapes_seconds',
-  help: 'The mean event loop lag that occurred between this and the previous scrape',
+  help: 'Event loop lag percentiles from the observations that occurred between this and the previous scrape',
   labelNames: [EventLoopMetricLabels.PERCENTILE],
   type: METRIC_TYPES.GAUGE,
 }

--- a/src/service/tracing/metrics/instruments.ts
+++ b/src/service/tracing/metrics/instruments.ts
@@ -1,15 +1,19 @@
 import { Counter, Gauge, Histogram } from 'prom-client'
 import {
+  BETWEEN_SCRAPES_EVENT_LOOP_LAG_MAX,
+  BETWEEN_SCRAPES_EVENT_LOOP_LAG_PERCENTILES,
   CONCURRENT_REQUESTS,
   REQUEST_RESPONSE_SIZES,
   REQUEST_TIMINGS,
   REQUESTS_ABORTED,
   REQUESTS_TOTAL,
 } from './MetricNames'
-export { MetricLabels } from './MetricNames'
+export { EventLoopMetricLabels, RequestsMetricLabels } from './MetricNames'
 
 export const createTotalRequestsInstrument = () => new Counter(REQUESTS_TOTAL)
 export const createTotalAbortedRequestsInstrument = () => new Counter(REQUESTS_ABORTED)
 export const createRequestsTimingsInstrument = () => new Histogram(REQUEST_TIMINGS)
 export const createRequestsResponseSizesInstrument = () => new Histogram(REQUEST_RESPONSE_SIZES)
 export const createConcurrentRequestsInstrument = () => new Gauge(CONCURRENT_REQUESTS)
+export const createEventLoopLagMaxInstrument = () => new Gauge(BETWEEN_SCRAPES_EVENT_LOOP_LAG_MAX)
+export const createEventLoopLagPercentilesInstrument = () => new Gauge(BETWEEN_SCRAPES_EVENT_LOOP_LAG_PERCENTILES)

--- a/src/service/tracing/metrics/measurers/EventLoopLagMeasurer.ts
+++ b/src/service/tracing/metrics/measurers/EventLoopLagMeasurer.ts
@@ -1,11 +1,8 @@
 import { EventLoopDelayMonitor, monitorEventLoopDelay } from 'perf_hooks'
 import { Gauge } from 'prom-client'
-import { promisify } from 'util'
 import { nanosecondsToSeconds } from '../../../../utils'
 import { createEventLoopLagMaxInstrument, createEventLoopLagPercentilesInstrument } from '../instruments'
 import { EventLoopMetricLabels } from '../MetricNames'
-
-const sleep = promisify(setTimeout)
 
 export class EventLoopLagMeasurer {
   private eventLoopDelayMonitor: EventLoopDelayMonitor
@@ -24,7 +21,6 @@ export class EventLoopLagMeasurer {
   }
 
   public async updateInstrumentsAndReset() {
-    await sleep(0)
     this.maxInstrument.set(nanosecondsToSeconds(this.eventLoopDelayMonitor.max))
     this.setPercentileObservation(95)
     this.setPercentileObservation(99)

--- a/src/service/tracing/metrics/measurers/EventLoopLagMeasurer.ts
+++ b/src/service/tracing/metrics/measurers/EventLoopLagMeasurer.ts
@@ -1,0 +1,40 @@
+import { EventLoopDelayMonitor, monitorEventLoopDelay } from 'perf_hooks'
+import { Gauge } from 'prom-client'
+import { promisify } from 'util'
+import { nanosecondsToSeconds } from '../../../../utils'
+import { createEventLoopLagMaxInstrument, createEventLoopLagPercentilesInstrument } from '../instruments'
+import { EventLoopMetricLabels } from '../MetricNames'
+
+const sleep = promisify(setTimeout)
+
+export class EventLoopLagMeasurer {
+  private eventLoopDelayMonitor: EventLoopDelayMonitor
+
+  private percentilesInstrument: Gauge<string>
+  private maxInstrument: Gauge<string>
+
+  constructor() {
+    this.eventLoopDelayMonitor = monitorEventLoopDelay({ resolution: 10 })
+    this.percentilesInstrument = createEventLoopLagPercentilesInstrument()
+    this.maxInstrument = createEventLoopLagMaxInstrument()
+  }
+
+  public start() {
+    this.eventLoopDelayMonitor.enable()
+  }
+
+  public async updateInstrumentsAndReset() {
+    await sleep(0)
+    this.maxInstrument.set(nanosecondsToSeconds(this.eventLoopDelayMonitor.max))
+    this.setPercentileObservation(95)
+    this.setPercentileObservation(99)
+    this.eventLoopDelayMonitor.reset()
+  }
+
+  private setPercentileObservation(percentile: number) {
+    this.percentilesInstrument.set(
+      { [EventLoopMetricLabels.PERCENTILE]: percentile },
+      nanosecondsToSeconds(this.eventLoopDelayMonitor.percentile(percentile))
+    )
+  }
+}

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -15,8 +15,8 @@ import {
   createRequestsTimingsInstrument,
   createTotalAbortedRequestsInstrument,
   createTotalRequestsInstrument,
-  MetricLabels,
-} from './metrics'
+  RequestsMetricLabels,
+} from './metrics/instruments'
 
 const PATHS_BLACKLISTED_FOR_TRACING = ['/metrics', '/_status', '/healthcheck']
 
@@ -47,7 +47,7 @@ export const addTracingMiddleware = (tracer: Tracer) => {
 
     ctx.tracing = { currentSpan, tracer }
     ctx.req.once('aborted', () =>
-      abortedRequests.inc({ [MetricLabels.REQUEST_HANDLER]: (currentSpan as any).operationName as string }, 1)
+      abortedRequests.inc({ [RequestsMetricLabels.REQUEST_HANDLER]: (currentSpan as any).operationName as string }, 1)
     )
 
     let responseClosed = false
@@ -62,15 +62,15 @@ export const addTracingMiddleware = (tracer: Tracer) => {
       const responseLength = ctx.response.length
       if (responseLength) {
         responseSizes.observe(
-          { [MetricLabels.REQUEST_HANDLER]: (currentSpan as any).operationName as string },
+          { [RequestsMetricLabels.REQUEST_HANDLER]: (currentSpan as any).operationName as string },
           responseLength
         )
       }
 
       totalRequests.inc(
         {
-          [MetricLabels.REQUEST_HANDLER]: (currentSpan as any).operationName as string,
-          [MetricLabels.STATUS_CODE]: ctx.response.status,
+          [RequestsMetricLabels.REQUEST_HANDLER]: (currentSpan as any).operationName as string,
+          [RequestsMetricLabels.STATUS_CODE]: ctx.response.status,
         },
         1
       )
@@ -99,7 +99,7 @@ export const addTracingMiddleware = (tracer: Tracer) => {
       const onResFinished = () => {
         requestTimings.observe(
           {
-            [MetricLabels.REQUEST_HANDLER]: (currentSpan as any).operationName as string,
+            [RequestsMetricLabels.REQUEST_HANDLER]: (currentSpan as any).operationName as string,
           },
           hrToMillisFloat(process.hrtime(start))
         )

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -1,10 +1,11 @@
 import { collectDefaultMetrics, register } from 'prom-client'
 
 import { MetricsLogger } from '../../../logger/metricsLogger'
+import { EventLoopLagMeasurer } from '../../../tracing/metrics/measurers/EventLoopLagMeasurer'
 import { ServiceContext } from '../typings'
 import { Recorder } from '../utils/recorder'
 
-export async function recorderMiddleware (ctx: ServiceContext, next: () => Promise<void>) {
+export async function recorderMiddleware(ctx: ServiceContext, next: () => Promise<void>) {
   const recorder = new Recorder()
   ctx.state.recorder = recorder
   await next()
@@ -22,12 +23,16 @@ export const addMetricsLoggerMiddleware = () => {
 
 export const prometheusLoggerMiddleware = () => {
   collectDefaultMetrics()
+  const eventLoopLagMeasurer = new EventLoopLagMeasurer()
+  eventLoopLagMeasurer.start()
+
   return async (ctx: ServiceContext, next: () => Promise<void>) => {
     if (ctx.request.path !== '/metrics') {
       return next()
     }
 
     ctx.tracing?.currentSpan.setOperationName('builtin:prometheus-metrics')
+    await eventLoopLagMeasurer.updateInstrumentsAndReset()
     ctx.set('Content-Type', register.contentType)
     ctx.body = register.metrics()
     ctx.status = 200

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -19,6 +19,10 @@ export const hrToMillisFloat = ([seconds, nanoseconds]: [number, number]) => {
   return (seconds * 1e3) + (nanoseconds / 1e6)
 }
 
+export const nanosecondsToSeconds = (nanoseconds: number) => {
+  return nanoseconds / 1e9
+}
+
 export const hrToNano = ([seconds, nanoseconds]: [number, number]) =>
   seconds * 1e9 + nanoseconds
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add new event loop lag metrics - max, p99 and p95 - measured between prometheus scraps:
  - runtime_event_loop_lag_max_between_scrapes_seconds
  - runtime_event_loop_lag_percentiles_between_scrapes_seconds 

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
