### PR TITLE
Remove sensitive error data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove sensitive exception data before responding to browser.
 
 ## [6.36.0] - 2020-07-30
 ### Added
@@ -23,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - [metrics] Typo on event listened to increment `runtime_http_aborted_requests_total`.
-- [tracing:entrypoint] Fix waiting for response stream to finish. 
+- [tracing:entrypoint] Fix waiting for response stream to finish.
 
 ## [6.35.0] - 2020-07-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.36.1] - 2020-08-17
 ### Fixed
 - Remove sensitive exception data before responding to browser.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.36.0",
+  "version": "6.36.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/graphql/middlewares/error.ts
+++ b/src/service/worker/runtime/graphql/middlewares/error.ts
@@ -27,30 +27,32 @@ const createLogErrorToSplunk = (vtex: IOContext) => (err: any) => {
     logger,
   } = vtex
 
-  // Prevent logging cancellation error (it's not an error)
-  if (err?.extensions?.exception?.code === cancelledErrorCode) {
-    return
-  }
+  try {
+    // Prevent logging cancellation error (it's not an error)
+    if (err?.extensions?.exception?.code === cancelledErrorCode) {
+      return
+    }
 
-  // Add pathName to each error
-  if (err.path) {
-    err.pathName = generatePathName(err.path)
-  }
+    // Add pathName to each error
+    if (err.path) {
+      err.pathName = generatePathName(err.path)
+    }
 
-  const log = {
-    ...err,
-    routeId: id,
-  }
+    const log = {
+      ...err,
+      routeId: id,
+    }
 
-  // Grab level from originalError, default to "error" level.
-  let level = err?.extensions?.exception?.level as LogLevel
-  if (!level || !(level === LogLevel.Error || level === LogLevel.Warn)) {
-    level = LogLevel.Error
-  }
-  logger.log(log, level)
-
-  if (!LINKED && err?.extensions?.exception?.sensitive) {
-    delete err.extensions.exception.sensitive
+    // Grab level from originalError, default to "error" level.
+    let level = err?.extensions?.exception?.level as LogLevel
+    if (!level || !(level === LogLevel.Error || level === LogLevel.Warn)) {
+      level = LogLevel.Error
+    }
+    logger.log(log, level)
+  } finally {
+    if (!LINKED && err?.extensions?.exception?.sensitive) {
+      delete err.extensions.exception.sensitive
+    }
   }
 }
 

--- a/src/service/worker/runtime/graphql/middlewares/error.ts
+++ b/src/service/worker/runtime/graphql/middlewares/error.ts
@@ -1,4 +1,4 @@
-import { formatApolloErrors } from 'apollo-server-errors'
+import { formatApolloErrors, ApolloError } from 'apollo-server-errors'
 import { uniqBy } from 'ramda'
 
 import {
@@ -10,6 +10,7 @@ import { IOContext } from '../../typings'
 import { GraphQLServiceContext } from '../typings'
 import { createFormatError } from '../utils/error'
 import { generatePathName } from '../utils/pathname'
+import { LINKED } from '../../../../../constants'
 
 const TWO_SECONDS_S = 2
 
@@ -47,6 +48,10 @@ const createLogErrorToSplunk = (vtex: IOContext) => (err: any) => {
     level = LogLevel.Error
   }
   logger.log(log, level)
+
+  if (!LINKED && err?.extensions?.exception?.sensitive) {
+    delete err.extensions.exception.sensitive
+  }
 }
 
 export async function graphqlError (ctx: GraphQLServiceContext, next: () => Promise<void>) {

--- a/src/service/worker/runtime/graphql/middlewares/error.ts
+++ b/src/service/worker/runtime/graphql/middlewares/error.ts
@@ -1,6 +1,7 @@
-import { formatApolloErrors, ApolloError } from 'apollo-server-errors'
+import { formatApolloErrors } from 'apollo-server-errors'
 import { uniqBy } from 'ramda'
 
+import { LINKED } from '../../../../../constants'
 import {
   cancelledErrorCode,
   cancelledRequestStatus,
@@ -10,7 +11,6 @@ import { IOContext } from '../../typings'
 import { GraphQLServiceContext } from '../typings'
 import { createFormatError } from '../utils/error'
 import { generatePathName } from '../utils/pathname'
-import { LINKED } from '../../../../../constants'
 
 const TWO_SECONDS_S = 2
 

--- a/src/service/worker/runtime/graphql/utils/error.ts
+++ b/src/service/worker/runtime/graphql/utils/error.ts
@@ -72,14 +72,14 @@ const formatError = (error: any, details?: any) => {
         sensitive: pick(SENSITIVE_EXCEPTION_DATA, formattedError.originalError),
       }
     } else {
-      const mergedEx = {...formattedError.originalError,
+      const mergedException = {...formattedError.originalError,
         ...formattedError.extensions.exception,
       }
       const extendedException = {
         message: formattedError.originalError.message,
         name: formattedError.originalError.name,
-        ...omit(SENSITIVE_EXCEPTION_DATA, mergedEx),
-        sensitive: pick(SENSITIVE_EXCEPTION_DATA, mergedEx),
+        ...omit(SENSITIVE_EXCEPTION_DATA, mergedException),
+        sensitive: pick(SENSITIVE_EXCEPTION_DATA, mergedException),
       }
       formattedError.extensions.exception = cleanError(extendedException)
     }

--- a/src/service/worker/runtime/graphql/utils/error.ts
+++ b/src/service/worker/runtime/graphql/utils/error.ts
@@ -1,10 +1,11 @@
-import { pick } from 'ramda'
+import { pick, omit } from 'ramda'
 
 import { cleanError } from '../../../../../utils/error'
 import { GraphQLServiceContext } from '../typings'
 
 const ERROR_FIELD_WHITELIST = ['message', 'path', 'stack', 'extensions', 'statusCode', 'name', 'headers', 'originalError', 'code']
 const QUERY_FIELDS = ['query', 'operationName', 'variables']
+const SENSITIVE_EXCEPTION_DATA = ['config', 'request', 'response', 'stack']
 
 const trimVariables = (variables: object) => {
   if (variables) {
@@ -67,16 +68,18 @@ const formatError = (error: any, details?: any) => {
       formattedError.extensions.exception = {
         message: formattedError.originalError.message,
         name: formattedError.originalError.name,
-        stack: formattedError.originalError.stack,
-        ...formattedError.originalError,
+        ...omit(SENSITIVE_EXCEPTION_DATA, formattedError.originalError),
+        sensitive: pick(SENSITIVE_EXCEPTION_DATA, formattedError.originalError)
       }
     } else {
+      const mergedEx = {...formattedError.originalError,
+        ...formattedError.extensions.exception,
+      }
       const extendedException = {
         message: formattedError.originalError.message,
         name: formattedError.originalError.name,
-        stack: formattedError.originalError.stack,
-        ...formattedError.originalError,
-        ...formattedError.extensions.exception,
+        ...omit(SENSITIVE_EXCEPTION_DATA, mergedEx),
+        sensitive: pick(SENSITIVE_EXCEPTION_DATA, mergedEx)
       }
       formattedError.extensions.exception = cleanError(extendedException)
     }

--- a/src/service/worker/runtime/graphql/utils/error.ts
+++ b/src/service/worker/runtime/graphql/utils/error.ts
@@ -1,11 +1,10 @@
 import { omit, pick } from 'ramda'
 
-import { cleanError } from '../../../../../utils/error'
+import { cleanError, SENSITIVE_EXCEPTION_FIELDS } from '../../../../../utils/error'
 import { GraphQLServiceContext } from '../typings'
 
 const ERROR_FIELD_WHITELIST = ['message', 'path', 'stack', 'extensions', 'statusCode', 'name', 'headers', 'originalError', 'code']
 const QUERY_FIELDS = ['query', 'operationName', 'variables']
-const SENSITIVE_EXCEPTION_DATA = ['config', 'request', 'response', 'stack']
 
 const trimVariables = (variables: object) => {
   if (variables) {
@@ -68,8 +67,8 @@ const formatError = (error: any, details?: any) => {
       formattedError.extensions.exception = {
         message: formattedError.originalError.message,
         name: formattedError.originalError.name,
-        ...omit(SENSITIVE_EXCEPTION_DATA, formattedError.originalError),
-        sensitive: pick(SENSITIVE_EXCEPTION_DATA, formattedError.originalError),
+        ...omit(SENSITIVE_EXCEPTION_FIELDS, formattedError.originalError),
+        sensitive: pick(SENSITIVE_EXCEPTION_FIELDS, formattedError.originalError),
       }
     } else {
       const mergedException = {...formattedError.originalError,
@@ -78,8 +77,8 @@ const formatError = (error: any, details?: any) => {
       const extendedException = {
         message: formattedError.originalError.message,
         name: formattedError.originalError.name,
-        ...omit(SENSITIVE_EXCEPTION_DATA, mergedException),
-        sensitive: pick(SENSITIVE_EXCEPTION_DATA, mergedException),
+        ...omit(SENSITIVE_EXCEPTION_FIELDS, mergedException),
+        sensitive: pick(SENSITIVE_EXCEPTION_FIELDS, mergedException),
       }
       formattedError.extensions.exception = cleanError(extendedException)
     }

--- a/src/service/worker/runtime/graphql/utils/error.ts
+++ b/src/service/worker/runtime/graphql/utils/error.ts
@@ -1,4 +1,4 @@
-import { pick, omit } from 'ramda'
+import { omit, pick } from 'ramda'
 
 import { cleanError } from '../../../../../utils/error'
 import { GraphQLServiceContext } from '../typings'
@@ -69,7 +69,7 @@ const formatError = (error: any, details?: any) => {
         message: formattedError.originalError.message,
         name: formattedError.originalError.name,
         ...omit(SENSITIVE_EXCEPTION_DATA, formattedError.originalError),
-        sensitive: pick(SENSITIVE_EXCEPTION_DATA, formattedError.originalError)
+        sensitive: pick(SENSITIVE_EXCEPTION_DATA, formattedError.originalError),
       }
     } else {
       const mergedEx = {...formattedError.originalError,
@@ -79,7 +79,7 @@ const formatError = (error: any, details?: any) => {
         message: formattedError.originalError.message,
         name: formattedError.originalError.name,
         ...omit(SENSITIVE_EXCEPTION_DATA, mergedEx),
-        sensitive: pick(SENSITIVE_EXCEPTION_DATA, mergedEx)
+        sensitive: pick(SENSITIVE_EXCEPTION_DATA, mergedEx),
       }
       formattedError.extensions.exception = cleanError(extendedException)
     }

--- a/src/service/worker/runtime/http/middlewares/error.ts
+++ b/src/service/worker/runtime/http/middlewares/error.ts
@@ -1,4 +1,5 @@
 import { IOClients } from '../../../../../clients/IOClients'
+import { LINKED } from '../../../../../constants'
 import {
   cancelledRequestStatus,
   RequestCancelledError,
@@ -7,7 +8,7 @@ import {
   TooManyRequestsError,
   tooManyRequestsStatus,
 } from '../../../../../errors/TooManyRequestsError'
-import { cleanError } from '../../../../../utils/error'
+import { cleanError, SENSITIVE_EXCEPTION_FIELDS } from '../../../../../utils/error'
 import { LogLevel } from '../../../../logger'
 import {
   ParamsContext,
@@ -20,6 +21,70 @@ const META_HEADER = 'x-vtex-meta'
 const ETAG_HEADER = 'etag'
 const TWO_SECONDS_S = 2
 const production = process.env.VTEX_PRODUCTION === 'true'
+
+// todo: unify GraphQL and REST exception treatment
+const logAndRemoveSensitiveData = <
+  T extends IOClients,
+  U extends RecorderState,
+  V extends ParamsContext
+> (ctx: ServiceContext<T, U, V>,err: any) => {
+  const {
+    method,
+    status,
+    query,
+    vtex: {
+      operationId,
+      requestId,
+      route: {
+        id,
+        params,
+      },
+      serverTiming,
+    },
+    headers: {
+      'x-forwarded-path': forwardedPath,
+      'x-forwarded-host': forwardedHost,
+      'x-forwarded-proto': forwardedProto,
+      'x-vtex-caller': caller,
+      'x-vtex-platform': platform,
+      'x-vtex-product': product,
+      'x-vtex-locale': locale,
+    },
+  } = ctx
+
+  // Grab level from originalError, default to "error" level.
+  let level = err && err.level as LogLevel
+  if (!level || !(level === LogLevel.Error || level === LogLevel.Warn)) {
+    level = LogLevel.Error
+  }
+
+  const log = {
+    ...err,
+    caller,
+    forwardedHost,
+    forwardedPath,
+    forwardedProto,
+    locale,
+    method,
+    operationId,
+    params,
+    platform,
+    product,
+    query,
+    requestId,
+    routeId: id,
+    serverTiming,
+    status,
+  }
+
+  // Use sendLog directly to avoid cleaning error twice.
+  ctx.vtex.logger.log(log, level)
+  if (!LINKED) {
+    SENSITIVE_EXCEPTION_FIELDS.forEach(field => {
+      delete err[field]
+    })
+  }
+}
 
 export async function error<
   T extends IOClients,
@@ -46,7 +111,6 @@ export async function error<
       : ctx.status >= 500 && ctx.status <= 599
         ? ctx.status
         : 500
-    ctx.body = ctx.body || err
 
     // Do not generate etag for errors
     ctx.remove(META_HEADER)
@@ -60,57 +124,7 @@ export async function error<
       ctx.set(CACHE_CONTROL_HEADER, `no-cache, no-store`)
     }
 
-    // Log error
-    const {
-      method,
-      status,
-      query,
-      vtex: {
-        operationId,
-        requestId,
-        route: {
-          id,
-          params,
-        },
-        serverTiming,
-      },
-      headers: {
-        'x-forwarded-path': forwardedPath,
-        'x-forwarded-host': forwardedHost,
-        'x-forwarded-proto': forwardedProto,
-        'x-vtex-caller': caller,
-        'x-vtex-platform': platform,
-        'x-vtex-product': product,
-        'x-vtex-locale': locale,
-      },
-    } = ctx
-
-    // Grab level from originalError, default to "error" level.
-    let level = err && err.level as LogLevel
-    if (!level || !(level === LogLevel.Error || level === LogLevel.Warn)) {
-      level = LogLevel.Error
-    }
-
-    const log = {
-      ...err,
-      caller,
-      forwardedHost,
-      forwardedPath,
-      forwardedProto,
-      locale,
-      method,
-      operationId,
-      params,
-      platform,
-      product,
-      query,
-      requestId,
-      routeId: id,
-      serverTiming,
-      status,
-    }
-
-    // Use sendLog directly to avoid cleaning error twice.
-    ctx.vtex.logger.log(log, level)
+    logAndRemoveSensitiveData(ctx, err)
+    ctx.body = ctx.body || err
   }
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -2,6 +2,7 @@
 import { find, keys, pick } from 'ramda'
 
 export const PICKED_AXIOS_PROPS = ['baseURL', 'cacheable', 'data', 'finished', 'headers', 'method', 'timeout', 'status', 'path', 'url', 'metric', 'inflightKey', 'forceMaxAge', 'params', 'responseType']
+export const SENSITIVE_EXCEPTION_FIELDS = ['config', 'request', 'response', 'stack']
 
 const MAX_ERROR_STRING_LENGTH = process.env.MAX_ERROR_STRING_LENGTH ? parseInt(process.env.MAX_ERROR_STRING_LENGTH, 10) : 8 * 1024
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove sensitive error data

#### What problem is this solving?

We are exposing sensitive data when an exception occurs: stack, headers, etc..

#### Screenshots or example usage
Now:
<img width="968" alt="exposed" src="https://user-images.githubusercontent.com/2726345/90414995-ddd22e00-e086-11ea-9c57-3d57a0e2ebb2.png">

Fixed:
<img width="883" alt="fixed_not_linked" src="https://user-images.githubusercontent.com/2726345/90415044-efb3d100-e086-11ea-824a-e93e1506b6c4.png">

Keeping information if the developer is linking the app:
<img width="1082" alt="fixed_linked" src="https://user-images.githubusercontent.com/2726345/90415125-078b5500-e087-11ea-92ea-dcb4bc6738cf.png">

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
