### PR TITLE
Remove x-vtex-app-key and x-vtex-app-token from logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove x-vtex-app-key and x-vtex-app-token from logs.
 
 ## [6.36.0] - 2020-07-30
 ### Added
@@ -23,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - [metrics] Typo on event listened to increment `runtime_http_aborted_requests_total`.
-- [tracing:entrypoint] Fix waiting for response stream to finish. 
+- [tracing:entrypoint] Fix waiting for response stream to finish.
 
 ## [6.35.0] - 2020-07-08
 ### Added

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -3,6 +3,8 @@ import { find, keys, pick } from 'ramda'
 
 export const PICKED_AXIOS_PROPS = ['baseURL', 'cacheable', 'data', 'finished', 'headers', 'method', 'timeout', 'status', 'path', 'url', 'metric', 'inflightKey', 'forceMaxAge', 'params', 'responseType']
 
+const FORBIDDEN_LOG_HEADERS = ['authorization', 'proxy-authorization', 'vtexidclientautcookie', 'x-vtex-api-appkey', 'x-vtex-api-apptoken']
+
 const MAX_ERROR_STRING_LENGTH = process.env.MAX_ERROR_STRING_LENGTH ? parseInt(process.env.MAX_ERROR_STRING_LENGTH, 10) : 8 * 1024
 
 const findCaseInsensitive = (target: string, set: string[]) => find(
@@ -69,18 +71,12 @@ const destroyCircular = (from: any, seen: any[]) => {
       const headers = to[property] && to[property].headers
       if (headers) {
         const headerNames = keys(headers)
-        const authorization = findCaseInsensitive('authorization', headerNames as string[])
-        if (!!authorization) {
-          delete headers[authorization]
-        }
-        const proxyAuth = findCaseInsensitive('proxy-authorization', headerNames as string[])
-        if (!!proxyAuth) {
-          delete headers[proxyAuth]
-        }
-        const vtexIdClientAutCookie = findCaseInsensitive('vtexidclientautcookie', headerNames as string[])
-        if (!!vtexIdClientAutCookie) {
-          delete headers[vtexIdClientAutCookie]
-        }
+        FORBIDDEN_LOG_HEADERS.forEach(header => {
+          const foundHeader = findCaseInsensitive(header, headerNames as string[])
+          if (foundHeader) {
+            delete headers[foundHeader]
+          }
+        })
       }
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove x-vtex-app-key and x-vtex-app-token from logs.

#### What problem is this solving?

It is sensitive information that is going to the browser when an exception occurs

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
