### PR TITLE
variable size keyword fields are correctly read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Adds support for a variable brand keywords array size for different languages. 
 
 ## [6.37.1] - 2020-12-10
 ### Changed

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,4 +72,4 @@ export const INSPECT_DEBUGGER_PORT = 5858
 
 export const cancellableMethods = new Set(['GET', 'OPTIONS', 'HEAD'])
 
-export const KEYWORDS_WILDCARD = "KeywordAssignedWildcard"
+export const KEYWORDS_WILDCARD = 'KeywordAssignedWildcard'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,3 +71,5 @@ export const PRODUCTION = process.env.VTEX_PRODUCTION === 'true'
 export const INSPECT_DEBUGGER_PORT = 5858
 
 export const cancellableMethods = new Set(['GET', 'OPTIONS', 'HEAD'])
+
+export const KEYWORDS_WILDCARD = "KeywordAssignedWildcard"

--- a/src/service/worker/runtime/graphql/schema/messagesLoaderV2.ts
+++ b/src/service/worker/runtime/graphql/schema/messagesLoaderV2.ts
@@ -7,7 +7,9 @@ import {
 } from '../../../../../clients/apps/MessagesGraphQL'
 import { AppMetaInfo } from '../../../../../clients/infra/Apps'
 import { IOClients } from './../../../../../clients/IOClients'
-import { KEYWORDS_WILDCARD } from '../../../../../constants'
+import { KEYWORDS_WILDCARD } from './../../../../../constants'
+
+
 
 type Indexed<X> = [number, X]
 
@@ -82,7 +84,7 @@ const removeKeywordWildcards = (indexedMessages:Array<[number, string]>) => {
     return indexedMessages
   }
 
-  const sanitizedIndexedMessages = indexedMessages.slice(0, keywordWildcardIndex).concat([[keywordWildcardIndex, ""]], indexedMessages.slice(keywordWildcardIndex + 1))
+  const sanitizedIndexedMessages = indexedMessages.slice(0, keywordWildcardIndex).concat([[keywordWildcardIndex, '']], indexedMessages.slice(keywordWildcardIndex + 1))
   return sanitizedIndexedMessages
 }
 

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslatableV2.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslatableV2.ts
@@ -2,9 +2,10 @@ import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 
 import { Behavior } from '../../../../../../clients'
+import { KEYWORDS_WILDCARD } from '../../../../../../constants'
 import { IOContext, ServiceContext } from '../../../typings'
 import { createMessagesLoader, MessagesLoaderV2 } from '../messagesLoaderV2'
-import { KEYWORDS_WILDCARD } from '../../../../../../constants'
+
 
 const CONTEXT_REGEX = /\(\(\((?<context>(.)*)\)\)\)/
 const FROM_REGEX = /\<\<\<(?<from>(.)*)\>\>\>/
@@ -98,8 +99,8 @@ const getKeywordsReference = (keywords: string[]) => {
   const keywordsReferenceContent = KEYWORDS_WILDCARD
   const keywordsReferenceMessage = {
     content: keywordsReferenceContent,
-    context: context,
-    from: from
+    context,
+    from,
   }
 
   return formatTranslatableStringV2(keywordsReferenceMessage)
@@ -109,7 +110,7 @@ const parseToKeywordArray = (keywords: string | null) => {
   return keywords!.split(',').map(keyword => keyword.trim())
 }
 
-const shouldGetKeywordsRef = (isKeywordArray: Boolean, response: string[] , locale: string | undefined) => {
+const shouldGetKeywordsRef = (isKeywordArray: boolean, response: string[] , locale: string | undefined) => {
   return isKeywordArray && response && parseTranslatableStringV2(response[0]).from?.split('-')[0] !== locale?.split('-')[0]
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Provide a simple experience for handling translations through the catalog

#### What problem is this solving?
The brand keywords field array can now assume different sizes for different languages

#### How should this be manually tested?
By linking this version of node-vtex-api through yarn link to [this version](https://github.com/vtex/catalog-graphql/pull/229) of the catalog running `vtex link` on the account fashion2 with workspace juaresba, setting keywords translations with this query:

mutation {
  translateBrand(brand: {
    id: 2000000,
    keywords: ["testkeyword1", "testkeyword2"]
  }
  locale: "pt-BR")
}

And finally, reading the results in en-US, pt-BR and es-ES with this query:
{
  brand(id: 2000000) {
    name
    keywords
  }
}

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
