### PR TITLE
Remove sensitive info logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Set wait time to force shutdown workers based on service timeout
 - Stop removing response from error.
+- Update @vtex/node-error-report to remove sensitive information from errors logged to splunk and to distributed tracing.
+- Remove sensitive information from headers before logging onto tracing spans.
 
 ## [6.36.1] - 2020-08-17
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@types/koa": "^2.11.0",
     "@types/koa-compose": "^3.2.3",
-    "@vtex/node-error-report": "^0.0.3-beta.4",
+    "@vtex/node-error-report": "^0.0.3",
     "@wry/equality": "^0.1.9",
     "agentkeepalive": "^4.0.2",
     "apollo-server-errors": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@types/koa": "^2.11.0",
     "@types/koa-compose": "^3.2.3",
-    "@vtex/node-error-report": "^0.0.2",
+    "@vtex/node-error-report": "^0.0.3-beta.4",
     "@wry/equality": "^0.1.9",
     "agentkeepalive": "^4.0.2",
     "apollo-server-errors": "^2.2.1",

--- a/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/spanSetup.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/spanSetup.ts
@@ -3,6 +3,7 @@ import buildFullPath from 'axios/lib/core/buildFullPath'
 import { Span } from 'opentracing'
 import { ROUTER_CACHE_HEADER } from '../../../../../../constants'
 import { CustomHttpTags, OpentracingTags } from '../../../../../../tracing/Tags'
+import { cloneAndSanitizeHeaders } from '../../../../../../tracing/utils'
 
 export const injectRequestInfoOnSpan = (span: Span, http: AxiosInstance, config: AxiosRequestConfig) => {
   span.addTags({
@@ -11,7 +12,7 @@ export const injectRequestInfoOnSpan = (span: Span, http: AxiosInstance, config:
     [OpentracingTags.HTTP_URL]: buildFullPath(config.baseURL, http.getUri(config)),
   })
 
-  span.log({ 'request-headers': config.headers })
+  span.log({ 'request-headers': cloneAndSanitizeHeaders(config.headers) })
 }
 
 // Response may be undefined in case of client timeout, invalid URL, ...
@@ -21,7 +22,7 @@ export const injectResponseInfoOnSpan = (span: Span, response: AxiosResponse<any
     return
   }
 
-  span.log({ 'response-headers': response.headers })
+  span.log({ 'response-headers': cloneAndSanitizeHeaders(response.headers) })
   span.setTag(OpentracingTags.HTTP_STATUS_CODE, response.status)
   if (response.headers[ROUTER_CACHE_HEADER]) {
     span.setTag(CustomHttpTags.HTTP_ROUTER_CACHE_RESULT, response.headers[ROUTER_CACHE_HEADER])

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -6,8 +6,8 @@ import { RuntimeLogEvents } from '../../tracing/LogEvents'
 import { RuntimeLogFields } from '../../tracing/LogFields'
 import { CustomHttpTags, OpentracingTags, VTEXIncomingRequestTags } from '../../tracing/Tags'
 import { UserLandTracer } from '../../tracing/UserLandTracer'
+import { cloneAndSanitizeHeaders } from '../../tracing/utils'
 import { hrToMillis, hrToMillisFloat } from '../../utils'
-import { addPrefixOntoObjectKeys } from '../../utils/addPrefixOntoObjectKeys'
 import { ServiceContext } from '../worker/runtime/typings'
 import {
   createConcurrentRequestsInstrument,
@@ -91,8 +91,8 @@ export const addTracingMiddleware = (tracer: Tracer) => {
           [VTEXIncomingRequestTags.VTEX_ACCOUNT]: ctx.get(ACCOUNT_HEADER),
         })
 
-        currentSpan.log(addPrefixOntoObjectKeys('req.headers', ctx.request.headers))
-        currentSpan.log(addPrefixOntoObjectKeys('res.headers', ctx.response.headers))
+        currentSpan.log(cloneAndSanitizeHeaders(ctx.request.headers, 'req.headers.'))
+        currentSpan.log(cloneAndSanitizeHeaders(ctx.response.headers, 'res.headers.'))
         ctx.set(TRACE_ID_HEADER, traceInfo.traceId)
       }
 

--- a/src/tracing/utils.test.ts
+++ b/src/tracing/utils.test.ts
@@ -1,0 +1,60 @@
+import { cloneAndSanitizeHeaders } from './utils'
+import { SENSITIVE_STR } from '@vtex/node-error-report'
+
+describe('cloneAndSanitizeHeaders', () => {
+  const headers = {
+    authorization: '1337',
+    a: 'b',
+  }
+
+  test('Original object is not modified', () => {
+    cloneAndSanitizeHeaders(headers)
+    expect(headers).toEqual({
+      authorization: '1337',
+      a: 'b',
+    })
+  })
+
+  test('Sensitive information is redacted', () => {
+    expect(cloneAndSanitizeHeaders(headers)).toEqual({
+      authorization: SENSITIVE_STR,
+      a: 'b',
+    })
+  })
+
+  test('Prefix is added if specified', () => {
+    expect(cloneAndSanitizeHeaders(headers, 'test.')).toEqual({
+      'test.authorization': SENSITIVE_STR,
+      'test.a': 'b',
+    })
+  })
+
+  test('It works if the header is an axios header object', () => {
+    const axiosHeader = {
+      common: {
+        Accept: 'application/json, text/plain, */*',
+      },
+      delete: {},
+      get: {},
+      head: {},
+      post: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      ...headers,
+    }
+
+    expect(cloneAndSanitizeHeaders(axiosHeader)).toEqual({
+      common: {
+        Accept: 'application/json, text/plain, */*',
+      },
+      delete: {},
+      get: {},
+      head: {},
+      post: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      authorization: SENSITIVE_STR,
+      a: 'b',
+    })
+  })
+})

--- a/src/tracing/utils.test.ts
+++ b/src/tracing/utils.test.ts
@@ -1,31 +1,31 @@
-import { cloneAndSanitizeHeaders } from './utils'
 import { SENSITIVE_STR } from '@vtex/node-error-report'
+import { cloneAndSanitizeHeaders } from './utils'
 
 describe('cloneAndSanitizeHeaders', () => {
   const headers = {
-    authorization: '1337',
     a: 'b',
+    authorization: '1337',
   }
 
   test('Original object is not modified', () => {
     cloneAndSanitizeHeaders(headers)
     expect(headers).toEqual({
-      authorization: '1337',
       a: 'b',
+      authorization: '1337',
     })
   })
 
   test('Sensitive information is redacted', () => {
     expect(cloneAndSanitizeHeaders(headers)).toEqual({
-      authorization: SENSITIVE_STR,
       a: 'b',
+      authorization: SENSITIVE_STR,
     })
   })
 
   test('Prefix is added if specified', () => {
     expect(cloneAndSanitizeHeaders(headers, 'test.')).toEqual({
-      'test.authorization': SENSITIVE_STR,
       'test.a': 'b',
+      'test.authorization': SENSITIVE_STR,
     })
   })
 
@@ -44,6 +44,8 @@ describe('cloneAndSanitizeHeaders', () => {
     }
 
     expect(cloneAndSanitizeHeaders(axiosHeader)).toEqual({
+      a: 'b',
+      authorization: SENSITIVE_STR,
       common: {
         Accept: 'application/json, text/plain, */*',
       },
@@ -53,8 +55,6 @@ describe('cloneAndSanitizeHeaders', () => {
       post: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
-      authorization: SENSITIVE_STR,
-      a: 'b',
     })
   })
 })

--- a/src/tracing/utils.ts
+++ b/src/tracing/utils.ts
@@ -1,5 +1,5 @@
-import { Span } from 'opentracing'
 import { authFields, sanitizeAuth } from '@vtex/node-error-report'
+import { Span } from 'opentracing'
 
 export interface TraceInfo {
   traceId: string

--- a/src/tracing/utils.ts
+++ b/src/tracing/utils.ts
@@ -1,4 +1,5 @@
 import { Span } from 'opentracing'
+import { authFields, sanitizeAuth } from '@vtex/node-error-report'
 
 export interface TraceInfo {
   traceId: string
@@ -11,4 +12,34 @@ export function getTraceInfo(span: Span): TraceInfo {
     isSampled: (spanContext as any).isSampled?.() ?? false,
     traceId: spanContext.toTraceId(),
   }
+}
+
+/**
+ * Do a shallow copy of a headers object and redacts sensitive information.
+ *
+ * @param headersObj The headers object
+ * @param resultFieldsPrefix The prefix that will be added to each field on the result object
+ */
+export const cloneAndSanitizeHeaders = (headersObj: Record<string, any>, resultFieldsPrefix: string = '') => {
+  const ret: Record<string, string> = {}
+  const entries = Object.entries(headersObj)
+  for (const [key, val] of entries) {
+    // Most of the time val is a string, but there are some cases, for example when we do a axios interceptor,
+    // that a header field can contain an object, for example:
+    // ```
+    // "common": {
+    //   "Accept": "application/json, text/plain, */*"
+    // },
+    // "delete": { },
+    // "get": { },
+    // "head": { },
+    // "post": {
+    //   "Content-Type": "application/x-www-form-urlencoded"
+    // },
+    // ```
+    // In those corner cases we probably won't have a sensitive string as key, so we don't treat them here
+    ret[`${resultFieldsPrefix}${key}`] = authFields.includes(key) ? sanitizeAuth(val) : val
+  }
+
+  return ret
 }

--- a/src/utils/addPrefixOntoObjectKeys.ts
+++ b/src/utils/addPrefixOntoObjectKeys.ts
@@ -1,8 +1,0 @@
-export const addPrefixOntoObjectKeys = (prefix: string, obj: Record<string, string>) => {
-  const ret: Record<string, string> = {}
-  const entries = Object.entries(obj)
-  for (const [key, val] of entries) {
-    ret[`${prefix}.${key}`] = val
-  }
-  return ret
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -756,10 +756,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/node-error-report@^0.0.3-beta.4":
-  version "0.0.3-beta.4"
-  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.3-beta.4.tgz#2361fa1bf63659e18ff70b3cf99ee01582c19c8d"
-  integrity sha512-B7f3o/Nouw3ZCqHFOoN4x2z0mjAoIj0xSMKUJ9bDdL4VUFIfXcb213XOEd8xltDpdLJvpOafxE52ymYYYe8NHQ==
+"@vtex/node-error-report@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.3.tgz#365a2652aeebbd6b51ddc5d64c3c0bc1a326dc71"
+  integrity sha512-HhBworWQfSs6PU3yroloc7H2/pWboDIzgdiJ6SYc3mJVRU5/bXtwM9HGPkAGZvAb/0cMwFC963SYYKvOfeSjbA==
   dependencies:
     is-stream "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -756,10 +756,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/node-error-report@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.2.tgz#edf15095d6bb543d28b46f86bc109e6214149dfe"
-  integrity sha512-Q6V8E1IR/U0H6uTB1G+gH4ugL4Kw1l/WsK7W46LQBsxv4ISlZcO7dXPlWrL4RzRcVam5yzGAwNkv2wJdW61tAA==
+"@vtex/node-error-report@^0.0.3-beta.4":
+  version "0.0.3-beta.4"
+  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.3-beta.4.tgz#2361fa1bf63659e18ff70b3cf99ee01582c19c8d"
+  integrity sha512-B7f3o/Nouw3ZCqHFOoN4x2z0mjAoIj0xSMKUJ9bDdL4VUFIfXcb213XOEd8xltDpdLJvpOafxE52ymYYYe8NHQ==
   dependencies:
     is-stream "^2.0.0"
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Update @vtex/node-error-report with the changes on https://github.com/vtex/node-error-report/pull/3 to redact sensitive fields.
- Sanitize headers logged by distributed tracing.

#### How should this be manually tested?

You can ask me to show it working, I have prepared a running example with the changes.

Send a request with jaeger-debug-id to a service and check:
- The entrypoint span should redact headers like `x-vtex-credential` on the request headers log.
- Request spans should redact authorization and proxy-authorization headers on request headers (and response headers if any of these headers are present).
- Span error logs should redact auth headers (example of the new behavior: [error on splunk]( https://splunk72.vtex.com/en-US/app/vtex_io_apps/search?earliest=-4h%40m&latest=now&q=search%20index%3Dio_vtex_logs%20d0c54bb6a5ac945571806b78ad69136a&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&sid=1597775787.677959_D730961E-090B-4E7E-A081-1F7623D93A11&workload_pool=) - note that in case of JWT tokens only a portion is redacted - this behavior is documented [here](https://github.com/vtex/node-error-report/blob/591e5df2675c56a75c71063b9dfee11c181e9766/src/utils/cloneAndSanitizeObject.ts#L21-L38))

![Screenshot from 2020-08-18 15-36-56](https://user-images.githubusercontent.com/26463288/90552114-b8b5ec00-e168-11ea-8c43-50ead7d3232b.png)


The fields filtered are: https://github.com/vtex/node-error-report/blob/591e5df2675c56a75c71063b9dfee11c181e9766/src/utils/cloneAndSanitizeObject.ts#L3-L13

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
