### PR TITLE
Fix/registry cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.44.1-beta] - 2021-08-21
+
 ## [6.44.0] - 2021-07-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.44.0",
+  "version": "6.44.1-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/index.ts
+++ b/src/HttpClient/index.ts
@@ -3,5 +3,5 @@ export * from './typings'
 export * from './GraphQLClient'
 export * from './agents'
 
-export { Cached, CacheType } from './middlewares/cache'
+export { Cached, cacheKey, CacheType } from './middlewares/cache'
 export { inflightURL, inflightUrlWithQuery } from './middlewares/inflight'

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -92,7 +92,8 @@ export const cacheMiddleware = ({ type, storage }: CacheOptions) => {
 
     const span = ctx.tracing!.rootSpan
 
-    const key = cacheKey(ctx.config)
+    const cacheKeyGenerator = ctx.config.cacheKey ?? cacheKey
+    const key = cacheKeyGenerator(ctx.config)
     const segmentToken = ctx.config.headers[SEGMENT_HEADER]
     const keyWithSegment = key + segmentToken
 

--- a/src/HttpClient/middlewares/inflight.ts
+++ b/src/HttpClient/middlewares/inflight.ts
@@ -1,5 +1,5 @@
 import { stringify } from 'qs'
-import { InflightKeyGenerator, MiddlewareContext, RequestConfig } from '../typings'
+import { RequestKeyGenerator, MiddlewareContext, RequestConfig } from '../typings'
 
 export type Inflight = Required<Pick<MiddlewareContext, 'cacheHit' | 'response'>>
 
@@ -54,6 +54,6 @@ export const singleFlightMiddleware = async (ctx: MiddlewareContext, next: () =>
   }
 }
 
-export const inflightURL: InflightKeyGenerator = ({baseURL, url}: RequestConfig) => baseURL! + url!
+export const inflightURL: RequestKeyGenerator = ({baseURL, url}: RequestConfig) => baseURL! + url!
 
-export const inflightUrlWithQuery: InflightKeyGenerator = ({baseURL, url, params}: RequestConfig) => baseURL! + url! + stringify(params, {arrayFormat: 'repeat', addQueryPrefix: true})
+export const inflightUrlWithQuery: RequestKeyGenerator = ({baseURL, url, params}: RequestConfig) => baseURL! + url! + stringify(params, {arrayFormat: 'repeat', addQueryPrefix: true})

--- a/src/HttpClient/middlewares/inflight.ts
+++ b/src/HttpClient/middlewares/inflight.ts
@@ -1,5 +1,5 @@
 import { stringify } from 'qs'
-import { RequestKeyGenerator, MiddlewareContext, RequestConfig } from '../typings'
+import { MiddlewareContext, RequestConfig, RequestKeyGenerator } from '../typings'
 
 export type Inflight = Required<Pick<MiddlewareContext, 'cacheHit' | 'response'>>
 

--- a/src/HttpClient/typings.ts
+++ b/src/HttpClient/typings.ts
@@ -9,7 +9,10 @@ import { SpanReferenceTypes } from '../tracing'
 import { IUserLandTracer } from '../tracing/UserLandTracer'
 import { Cached, CacheType } from './middlewares/cache'
 
-export type InflightKeyGenerator = (x: RequestConfig) => string
+export type RequestKeyGenerator = (x: RequestConfig) => string
+
+// Deprecated in favor of RequestKeyGenerator, keeping it for compatibility reasons
+export type InflightKeyGenerator = RequestKeyGenerator
 
 interface RequestTracingUserConfig {
   rootSpan?: Span
@@ -46,7 +49,8 @@ export interface RequestConfig extends AxiosRequestConfig, RequestTracingConfig 
   production?: boolean
   cacheable?: CacheType
   memoizeable?: boolean
-  inflightKey?: InflightKeyGenerator
+  inflightKey?: RequestKeyGenerator
+  cacheKey?: RequestKeyGenerator
   forceMaxAge?: number
   responseEncoding?: BufferEncoding
   nullIfNotFound?: boolean

--- a/src/clients/infra/Apps.ts
+++ b/src/clients/infra/Apps.ts
@@ -341,8 +341,8 @@ export class Apps extends InfraClient {
 
     try {
       return this.http.getBuffer(this.routes.File(locator, path), {
-        cacheable: linked ? CacheType.Memory : CacheType.Disk,
         cacheKey: linked ? undefined : registryCacheKey,
+        cacheable: linked ? CacheType.Memory : CacheType.Disk,
         inflightKey,
         metric,
         tracing: {
@@ -365,8 +365,8 @@ export class Apps extends InfraClient {
     const inflightKey = inflightURL
     const metric = linked ? 'apps-get-json' : 'registry-get-json'
     return this.http.get<T>(this.routes.File(locator, path), {
-      cacheable: linked ? CacheType.Memory : CacheType.Any,
       cacheKey: linked ? null : registryCacheKey,
+      cacheable: linked ? CacheType.Memory : CacheType.Any,
       inflightKey,
       metric,
       nullIfNotFound,

--- a/src/clients/infra/Apps.ts
+++ b/src/clients/infra/Apps.ts
@@ -331,7 +331,7 @@ export class Apps extends InfraClient {
     const { logger } = this.context
     const locator = parseAppId(app)
     const linked = !!locator.build
-    const inflightKey = inflightURL
+    const inflightKey = linked ? inflightURL : registryCacheKey
 
     if (staleIfError && this.memoryCache) {
       saveVersion(app, this.memoryCache)
@@ -362,7 +362,7 @@ export class Apps extends InfraClient {
   public getAppJSON = <T extends object | null>(app: string, path: string, nullIfNotFound?: boolean, tracingConfig?: RequestTracingConfig) => {
     const locator = parseAppId(app)
     const linked = !!locator.build
-    const inflightKey = inflightURL
+    const inflightKey = linked ? inflightURL : registryCacheKey
     const metric = linked ? 'apps-get-json' : 'registry-get-json'
     return this.http.get<T>(this.routes.File(locator, path), {
       cacheKey: linked ? null : registryCacheKey,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allows HTTP clients to modify the request cache keys, in order for registry calls to share cache across accounts.

#### What problem is this solving?

`graphql-server` must get the app files for every account that calls it.

#### How should this be manually tested?

Link node VTEX API and see if cache is properly shared through logs.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
