### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.77.4] - 2021-10-22
+
 ## [3.77.3] - 2021-10-22
 ### Fixed
 - Extract session cookie in a safe manner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "3.77.3",
+  "version": "3.77.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
I have just tried to release `v3.77.3` ([PR](https://github.com/vtex/node-vtex-api/pull/479)), because `v3.77.2` was the version on `package.json` at the time, but turns out there already was a 3.77.3 version published on `npm`.
