### PR TITLE
remove missing x-vtex-provider log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.45.4] - 2021-09-16
+
 ### Removed
 
 - `Missing x-vtex-provider header` log.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `Missing x-vtex-provider header` log.
+
 ## [6.45.3] - 2021-08-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.45.3",
+  "version": "6.45.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/graphql/middlewares/updateSchema.ts
+++ b/src/service/worker/runtime/graphql/middlewares/updateSchema.ts
@@ -18,7 +18,6 @@ export const updateSchema = <T extends IOClients, U extends RecorderState, V ext
     } = ctx
 
     if (!ctx.headers[PROVIDER_HEADER]) {
-      logger.warn({ message: 'Missing x-vtex-provider header' })
       await next()
       return
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This log was important in the past when we were deploying the [auto updateSchema](https://github.com/vtex/node-vtex-api/pull/420) for the search app. But now, all the search apps are already sending the header properly, so we don't need this anymore. Besides that, it's logging the message for cases where the header is not required and this is overusing Splunk

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
