### PR TITLE
Wait for in-flight requests before killing workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Set wait time to force shutdown workers based on service timeout
 
 ## [6.36.1] - 2020-08-17
 ### Fixed


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the worker's SIGTERM handler to wait for service timeout before killing any process.

#### What problem is this solving?

We have a hypothesis that workers are killed prematurely without finishing in-flight requests on the application lifecycle. Our thesis is based on two main points:

1) [Errors happening when pods are scaling down/removed](https://vtex.slack.com/archives/CCYP7AS59/p1597421846043800?thread_ts=1597261439.002200&cid=CCYP7AS59)
2) [The way that Kubernetes handle a graceful shutdown](https://pracucci.com/graceful-shutdown-of-kubernetes-pods.html)

We notice that currently, our timeout to [kill any process running on the pod is 1.5s](https://github.com/vtex/node-vtex-api/blob/master/src/service/master.ts#L74) after receives SIGTERM.

Based on that we are changing the following rules:

1) Since our services timeout can be set up to 60s, the process will wait at max the specified timeout.
2) The worker will wait for at least 30s before sending SIGKILL to child workers and then, exit their own process, this time is based on Kubernetes default time.

We expect to won't see this problem happening again since all in-flight requests can be finished up before the SIGKILL are sent.

Also, we set SIGINT to 1s, why?

![image](https://user-images.githubusercontent.com/5839364/90527119-91025c00-e147-11ea-9034-4986fb2369e9.png)
[Source](https://man7.org/linux/man-pages/man7/signal.7.html)

We don't have any production usage of SIGINT, so we set to 1s just in case you need to run - in dev time - the runtime on your own machine.

_There's another change pending on platform to set the time to send SIGKILL based on service time._

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
