### PR TITLE
Allow sending events to any resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Allow sending events to any resource
 
 ## [6.36.2] - 2020-08-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.36.3] - 2020-09-09
 ### Changed
 - Allow sending events to any resource
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.36.2",
+  "version": "6.36.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/infra/Events.ts
+++ b/src/clients/infra/Events.ts
@@ -1,19 +1,25 @@
+import { isNullOrUndefined, isObject } from 'util'
 import { InstanceOptions, RequestTracingConfig } from '../../HttpClient'
 import { IOContext } from '../../service/worker/runtime/typings'
 import { InfraClient } from './InfraClient'
 
+const ANY_APP = ''
 const eventRoute = (route: string) => `/events/${route}`
+const isResourceVRN = (appIdOrResource: string | ResourceVRN): appIdOrResource is ResourceVRN =>
+  isObject(appIdOrResource) && !isNullOrUndefined((appIdOrResource as ResourceVRN).service)
 
 export class Events extends InfraClient {
-  constructor(context: IOContext, options?: InstanceOptions) {
-    super('courier@0.x', { ...context, recorder: undefined }, options)
+  constructor({ recorder, ...context }: IOContext, options?: InstanceOptions) {
+    super('courier@0.x', context, options)
   }
 
-  public sendEvent = (subject: string, route: string, message?: any, tracingConfig?: RequestTracingConfig) => {
-    const resource =
-      subject === ''
-        ? ''
-        : `vrn:apps:aws-us-east-1:${this.context.account}:${this.context.workspace}:/apps/${subject}`
+  public sendEvent = (
+    appIdOrResource: string | ResourceVRN,
+    route: string,
+    message?: any,
+    tracingConfig?: RequestTracingConfig
+  ) => {
+    const resource = this.resourceFor(appIdOrResource)
     return this.http.put(eventRoute(route), message, {
       metric: 'events-send',
       params: { resource },
@@ -23,4 +29,19 @@ export class Events extends InfraClient {
       },
     })
   }
+
+  private resourceFor = (appIdOrResource: string | ResourceVRN) => {
+    if (appIdOrResource === ANY_APP) {
+      return ANY_APP
+    }
+    const { service, path } = isResourceVRN(appIdOrResource)
+      ? appIdOrResource
+      : { service: 'apps', path: `/apps/${appIdOrResource}` }
+    return `vrn:${service}:${this.context.region}:${this.context.account}:${this.context.workspace}:${path}`
+  }
+}
+
+export interface ResourceVRN {
+  service: string
+  path: string
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Support sending events to arbitrary resources.

#### What problem is this solving?

Currently, we only support sending events to apps, and due to a backwards compatibility feature the only possible VRN is this one [`vrn:apps:aws-us-east-1:${this.context.account}:${this.context.workspace}:/apps/${subject}`](https://github.com/vtex/node-vtex-api/blob/master/src/clients/infra/Events.ts#L16).

This change is intended to maintain compatibility but add the option to send an event to any [resource](https://github.com/vtex/io-platform/tree/master/authorization#resources).

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
