### PR TITLE
Add App State method to registry client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.40.0] - 2021-03-02
+
+### Added
+
+- `getAppState` method to `registry` client
+
 ## [6.39.1] - 2021-02-05
+
 - Increase HTTP agents connection pools freeSockets and lifetime
 
 ## [6.39.0] - 2021-01-27

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.40.0-beta.1",
+  "version": "6.40.0-beta.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.40.0-beta.2",
+  "version": "6.40.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.39.1",
+  "version": "6.40.0-beta.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -66,6 +66,8 @@ export type AppBundleLinked = AppBundleResponse & {
   bundleSize?: number,
 }
 
+export type AppState = 'stable' | 'releaseCandidate'
+
 export interface HouseKeeperState {
   infra: string[]
   edition: string[]


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->
Adding app state method to registry client

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Being able to know if an app is `stable` before being submitted to the app store.

#### How should this be manually tested?
You can link `@vtex/api` in an app and use the `registry` client to call the `getAppState` method.

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
