### PR TITLE
Feature/md search pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.37.0] - 2020-10-08
 ### Added
 - `searchDocumentsWithPaginationInfo` on Masterdata client
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `searchDocumentsWithPaginationInfo` on Masterdata client
 
 ## [6.36.3] - 2020-09-09
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.36.3",
+  "version": "6.37.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adding a method on Masterdata client to search for documents and return pagination info found on the headers.

<!--- Describe your changes in detail. -->

#### What problem is this solving?
Creating UIs that rely on total amount of documents retrieved.
 
#### How should this be manually tested?
Use the `searchDocumentsWithPaginationInfo` in any MD entity

![image](https://user-images.githubusercontent.com/11340665/95118084-0e962180-0720-11eb-92e3-327aacf4c7e1.png)

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
