### PR TITLE
Bypass metrics handling for internet requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix prometheus metrics being publicly exposed on /metrics.
+
 ## [6.41.0] - 2021-03-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.41.1] - 2021-05-17
+
 ### Fixed
 - Fix prometheus metrics being publicly exposed on /metrics.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.41.0",
+  "version": "6.41.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -18,7 +18,7 @@ import {
   RequestsMetricLabels,
 } from './metrics/instruments'
 
-const PATHS_BLACKLISTED_FOR_TRACING = ['/metrics', '/_status', '/healthcheck']
+const PATHS_BLACKLISTED_FOR_TRACING = ['/_status', '/healthcheck']
 
 export const addTracingMiddleware = (tracer: Tracer) => {
   const concurrentRequests = createConcurrentRequestsInstrument()

--- a/src/service/worker/index.ts
+++ b/src/service/worker/index.ts
@@ -211,8 +211,8 @@ export const startWorker = (serviceJSON: ServiceJSON) => {
   const app = new Koa()
   app.proxy = true
   app
-    .use(addTracingMiddleware(tracer))
     .use(prometheusLoggerMiddleware())
+    .use(addTracingMiddleware(tracer))
     .use(addMetricsLoggerMiddleware())
     .use(compress())
     .use(recorderMiddleware)

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -1,4 +1,5 @@
 import { collectDefaultMetrics, register } from 'prom-client'
+import { COLOSSUS_ROUTE_ID_HEADER } from '../../../../constants'
 
 import { MetricsLogger } from '../../../logger/metricsLogger'
 import { EventLoopLagMeasurer } from '../../../tracing/metrics/measurers/EventLoopLagMeasurer'
@@ -31,7 +32,11 @@ export const prometheusLoggerMiddleware = () => {
       return next()
     }
 
-    ctx.tracing?.currentSpan.setOperationName('builtin:prometheus-metrics')
+    const routeId = ctx.get(COLOSSUS_ROUTE_ID_HEADER)
+    if (routeId) {
+      return next()
+    }
+
     await eventLoopLagMeasurer.updateInstrumentsAndReset()
     ctx.set('Content-Type', register.contentType)
     ctx.body = register.metrics()


### PR DESCRIPTION
#### What is the purpose of this pull request?

Stop exposing the `/metrics` endpoint used by Prometheus.

#### What problem is this solving?

Internal metadata leaking.

#### How should this be manually tested?

It is working here: https://brunoh2--b2bstore.myvtex.com/metrics
The leak can be seen anywhere else, like: https://storetheme.vtex.com/metrics

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
