### PR TITLE
Add logs to MineWinsConflict resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.37.1] - 2020-12-10
 ### Changed
 - Add logs to MineWinsConflictResolver
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add logs to MineWinsConflictResolver
 
 ## [6.37.0] - 2020-10-08
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.37.0",
+  "version": "6.37.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/infra/VBase.ts
+++ b/src/clients/infra/VBase.ts
@@ -1,10 +1,10 @@
-import { Logger } from './../../service/logger/logger';
 import { AxiosError } from 'axios'
 import { IncomingMessage } from 'http'
 import mime from 'mime-types'
 import { basename } from 'path'
 import { Readable } from 'stream'
 import { createGzip } from 'zlib'
+import { Logger } from './../../service/logger/logger'
 
 import {
   inflightURL,

--- a/src/clients/infra/VBase.ts
+++ b/src/clients/infra/VBase.ts
@@ -1,3 +1,4 @@
+import { Logger } from './../../service/logger/logger';
 import { AxiosError } from 'axios'
 import { IncomingMessage } from 'http'
 import mime from 'mime-types'
@@ -98,7 +99,8 @@ export class VBase extends InfraClient {
       .catch(async (error: AxiosError<T>) => {
         const { response } = error
         if (response && response.status === 409 && conflictsResolver) {
-          return { ...response, data: await conflictsResolver.resolve() } as IOResponse<T>
+          const conflictsMergedData = await conflictsResolver.resolve(this.context.logger)
+          return { ...response, data: conflictsMergedData } as IOResponse<T>
         }
         throw error
       })
@@ -234,5 +236,5 @@ export interface VBaseConflict{
 }
 
 export interface ConflictsResolver<T>{
-  resolve: () => T | Promise<T>
+  resolve: (logger?: Logger) => T | Promise<T>
 }

--- a/src/utils/MineWinsConflictsResolver.ts
+++ b/src/utils/MineWinsConflictsResolver.ts
@@ -1,8 +1,8 @@
-import { Logger } from './../service/logger/logger';
 import { AxiosResponse } from 'axios'
 import { Base64 } from 'js-base64'
 import { eqProps, equals } from 'ramda'
 import { isArray, isObject } from 'util'
+import { Logger } from './../service/logger/logger'
 
 import {
   ConflictsResolver,
@@ -47,13 +47,13 @@ export class MineWinsConflictsResolver<T> implements ConflictsResolver<T> {
 
       if(logger){
         logger.info({
-          conflictsResolution: MineWinsConflictsResolver.constructor.name,
-          bucket: this.bucket,
-          filePath: this.filePath,
           base: selectedConflict.base.parsedContent,
+          bucket: this.bucket,
+          conflictsResolution: MineWinsConflictsResolver.constructor.name,
+          filePath: this.filePath,
           master: selectedConflict.master.parsedContent,
           mine: selectedConflict.mine.parsedContent,
-          resolved
+          resolved,
         })
       }
 

--- a/src/utils/MineWinsConflictsResolver.ts
+++ b/src/utils/MineWinsConflictsResolver.ts
@@ -1,3 +1,4 @@
+import { Logger } from './../service/logger/logger';
 import { AxiosResponse } from 'axios'
 import { Base64 } from 'js-base64'
 import { eqProps, equals } from 'ramda'
@@ -31,7 +32,7 @@ export class MineWinsConflictsResolver<T> implements ConflictsResolver<T> {
     this.comparableKeys = comparableKeys
   }
 
-  public async resolve() {
+  public async resolve(logger?: Logger) {
     return await this.client.getConflicts<AxiosResponse<VBaseConflictData[]>>(this.bucket).then(data => {
       const { data: conflicts }: { data: VBaseConflictData[] } = data
       const selectedConflict = conflicts.find(conflict => conflict.path === this.filePath)
@@ -43,6 +44,19 @@ export class MineWinsConflictsResolver<T> implements ConflictsResolver<T> {
       selectedConflict.master.parsedContent = this.parseConflict(selectedConflict.master)
       selectedConflict.mine.parsedContent = this.parseConflict(selectedConflict.mine)
       const resolved = this.resolveConflictMineWins(selectedConflict)
+
+      if(logger){
+        logger.info({
+          conflictsResolution: MineWinsConflictsResolver.constructor.name,
+          bucket: this.bucket,
+          filePath: this.filePath,
+          base: selectedConflict.base.parsedContent,
+          master: selectedConflict.master.parsedContent,
+          mine: selectedConflict.mine.parsedContent,
+          resolved
+        })
+      }
+
       return resolved as T
     })
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

1 - compile node-vtex-api: `yarn watch`
2 - link node-vtex-api: `yarn link`

Clone `pages-graphql` which is the app that uses this functionality 
`git clone git@github.com:vtex/pages-graphql.git`

link node-vtex-api to pages-graphql
1 - `cd pages-graphql`
2 - `yarn link @vtex/api`

Open a workspace in one account and link `pages-graphql` e.g:

1 - `vtex switch storecomponents`
2 - `vtex use jey -r`
3 - inside pages-graphql dir `vtex link --verbose`

Provoke a content conflict

1 - Edit some content in your workspace using admin site editor
2 - Edit some content in master workspace using admin site editor

Open your workspace now, you should be able to see the conflicts logs on pages-graphql link.

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
