### PR TITLE
Adds an interface for the new messages-grapqhl functionality 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added an interface to the `userTranslations` query of the MessagesGraphQL client.
+
 ## [6.40.0] - 2021-03-02
 
 ### Added

--- a/src/clients/apps/MessagesGraphQL.ts
+++ b/src/clients/apps/MessagesGraphQL.ts
@@ -54,20 +54,20 @@ interface TranslatedV2 {
   translate: string[]
 }
 
-interface MessageInputV2 {
+export interface MessageInputV2 {
   content: string
   context?: string
   behavior?: Behavior
 }
 
-interface MessageListV2 {
+export interface MessageListV2 {
   srcLang: string
   groupContext?: string
   context?: string
   translations: Translation[]
 }
 
-interface Translation {
+export interface Translation {
   lang: string
   translation: string
 }
@@ -76,7 +76,7 @@ const MAX_BATCH_SIZE = 500
 
 export class MessagesGraphQL extends AppGraphQLClient {
   constructor(vtex: IOContext, options?: InstanceOptions) {
-    super('vtex.messages@1.63.0-beta.0', vtex, options)
+    super('vtex.messages@1.63.0-beta.1', vtex, options)
   }
 
   public translateV2 (args: TranslateInput, tracingConfig?: RequestTracingConfig) {
@@ -181,11 +181,11 @@ export class MessagesGraphQL extends AppGraphQLClient {
     return response.data!.saveV2
   }
 
-  public async userTranslations (args: MessageInputV2[], tracingConfig?: RequestTracingConfig) {
+  public async userTranslations (args: IndexedByFrom, tracingConfig?: RequestTracingConfig) {
     const metric = 'messages-user-translations'
-    const response = await this.graphql.query<{ userTranslations: MessageListV2[] }, { args: MessageInputV2[] }>(
+    const response = await this.graphql.query<{ userTranslations: MessageListV2[] }, { args: IndexedByFrom }>(
       {
-        query: `query UserTranslations($args:[MessageInputV2!]!){
+        query: `query UserTranslations($args: IndexedMessages!){
           userTranslations(args: $args) {
             srcLang
             groupContext

--- a/src/clients/apps/MessagesGraphQL.ts
+++ b/src/clients/apps/MessagesGraphQL.ts
@@ -54,20 +54,20 @@ interface TranslatedV2 {
   translate: string[]
 }
 
-type MessageInputV2 = {
+interface MessageInputV2 {
   content: string
   context?: string
   behavior?: Behavior
 }
 
-type MessageListV2 = {
+interface MessageListV2 {
   srcLang: string
   groupContext?: string
   context?: string
   translations: Translation[]
-};
+}
 
-type Translation = {
+interface Translation {
   lang: string
   translation: string
 }

--- a/src/clients/apps/MessagesGraphQL.ts
+++ b/src/clients/apps/MessagesGraphQL.ts
@@ -76,7 +76,7 @@ const MAX_BATCH_SIZE = 500
 
 export class MessagesGraphQL extends AppGraphQLClient {
   constructor(vtex: IOContext, options?: InstanceOptions) {
-    super('vtex.messages@1.63.0-beta.1', vtex, options)
+    super('vtex.messages@1.x', vtex, options)
   }
 
   public translateV2 (args: TranslateInput, tracingConfig?: RequestTracingConfig) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
To add an interface to the new MessagesGraphQL client functionality

#### What problem is this solving?

Allows the catalog-graphql to access this new endpoint.

#### How should this be manually tested?

By linking it to [this version of the catalog-graphql]() in this [workspace](https://juaresba--fashion2.myvtex.com/) (it has the correct version of messages-graphql linked, [this one](https://github.com/vtex/messages/pull/162))

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
