### PR TITLE
Fix/sensitive error data 3x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove sensitive data when an exception occurs.
 
 ## [3.75.0] - 2020-05-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.75.1] - 2020-08-20
 ### Fixed
 - Remove sensitive data when an exception occurs.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.75.0",
+  "version": "3.75.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ export const LOCALE_HEADER = 'x-vtex-locale'
 export const FORWARDED_HOST_HEADER = 'x-forwarded-host'
 export const TENANT_HEADER = 'x-vtex-tenant'
 export const BINDING_HEADER = 'x-vtex-binding'
-
+export const LINKED = !!process.env.VTEX_APP_LINK
 export type VaryHeaders = typeof SEGMENT_HEADER | typeof SESSION_HEADER | typeof PRODUCT_HEADER | typeof LOCALE_HEADER
 
 export const BODY_HASH = '__graphqlBodyHash'

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -101,7 +101,7 @@ export async function graphqlError (ctx: GraphQLServiceContext, next: () => Prom
       // Log each error to splunk individually
       forEach((err: any) => {
         // Prevent logging cancellation error (it's not an error)
-        if (err.extensions.exception?.code !== cancelledErrorCode) {
+        if (!err.extensions.exception || err.extensions.exception.code !== cancelledErrorCode) {
           // Add pathName to each error
           if (err.path) {
             err.pathName = generatePathName(err.path)
@@ -120,7 +120,7 @@ export async function graphqlError (ctx: GraphQLServiceContext, next: () => Prom
           ctx.vtex.logger.log(log, level)
         }
 
-        if (!LINKED && err?.extensions?.exception?.sensitive) {
+        if (!LINKED && err.extensions.exception && err.extensions.exception.sensitive) {
           delete err.extensions.exception.sensitive
         }
       }, uniqueErrors)

--- a/src/service/graphql/middlewares/error.ts
+++ b/src/service/graphql/middlewares/error.ts
@@ -1,6 +1,7 @@
 import { any, chain, compose, filter, forEach, has, map, prop, uniqBy } from 'ramda'
 
 import { LogLevel } from '../../../clients/Logger'
+import { LINKED } from '../../../constants'
 import { cancelledErrorCode, cancelledRequestStatus } from '../../../errors/RequestCancelledError'
 import { GraphQLServiceContext } from '../typings'
 import { toArray } from '../utils/array'
@@ -120,6 +121,10 @@ export async function graphqlError (ctx: GraphQLServiceContext, next: () => Prom
           level = LogLevel.Error
         }
         ctx.vtex.logger.log(log, level)
+
+        if (!LINKED && err?.extensions?.exception?.sensitive) {
+          delete err.extensions.exception.sensitive
+        }
       }, uniqueErrors)
 
       // Expose graphQLErrors with pathNames to timings middleware

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -2,7 +2,7 @@
 import { find, keys, pick } from 'ramda'
 
 export const PICKED_AXIOS_PROPS = ['baseURL', 'cacheable', 'data', 'finished', 'headers', 'method', 'timeout', 'status', 'path', 'url', 'metric', 'inflightKey', 'forceMaxAge', 'params', 'responseType']
-export const SENSITIVE_EXCEPTION_FIELDS = ['config', 'request', 'response', 'stack']
+export const SENSITIVE_EXCEPTION_FIELDS = ['config', 'request', 'stack']
 
 const MAX_ERROR_STRING_LENGTH = process.env.MAX_ERROR_STRING_LENGTH ? parseInt(process.env.MAX_ERROR_STRING_LENGTH, 10) : 8 * 1024
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -2,6 +2,7 @@
 import { find, keys, pick } from 'ramda'
 
 export const PICKED_AXIOS_PROPS = ['baseURL', 'cacheable', 'data', 'finished', 'headers', 'method', 'timeout', 'status', 'path', 'url', 'metric', 'inflightKey', 'forceMaxAge', 'params', 'responseType']
+export const SENSITIVE_EXCEPTION_FIELDS = ['config', 'request', 'response', 'stack']
 
 const MAX_ERROR_STRING_LENGTH = process.env.MAX_ERROR_STRING_LENGTH ? parseInt(process.env.MAX_ERROR_STRING_LENGTH, 10) : 8 * 1024
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove sensitive error data, as done here: https://github.com/vtex/node-vtex-api/pull/408

#### What problem is this solving?

We are exposing sensitive data when an exception occurs: stack, headers, etc..

#### Screenshots or example usage

Before:
![beforefix](https://user-images.githubusercontent.com/2726345/90522164-c310bf80-e141-11ea-9cfa-fd33a3dbd216.png)

After:
![afterfix](https://user-images.githubusercontent.com/2726345/90522520-31558200-e142-11ea-838c-5ad79754b72e.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
