### PR TITLE
Increase http agent connection pool free sockets and lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.39.1] - 2021-02-05
 - Increase HTTP agents connection pools freeSockets and lifetime
 
 ## [6.39.0] - 2021-01-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Increase HTTP agents connection pools freeSockets and lifetime
 
 ## [6.39.0] - 2021-01-27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.39.0",
+  "version": "6.39.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/agents.ts
+++ b/src/HttpClient/agents.ts
@@ -4,7 +4,7 @@ type HttpOptions = Omit<AgentHttpOptions, 'freeSocketTimeout' | 'keepAlive' | 'm
 
 export const createHttpAgent = (opts?: HttpOptions) => new HttpAgent({
   ...opts,
-  freeSocketTimeout: 15 * 1000,
+  freeSocketTimeout: 60 * 1000,
   keepAlive: true,
   maxFreeSockets: 256,
 })
@@ -13,7 +13,7 @@ type HttpsOptions = Omit<AgentHttpsOptions, 'freeSocketTimeout' | 'keepAlive' | 
 
 export const createHttpsAgent = (opts?: HttpsOptions) => new HttpsAgent({
   ...opts,
-  freeSocketTimeout: 15 * 1000,
+  freeSocketTimeout: 60 * 1000,
   keepAlive: true,
   maxFreeSockets: 256,
 })

--- a/src/HttpClient/agents.ts
+++ b/src/HttpClient/agents.ts
@@ -6,7 +6,7 @@ export const createHttpAgent = (opts?: HttpOptions) => new HttpAgent({
   ...opts,
   freeSocketTimeout: 15 * 1000,
   keepAlive: true,
-  maxFreeSockets: 50,
+  maxFreeSockets: 256,
 })
 
 type HttpsOptions = Omit<AgentHttpsOptions, 'freeSocketTimeout' | 'keepAlive' | 'maxFreeSockets'>
@@ -15,5 +15,5 @@ export const createHttpsAgent = (opts?: HttpsOptions) => new HttpsAgent({
   ...opts,
   freeSocketTimeout: 15 * 1000,
   keepAlive: true,
-  maxFreeSockets: 50,
+  maxFreeSockets: 256,
 })

--- a/src/HttpClient/agents.ts
+++ b/src/HttpClient/agents.ts
@@ -4,7 +4,8 @@ type HttpOptions = Omit<AgentHttpOptions, 'freeSocketTimeout' | 'keepAlive' | 'm
 
 export const createHttpAgent = (opts?: HttpOptions) => new HttpAgent({
   ...opts,
-  freeSocketTimeout: 60 * 1000,
+  socketActiveTTL: 120 * 1000,
+  freeSocketTimeout: 30 * 1000,
   keepAlive: true,
   maxFreeSockets: 256,
 })
@@ -13,7 +14,8 @@ type HttpsOptions = Omit<AgentHttpsOptions, 'freeSocketTimeout' | 'keepAlive' | 
 
 export const createHttpsAgent = (opts?: HttpsOptions) => new HttpsAgent({
   ...opts,
-  freeSocketTimeout: 60 * 1000,
+  socketActiveTTL: 120 * 1000,
+  freeSocketTimeout: 30 * 1000,
   keepAlive: true,
   maxFreeSockets: 256,
 })

--- a/src/HttpClient/agents.ts
+++ b/src/HttpClient/agents.ts
@@ -4,18 +4,18 @@ type HttpOptions = Omit<AgentHttpOptions, 'freeSocketTimeout' | 'keepAlive' | 'm
 
 export const createHttpAgent = (opts?: HttpOptions) => new HttpAgent({
   ...opts,
-  socketActiveTTL: 120 * 1000,
   freeSocketTimeout: 30 * 1000,
   keepAlive: true,
   maxFreeSockets: 256,
+  socketActiveTTL: 120 * 1000,
 })
 
 type HttpsOptions = Omit<AgentHttpsOptions, 'freeSocketTimeout' | 'keepAlive' | 'maxFreeSockets'>
 
 export const createHttpsAgent = (opts?: HttpsOptions) => new HttpsAgent({
   ...opts,
-  socketActiveTTL: 120 * 1000,
   freeSocketTimeout: 30 * 1000,
   keepAlive: true,
   maxFreeSockets: 256,
+  socketActiveTTL: 120 * 1000,
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is to allow the node framework from VTEX IO to support more diverse
use cases, by allowing apps to keep a larger connection pool, and also to
keep those connections alive for longer.

The value of 256 is actually the current default of node HTTP(S) agents, so
that's where the value came from. I decided to keep it explicit anyway, so we
have visibility about that configuration and can consider re-tuning it in the future.

To validate this change, I kept it running in a separate cluster (`stores-3a`) for a
whole week, to ensure that we didn't have any degradation and also to investigate
what improvements we would get. For now, the main apps that seem to benefit from
this are the `google-apis-proxy`, `search-resolver`, and the known `apps-graphql@2.x`
which couldn't update to the latest runtime because of the perf impact it was getting
(previously we didn't use to configure this, so it was operating with the 256-sized pool
already and had an observable regression when updating to the latest runtime)

Some queries:
 - [[apps with >100 free sockets]](https://splunk72.vtex.com/en-US/app/search/search?q=search%20index%3Dio_vtex_logs%20cluster%3Dstores-3a%20app%3Dvtex.*%20production%3Dtrue%20status.name%3D%22httpAgent%22%20%0A%7C%20stats%20p90(status.freeSockets)%20as%20freeSockets%20by%20app%0A%7C%20sort%20-freeSockets%0A%7C%20where%20freeSockets%20%3E%3D%20100%0A%7C%20eval%20app%3D%22%5C%22%22%2Bapp%2B%22%5C%22%22%0A%7C%20stats%20values(app)%20as%20apps%0A%7C%20eval%20apps%3D%22(%22%2Bmvjoin(apps%2C%20%22%20%22)%2B%22)%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1611352800&latest=1611959208&display.page.search.tab=statistics&display.general.type=statistics&sid=1611959381.1213381_5D3C75C2-A8BC-4E6E-8C2F-95794CD3FA6F)
 - [[effect of the change in the apps latency]](https://splunk72.vtex.com/en-US/app/search/search?q=search%20index%3Dkuberouter%20ClusterId%20IN%20(stores-2a%20stores-3a)%20kpi_name%3DServiceLatency%20serviceName%20IN%20(%22vtex.google-apis-proxy%400.10.2%22%20%22vtex.render-server%40*%22%20%22vtex.graphql-server%401.66.3%22%20%22vtex.search-resolver%401.32.1%22)%0A%7C%20eval%20s3a_count%3Dif(ClusterId%3D%22stores-3a%22%2C%20kpi_count%2C%200)%2C%20s3a_sum%3Dif(ClusterId%3D%22stores-3a%22%2C%20kpi_sum%2C%200)%2C%20s3a_max%3Dif(ClusterId%3D%22stores-3a%22%2C%20kpi_max%2C%200)%0A%7C%20eval%20s2a_count%3Dif(ClusterId%3D%22stores-2a%22%2C%20kpi_count%2C%200)%2C%20s2a_sum%3Dif(ClusterId%3D%22stores-2a%22%2C%20kpi_sum%2C%200)%2C%20s2a_max%3Dif(ClusterId%3D%22stores-2a%22%2C%20kpi_max%2C%200)%0A%7C%20bin%20span%3D3h%20_time%0A%7C%20stats%20sum(s3a_sum)%20as%20s3a_sum%20sum(s3a_count)%20as%20s3a_count%20sum(s2a_sum)%20as%20s2a_sum%20sum(s2a_count)%20as%20s2a_count%20max(s3a_max)%20as%20s3a_max%20max(s2a_max)%20as%20s2a_max%20by%20_time%2C%20serviceName%0A%7C%20eval%20s3a_avg%3Ds3a_sum%2Fs3a_count%2C%20s2a_avg%3Ds2a_sum%2Fs2a_count%2C%20s23_diff%3D(s2a_avg-s3a_avg)%0A%7C%20streamstats%20sum(s23_diff)%20as%20s23_cum_diff%20by%20serviceName%0A%7C%20timechart%20limit%3D100%20span%3D3h%20avg(s3a_avg)%20as%20pools_avg%20avg(s2a_avg)%20as%20curr_avg%20last(s23_cum_diff)%20as%20cumm_improvement%20by%20serviceName&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1611630000&latest=1611889200&display.page.search.tab=visualizations&display.general.type=visualizations&display.visualizations.trellis.enabled=1&display.visualizations.charting.legend.placement=right&display.visualizations.charting.axisTitleX.visibility=visible&display.visualizations.charting.axisTitleY.visibility=visible&display.visualizations.charting.axisTitleY2.visibility=visible&display.visualizations.trellis.size=large&display.visualizations.trellis.scales.shared=0&display.visualizations.chartHeight=1580&display.visualizations.charting.chart.overlayFields=improvement&display.visualizations.charting.axisY2.enabled=0&display.visualizations.charting.axisY2.scale=inherit&display.visualizations.charting.axisY2.abbreviation=none&display.visualizations.charting.axisY.minimumNumber=&display.visualizations.charting.axisY2.minimumNumber=&display.visualizations.charting.axisY2.maximumNumber=&sid=1611959278.1213350_5D3C75C2-A8BC-4E6E-8C2F-95794CD3FA6F) (observe the google-apis-proxy especially)
 - [[no negative impact observable in the border/tracon]](https://splunk72.vtex.com/en-US/app/vtex_tracon/search?s=%2FservicesNS%2Fnobody%2Fvtex_tracon%2Fsaved%2Fsearches%2FIO%2520Production%2520Clusters%2520Health&display.page.search.mode=smart&dispatch.sample_ratio=1&q=search%20index%3Dtracon%20cluster_id%20IN%20(stores-*a)%20domain%3D%22*%22%0A%7C%20bin%20span%3D3h%20_time%0A%7C%20eval%20result%20%3D%20if(status%3E%3D500%20OR%20status%3D429%2C%20%22error%22%2C%20%22success%22)%0A%7C%20stats%20count%20as%20status_count%20avg(duration_response_to_client)%20as%20avg_success_latency_per_min%20stdev(duration_response_to_client)%20as%20stdev_latency%20by%20cluster_id%2C%20result%2C%20_time%0A%7C%20eval%20status_count%3D10*status_count%0A%7C%20eventstats%20sum(status_count)%20as%20reqs_per_min%20by%20cluster_id%2C%20_time%0A%7C%20where%20result%3D%22success%22%20AND%20reqs_per_min%20%3E%201000%0A%7C%20eval%20success_pct%20%3D%20100.0%20*%20status_count%20%2F%20reqs_per_min%0A%0A%7C%20timechart%20minspan%3D1h%20min(success_pct)%20avg(avg_success_latency_per_min)%20avg(stdev_latency)%20avg(reqs_per_min)%20by%20cluster_id&earliest=1611457200&latest=1611975600&workload_pool=&display.general.type=visualizations&display.page.search.tab=visualizations&display.visualizations.chartHeight=1181&sid=1611959647.1213467_5D3C75C2-A8BC-4E6E-8C2F-95794CD3FA6F)
 - [[no negative impact observable in graphql-server overhead]](https://splunk72.vtex.com/en-US/app/vtex_io_apps/search?q=search%20index%3Dio_vtex_logs%20app%3Dvtex.graphql-server%401.66.3%20status.name%3Dtotal-proxy-overhead%20cluster%3Dstores-*a%0A%7C%20eval%20kpi_sum%3D%27status.count%27*%27status.mean%27%2C%20kpi_count%3D%27status.count%27%0A%7C%20timechart%20span%3D8h%20eval(sum(kpi_sum)%2Fsum(kpi_count))%20as%20avg%20by%20cluster&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1611543600&latest=1611889200&display.page.search.tab=visualizations&display.general.type=visualizations&display.visualizations.trellis.enabled=0&display.visualizations.charting.legend.placement=right&display.visualizations.charting.axisTitleX.visibility=visible&display.visualizations.charting.axisTitleY.visibility=visible&display.visualizations.charting.axisTitleY2.visibility=visible&display.visualizations.trellis.size=large&display.visualizations.trellis.scales.shared=0&display.visualizations.trellis.splitBy=_aggregation&sid=1611959776.1363846_0FC90BB0-9222-411B-B48E-3D77BD82C6AF)

#### What problem is this solving?
Decreased performance of apps that need to use a lot of simultaneous connections, as only 50 of them would be 
kept to be re-used later.

#### How should this be manually tested?
Put it on a cluster for a whole week to look for improvements and/or any regressions. ✅ 

#### Types of changes

* [x] Chore (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
