### PR TITLE
Add @translateTo GraphQL directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `TranslateTo` schema directive.
+- `translations` util.
+- README's `Development with IO clients` directions.
+
+### Changed
+
+- Moved the `TranslatableMessageV2` interface, `parseTranslatableStringV2`, `formatTranslatableStringV2` and `handleSingleString` methods and `CONTEXT_REGEX`, `FROM_REGEX` and `CONTENT_REGEX` constants from the `TranslatableV2` schema directive to the `translations` util.
+- README's `Development` section format.
+
 ## [6.37.1] - 2020-12-10
 ### Changed
 - Add logs to MineWinsConflictResolver

--- a/README.md
+++ b/README.md
@@ -49,4 +49,17 @@ export const example = async (ctx: Context, next: () => Promise<void>) => {
 
 ## Development
 
-Install the dependencies (`yarn`) and run `yarn watch`.
+- Install the dependencies: `yarn`
+- Watch for changes: `yarn watch`
+
+### Development with IO clients
+
+- Install the dependencies: `yarn`
+- [Link](https://classic.yarnpkg.com/en/docs/cli/link/) this package: `yarn link`
+- Watch for changes: `yarn watch`
+- Move to the app that depends on the changes made on this package: `cd ../<your-app>/node`
+- Link this package to your app's node_modules: `yarn link @vtex/api`
+
+Now, when you get a workspace up and running for your app with `vtex link`, you'll have this package linked as well.
+
+> When done developing, don't forget to unlink it from `<your-app>/node`: `yarn unlink @vtex/api`

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslatableV2.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslatableV2.ts
@@ -1,16 +1,13 @@
 import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
-
 import { Behavior } from '../../../../../../clients'
-import { IOContext, ServiceContext } from '../../../typings'
-import { createMessagesLoader, MessagesLoaderV2 } from '../messagesLoaderV2'
 
-const CONTEXT_REGEX = /\(\(\((?<context>(.)*)\)\)\)/
-const FROM_REGEX = /\<\<\<(?<from>(.)*)\>\>\>/
-const CONTENT_REGEX = /\(\(\((?<context>(.)*)\)\)\)|\<\<\<(?<from>(.)*)\>\>\>/g
+import { ServiceContext } from '../../../typings'
+import { handleSingleString } from '../../utils/translations'
+import { createMessagesLoader } from '../messagesLoaderV2'
 
 interface Args {
-  behavior: 'FULL' | 'USER_AND_APP' | 'USER_ONLY'
+  behavior: Behavior
   withAppsMetaInfo: boolean
 }
 
@@ -34,60 +31,12 @@ export class TranslatableV2 extends SchemaDirectiveVisitor {
       }
       const response = await resolve(root, args, ctx, info) as string | string[] | null
       const { vtex, loaders: { messagesV2 } } = ctx
-      const handler = handleSingleString(vtex, messagesV2!, behavior)
+      const handler = handleSingleString(vtex, messagesV2!, behavior, 'translatableV2')
       return Array.isArray(response)
         ? Promise.all(response.map(handler))
         : handler(response)
     }
   }
-}
-
-export interface TranslatableMessageV2 {
-  from?: string
-  content: string
-  context?: string
-}
-
-export const parseTranslatableStringV2 = (rawMessage: string): TranslatableMessageV2 => {
-  const context = rawMessage.match(CONTEXT_REGEX)?.groups?.context
-  const from = rawMessage.match(FROM_REGEX)?.groups?.from
-  const content = rawMessage.replace(CONTENT_REGEX, '')
-
-  return {
-    content: content?.trim(),
-    context: context?.trim(),
-    from: from?.trim(),
-  }
-}
-
-export const formatTranslatableStringV2 = ({from, content, context}: TranslatableMessageV2): string =>
-  `${content} ${context ? `(((${context})))` : ''} ${from ? `<<<${from}>>>` : ''}`
-
-const handleSingleString = (ctx: IOContext, messagesV2: MessagesLoaderV2 , behavior: Behavior) => async (rawMessage: string | null) => {
-  // Messages only knows how to process non empty strings.
-  if (rawMessage == null) {
-    return rawMessage
-  }
-
-  const { content, context, from: maybeFrom } = parseTranslatableStringV2(rawMessage)
-  const { binding, tenant } = ctx
-
-  if (content == null) {
-    throw new Error(`@translatableV2 directive needs a content to translate, but received ${JSON.stringify(rawMessage)}`)
-  }
-
-  const from = maybeFrom || binding?.locale || tenant?.locale
-
-  if (from == null) {
-    throw new Error('@translatableV2 directive needs a source language to translate from. You can do this by either setting \`ctx.vtex.tenant\` variable, call this app with the header \`x-vtex-tenant\` or format the string with the \`formatTranslatableStringV2\` function with the \`from\` option set')
-  }
-
-  return messagesV2.load({
-    behavior,
-    content,
-    context,
-    from,
-  })
 }
 
 export const translatableV2DirectiveTypeDefs = `

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslateTo.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslateTo.ts
@@ -28,7 +28,7 @@ export class TranslateTo extends SchemaDirectiveVisitor {
         vtex,
         loaders: { immutableMessagesV2 },
       } = ctx
-      const handler = handleSingleString(vtex, immutableMessagesV2!, behavior, 'translatableV2')
+      const handler = handleSingleString(vtex, immutableMessagesV2!, behavior, 'translateTo')
       return Array.isArray(response) ? Promise.all(response.map(handler)) : handler(response)
     }
   }

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslateTo.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslateTo.ts
@@ -1,0 +1,42 @@
+import { defaultFieldResolver, GraphQLField } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+import { Behavior } from '../../../../../../clients'
+
+import { ServiceContext } from '../../../typings'
+import { handleSingleString } from '../../utils/translations'
+import { createMessagesLoader } from '../messagesLoaderV2'
+
+interface Args {
+  behavior: Behavior
+  language: string
+}
+
+export class TranslateTo extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, ServiceContext>) {
+    const { resolve = defaultFieldResolver } = field
+    const { language, behavior = 'FULL' } = this.args as Args
+    field.resolve = async (root, args, ctx, info) => {
+      if (!ctx.loaders?.messagesV2Manual) {
+        const dependencies = await ctx.clients.apps.getAppsMetaInfos()
+        ctx.loaders = {
+          ...ctx.loaders,
+          messagesV2Manual: createMessagesLoader(ctx.clients, language, dependencies),
+        }
+      }
+      const response = (await resolve(root, args, ctx, info)) as string | string[] | null
+      const {
+        vtex,
+        loaders: { messagesV2Manual },
+      } = ctx
+      const handler = handleSingleString(vtex, messagesV2Manual!, behavior, 'translatableV2')
+      return Array.isArray(response) ? Promise.all(response.map(handler)) : handler(response)
+    }
+  }
+}
+
+export const translateToDirectiveTypeDefs = `
+directive @translateTo(
+  language: String!
+  behavior: String
+) on FIELD_DEFINITION
+`

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslateTo.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslateTo.ts
@@ -16,19 +16,19 @@ export class TranslateTo extends SchemaDirectiveVisitor {
     const { resolve = defaultFieldResolver } = field
     const { language, behavior = 'FULL' } = this.args as Args
     field.resolve = async (root, args, ctx, info) => {
-      if (!ctx.loaders?.messagesV2Manual) {
+      if (!ctx.loaders?.immutableMessagesV2) {
         const dependencies = await ctx.clients.apps.getAppsMetaInfos()
         ctx.loaders = {
           ...ctx.loaders,
-          messagesV2Manual: createMessagesLoader(ctx.clients, language, dependencies),
+          immutableMessagesV2: createMessagesLoader(ctx.clients, language, dependencies),
         }
       }
       const response = (await resolve(root, args, ctx, info)) as string | string[] | null
       const {
         vtex,
-        loaders: { messagesV2Manual },
+        loaders: { immutableMessagesV2 },
       } = ctx
-      const handler = handleSingleString(vtex, messagesV2Manual!, behavior, 'translatableV2')
+      const handler = handleSingleString(vtex, immutableMessagesV2!, behavior, 'translatableV2')
       return Array.isArray(response) ? Promise.all(response.map(handler)) : handler(response)
     }
   }

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
@@ -3,16 +3,11 @@ import { CacheControl, cacheControlDirectiveTypeDefs } from './CacheControl'
 import { Deprecated, deprecatedDirectiveTypeDefs } from './Deprecated'
 import { SanitizeDirective, sanitizeDirectiveTypeDefs } from './Sanitize'
 import { SettingsDirective, settingsDirectiveTypeDefs } from './Settings'
-import {
-  SmartCacheDirective,
-  smartCacheDirectiveTypeDefs,
-} from './SmartCacheDirective'
-import {
-  TranslatableV2,
-  translatableV2DirectiveTypeDefs,
-} from './TranslatableV2'
+import { SmartCacheDirective, smartCacheDirectiveTypeDefs } from './SmartCacheDirective'
+import { TranslatableV2, translatableV2DirectiveTypeDefs } from './TranslatableV2'
+import { TranslateTo, translateToDirectiveTypeDefs } from './TranslateTo'
 
-export { parseTranslatableStringV2, formatTranslatableStringV2 } from './TranslatableV2'
+export { parseTranslatableStringV2, formatTranslatableStringV2 } from '../../utils/translations'
 
 export const nativeSchemaDirectives = {
   auth: Auth,
@@ -22,6 +17,7 @@ export const nativeSchemaDirectives = {
   settings: SettingsDirective,
   smartcache: SmartCacheDirective,
   translatableV2: TranslatableV2,
+  translateTo: TranslateTo,
 }
 
 export const nativeSchemaDirectivesTypeDefs = [
@@ -32,4 +28,5 @@ export const nativeSchemaDirectivesTypeDefs = [
   settingsDirectiveTypeDefs,
   smartCacheDirectiveTypeDefs,
   translatableV2DirectiveTypeDefs,
+  translateToDirectiveTypeDefs,
 ].join('\n\n')

--- a/src/service/worker/runtime/graphql/utils/translations.ts
+++ b/src/service/worker/runtime/graphql/utils/translations.ts
@@ -1,0 +1,66 @@
+import { Behavior } from '../../../../../clients'
+import { IOContext } from '../../typings'
+import { MessagesLoaderV2 } from '../schema/messagesLoaderV2'
+
+export const CONTEXT_REGEX = /\(\(\((?<context>(.)*)\)\)\)/
+export const FROM_REGEX = /\<\<\<(?<from>(.)*)\>\>\>/
+export const CONTENT_REGEX = /\(\(\((?<context>(.)*)\)\)\)|\<\<\<(?<from>(.)*)\>\>\>/g
+
+export interface TranslatableMessageV2 {
+  from?: string
+  content: string
+  context?: string
+}
+
+export type TranslationDirectiveType = 'translatableV2' | 'translateTo'
+
+export const parseTranslatableStringV2 = (rawMessage: string): TranslatableMessageV2 => {
+  const context = rawMessage.match(CONTEXT_REGEX)?.groups?.context
+  const from = rawMessage.match(FROM_REGEX)?.groups?.from
+  const content = rawMessage.replace(CONTENT_REGEX, '')
+
+  return {
+    content: content?.trim(),
+    context: context?.trim(),
+    from: from?.trim(),
+  }
+}
+
+export const formatTranslatableStringV2 = ({ from, content, context }: TranslatableMessageV2): string =>
+  `${content} ${context ? `(((${context})))` : ''} ${from ? `<<<${from}>>>` : ''}`
+
+export const handleSingleString = (
+  ctx: IOContext,
+  loader: MessagesLoaderV2,
+  behavior: Behavior,
+  directiveName: TranslationDirectiveType
+) => async (rawMessage: string | null) => {
+  // Messages only knows how to process non empty strings.
+  if (rawMessage == null) {
+    return rawMessage
+  }
+
+  const { content, context, from: maybeFrom } = parseTranslatableStringV2(rawMessage)
+  const { binding, tenant } = ctx
+
+  if (content == null) {
+    throw new Error(
+      `@${directiveName} directive needs a content to translate, but received ${JSON.stringify(rawMessage)}`
+    )
+  }
+
+  const from = maybeFrom || binding?.locale || tenant?.locale
+
+  if (from == null) {
+    throw new Error(
+      `@${directiveName} directive needs a source language to translate from. You can do this by either setting ${'`ctx.vtex.tenant`'} variable, call this app with the header ${'`x-vtex-tenant`'} or format the string with the ${'`formatTranslatableStringV2`'} function with the ${'`from`'} option set`
+    )
+  }
+
+  return loader.load({
+    behavior,
+    content,
+    context,
+    from,
+  })
+}

--- a/src/service/worker/runtime/graphql/utils/translations.ts
+++ b/src/service/worker/runtime/graphql/utils/translations.ts
@@ -35,7 +35,7 @@ export const handleSingleString = (
   behavior: Behavior,
   directiveName: TranslationDirectiveType
 ) => async (rawMessage: string | null) => {
-  // Messages only knows how to process non empty strings.
+  // Messages only know how to process non empty strings.
   if (rawMessage == null) {
     return rawMessage
   }

--- a/src/service/worker/runtime/typings.ts
+++ b/src/service/worker/runtime/typings.ts
@@ -60,7 +60,7 @@ type KnownKeys<T> = {
 interface Loaders {
   messages?: DataLoader<IOMessage, string>
   messagesV2?: MessagesLoaderV2
-  messagesV2Manual?: MessagesLoaderV2
+  immutableMessagesV2?: MessagesLoaderV2
 }
 
 export type ServiceContext<ClientsT extends IOClients = IOClients, StateT extends RecorderState = RecorderState, CustomT extends ParamsContext = ParamsContext> = Pick<ParameterizedContext<StateT, Context<ClientsT>>, KnownKeys<ParameterizedContext<StateT, Context<ClientsT>>>> & CustomT & { loaders?: Loaders }

--- a/src/service/worker/runtime/typings.ts
+++ b/src/service/worker/runtime/typings.ts
@@ -60,6 +60,7 @@ type KnownKeys<T> = {
 interface Loaders {
   messages?: DataLoader<IOMessage, string>
   messagesV2?: MessagesLoaderV2
+  messagesV2Manual?: MessagesLoaderV2
 }
 
 export type ServiceContext<ClientsT extends IOClients = IOClients, StateT extends RecorderState = RecorderState, CustomT extends ParamsContext = ParamsContext> = Pick<ParameterizedContext<StateT, Context<ClientsT>>, KnownKeys<ParameterizedContext<StateT, Context<ClientsT>>>> & CustomT & { loaders?: Loaders }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the `translateTo` GraphQL directive to allow clients to specify which language they want the translatable strings to be translated. This is particularly useful for the Marketing team, which needs a fixed set of strings to be sent to Amplitude from user interactions on the admin. **Currently, we have a hardcoded set of message IDs translated to English. This is not scalable and this is the particular problem we're trying to solve.**

The `TranslatableMessageV2` interface, `parseTranslatableStringV2`, `formatTranslatableStringV2` and `handleSingleString` methods and `CONTEXT_REGEX`, `FROM_REGEX` and `CONTENT_REGEX` constants from the TranslatableV2 schema directive were moved to a util file called `translations.ts`. A new schema directive, TranslateTo, was created, which then shares the methods moved to the `translations` utils with the TranslatableV2 schema. The main difference between the TranslateTo and the TranslatableV2 schemas is that they share different loaders, and get the "language to translate" from different sources.

#### What problem is this solving?

It gives clients the ability to control the desired language to be translated, instead of counting solely on the locale context.

This is particularly useful for the Marketing team, which needs a fixed set of strings to be sent to Amplitude from user interactions on the admin. **Currently, we have a hardcoded set of message IDs translated to English. This is not scalable and this is the particular problem we're trying to solve.**

#### How should this be manually tested?

You can visit [this workspace and run the navigation query](https://marcelocardoso2--recorrenciaqa.myvtex.com/_v/private/vtex.admin-graphql@2.19.1/graphiql/v1?query=query%20Navigation%20%7B%0A%09navigation(adminVersion%3A%20v3)%20%7B%0A%20%20%09navigation%20%7B%0A%20%20%20%20%20%20items%20%7B%0A%20%20%20%20%20%20%20%20titleId%0A%20%20%20%20%20%20%20%20englishTitle%0A%20%20%20%20%20%20%20%20subItems%20%7B%0A%20%20%20%20%20%20%20%20%20%20labelId%20%0A%20%20%20%20%20%20%20%20%20%20englishLabel%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%09%0A%09%7D%0A%7D&operationName=Navigation). You'll see the `englishTitle` and `englishLabel` fields doesn't change regardless of what language is set on the IO context for your account. Or, you can:
- `yarn link` this project as @vtex/api
- Switch to the branch `feat/translateTo-directive` and run `yarn watch`
- Jump to the [admin-graphql](https://github.com/vtex/admin-graphql)'s `feat/translateTo-directive-usage` branch, and inside the `node` folder, run `yarn link @vtex/api`
- Link the app with `vtex link` and navigate to it's GraphiQL
- Add this query on GraphiQL (test it with adminVersion set to `v4` as well):
```graphql 
query Navigation {
  navigation(adminVersion: v3) {
    navigation {
      items {
        titleId
        englishTitle
        subItems {
          labelId
          englishLabel
        }
      }
    }
  }
}
```
- Play with this type, switching the language (following the IETFL language tag format) on the `@translateTo` directive: https://github.com/vtex/admin-graphql/blob/95c827fe1a7c7c68d3320969db435cc36ea5ced8/graphql/home.graphql#L105
- You should see the `englishTitle` and the `englishLabel` translated to the language set on the directive, as demonstrated below :point_down: 

#### Screenshots or example usage

```graphql 
type NavigationSubItem {
   # ...
  englishLabel: String @translateTo(language: "en-US")
}

type NavigationItem {
  # ...
  englishTitle: String @translateTo(language: "en-US")
}
```
![image](https://user-images.githubusercontent.com/33183880/104358147-cf305b80-54ec-11eb-9071-b41e295578ad.png)

---

We can pass any IETF language tag to the language param (the examples below are for demonstration purposes only).

```graphql 
type NavigationSubItem {
   # ...
  englishLabel: String @translateTo(language: "es-AR")
}

type NavigationItem {
  # ...
  englishTitle: String @translateTo(language: "es-AR")
}
```
![image](https://user-images.githubusercontent.com/33183880/104358249-ee2eed80-54ec-11eb-9bd0-a95279a63bf8.png)

---

```graphql 
type NavigationSubItem {
   # ...
  englishLabel: String @translateTo(language: "fr-FR")
}

type NavigationItem {
  # ...
  englishTitle: String @translateTo(language: "fr-FR")
}
```
![image](https://user-images.githubusercontent.com/33183880/104358379-220a1300-54ed-11eb-86d5-946f81b96200.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.


#### Related to

https://github.com/vtex/admin-graphql/pull/168