### PR TITLE
NAD-606 - Add `@metric` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `@telemetry` GraphQL directive
+- `@metric` GraphQL directive
 
 ## [6.43.1] - 2021-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `@telemetry` GraphQL directive
+
 ## [6.43.1] - 2021-07-12
+
 ### Fixed
+
 - Update axios to `0.21.1`
 
 ## [6.43.0] - 2021-06-23
@@ -18,17 +24,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update schema in runtime when provider app changes version
 
 ## [6.42.1] - 2021-05-18
+
 ### Fixed
 
 - [startWorker] Remove duplicated middleware
+
 ## [6.42.0] - 2021-05-17
 
 ### Added
 
 - [Rate Limit] Enable user to config the amount of requests to be processed per minute and concurrently by setting it in `service.json`.
+
 ## [6.41.1] - 2021-05-17
 
 ### Fixed
+
 - Fix prometheus metrics being publicly exposed on /metrics.
 
 ## [6.41.0] - 2021-03-09

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/Telemetry.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/Telemetry.ts
@@ -25,7 +25,7 @@ export class Telemetry extends SchemaDirectiveVisitor {
 
       const payload = {
         [ctx.graphql.status]: 1,
-      } as Record<string, string | number>
+      }
 
       metrics.batch(`graphql-telemetry-${APP.NAME}-${name}`, failedToResolve ? undefined : ellapsed, payload)
 

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/Telemetry.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/Telemetry.ts
@@ -1,0 +1,58 @@
+import { defaultFieldResolver, GraphQLField, print } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+import { cleanError } from '../../../../../../utils'
+import { Logger, LogLevel } from '../../../../../logger/logger'
+import { logger as globalLogger } from '../../../../listeners'
+import { GraphQLServiceContext } from '../../typings'
+
+export class Telemetry extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, GraphQLServiceContext>) {
+    const { resolve = defaultFieldResolver, name } = field
+
+    field.resolve = async (root, args, ctx, info) => {
+      let failedToResolve = false
+      let result: any = null
+      let timeToResolve = 0
+
+      try {
+        const start = process.hrtime.bigint()
+        result = await resolve(root, args, ctx, info)
+        timeToResolve = Number(process.hrtime.bigint() - start) / 1000000 // Milliseconds
+      } catch (error) {
+        result = error
+        failedToResolve = true
+      }
+
+      ctx.graphql.status = failedToResolve ? 'error' : 'success'
+
+      this.log(
+        failedToResolve ? LogLevel.Error : LogLevel.Info,
+        {
+          graphql: {
+            failedToResolve,
+            failureReason: failedToResolve ? cleanError(result) : null,
+            name,
+            operationName: ctx.graphql.query?.operationName || '',
+            query: ctx.graphql.query?.document && print(ctx.graphql.query?.document),
+            status: ctx.graphql.status,
+            timeToResolve,
+            variables: args,
+          },
+          headers: ctx.request.headers,
+          key: 'graphql-telemetry',
+        },
+        ctx.vtex.logger
+      )
+
+      return result
+    }
+  }
+
+  protected log<T>(level: LogLevel, payload: T, logger: Logger = globalLogger) {
+    logger[level](payload)
+  }
+}
+
+export const telemetryDirectiveTypeDefs = `
+directive @telemetry on FIELD_DEFINITION
+`

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/Telemetry.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/Telemetry.ts
@@ -29,6 +29,10 @@ export class Telemetry extends SchemaDirectiveVisitor {
 
       metrics.batch(`graphql-telemetry-${APP.NAME}-${name}`, failedToResolve ? undefined : ellapsed, payload)
 
+      if (failedToResolve) {
+        throw result
+      }
+
       return result
     }
   }

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/Telemetry.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/Telemetry.ts
@@ -1,4 +1,4 @@
-import { defaultFieldResolver, GraphQLField, print } from 'graphql'
+import { defaultFieldResolver, GraphQLField } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 import { APP } from '../../../../../..'
 import { GraphQLServiceContext } from '../../typings'

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
@@ -4,6 +4,7 @@ import { Deprecated, deprecatedDirectiveTypeDefs } from './Deprecated'
 import { SanitizeDirective, sanitizeDirectiveTypeDefs } from './Sanitize'
 import { SettingsDirective, settingsDirectiveTypeDefs } from './Settings'
 import { SmartCacheDirective, smartCacheDirectiveTypeDefs } from './SmartCacheDirective'
+import { Telemetry, telemetryDirectiveTypeDefs } from './Telemetry'
 import { TranslatableV2, translatableV2DirectiveTypeDefs } from './TranslatableV2'
 import { TranslateTo, translateToDirectiveTypeDefs } from './TranslateTo'
 
@@ -16,6 +17,7 @@ export const nativeSchemaDirectives = {
   sanitize: SanitizeDirective,
   settings: SettingsDirective,
   smartcache: SmartCacheDirective,
+  telemetry: Telemetry,
   translatableV2: TranslatableV2,
   translateTo: TranslateTo,
 }
@@ -27,6 +29,7 @@ export const nativeSchemaDirectivesTypeDefs = [
   sanitizeDirectiveTypeDefs,
   settingsDirectiveTypeDefs,
   smartCacheDirectiveTypeDefs,
+  telemetryDirectiveTypeDefs,
   translatableV2DirectiveTypeDefs,
   translateToDirectiveTypeDefs,
 ].join('\n\n')

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
@@ -1,10 +1,10 @@
 import { Auth, authDirectiveTypeDefs } from './Auth'
 import { CacheControl, cacheControlDirectiveTypeDefs } from './CacheControl'
 import { Deprecated, deprecatedDirectiveTypeDefs } from './Deprecated'
+import { Metric, metricDirectiveTypeDefs } from './Metric'
 import { SanitizeDirective, sanitizeDirectiveTypeDefs } from './Sanitize'
 import { SettingsDirective, settingsDirectiveTypeDefs } from './Settings'
 import { SmartCacheDirective, smartCacheDirectiveTypeDefs } from './SmartCacheDirective'
-import { Telemetry, telemetryDirectiveTypeDefs } from './Telemetry'
 import { TranslatableV2, translatableV2DirectiveTypeDefs } from './TranslatableV2'
 import { TranslateTo, translateToDirectiveTypeDefs } from './TranslateTo'
 
@@ -14,10 +14,10 @@ export const nativeSchemaDirectives = {
   auth: Auth,
   cacheControl: CacheControl,
   deprecated: Deprecated,
+  metric: Metric,
   sanitize: SanitizeDirective,
   settings: SettingsDirective,
   smartcache: SmartCacheDirective,
-  telemetry: Telemetry,
   translatableV2: TranslatableV2,
   translateTo: TranslateTo,
 }
@@ -26,10 +26,10 @@ export const nativeSchemaDirectivesTypeDefs = [
   authDirectiveTypeDefs,
   cacheControlDirectiveTypeDefs,
   deprecatedDirectiveTypeDefs,
+  metricDirectiveTypeDefs,
   sanitizeDirectiveTypeDefs,
   settingsDirectiveTypeDefs,
   smartCacheDirectiveTypeDefs,
-  telemetryDirectiveTypeDefs,
   translatableV2DirectiveTypeDefs,
   translateToDirectiveTypeDefs,
 ].join('\n\n')


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add a new directive to easily log data from GraphQL operations to Splunk.

Example usage:

```graphql
type Query {
    someOperation: String! @metric
    anotherOperation: String! @metric(name: "another-operation")
    metriclessOperation: String!
}
```

#### What problem is this solving?

Currently, only GraphQL errors are logged to Splunk, but what about the success cases? The goal of this PR is to easily allow successful and unsuccessful operations to be logged to Splunk. This gives us the ability to analyze operation-specific success/error ratios without too much hassle.

The motivation behind this feature is the need to **measure the availability** for the `navigation` query from the `vtex.admin-graphql` application.

#### How should this be manually tested?

Link this application and the [`feat/telemetry` branch from `vtex.admin-graphql`](https://github.com/vtex/admin-graphql/tree/feat/telemetry) on the workspace you want, [toggle this condition to true on the node-vtex-api](https://github.com/vtex/node-vtex-api/blob/master/src/service/worker/runtime/statusTrack.ts#L28) and execute the following query on your workspace: 

```graphql
query Navigation {
  navigation {
      section
  }
}
```

Wait a minute and run this query on Splunk:

```bash
index=io_vtex_logs app IN (vtex.admin-graphql@2*) production=false account={your account} workspace={your workspace} status.name="graphql-metric-*"
```

You should then see the status of the operation you've just executed logged there.

Or, if you don't feel like going through this (I have already):
- [To see a sample of what it should look like once it goes live, click here.
](https://splunk72.vtex.com/en-US/app/vtex_io_apps/search?q=search%20index%3Dio_vtex_logs%20app%20IN%20(vtex.admin-graphql%402*)%20production%3Dfalse%20account%3D%22teamadmin%22%20workspace%3D%22navmetrics%22%20status.name%3D%22graphql-metric-*%22&earliest=1626357540&latest=1626357840&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&sid=1626358635.3075722_5D3C75C2-A8BC-4E6E-8C2F-95794CD3FA6F)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
