### PR TITLE
Add where param to masterdata scroll documents function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.45.11] - 2022-04-08
+
 ### Fixed
 
 - Add where parameter to the MasterData scroll method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add where parameter to the MasterData scroll method
+
 ## [6.45.10] - 2022-03-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.45.10",
+  "version": "6.45.11",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/clients/external/Masterdata.ts
+++ b/src/clients/external/Masterdata.ts
@@ -212,7 +212,7 @@ export class MasterData extends ExternalClient {
   }
 
   public scrollDocuments<T>(
-    { dataEntity, fields, mdToken, schema, size, sort }: ScrollInput,
+    { dataEntity, fields, where, mdToken, schema, size, sort }: ScrollInput,
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'masterdata-scrollDocuments'
@@ -226,6 +226,7 @@ export class MasterData extends ExternalClient {
           _size: size,
           _sort: sort,
           _token: mdToken,
+          _where: where,
         },
         tracing: {
           requestSpanNameSuffix: metric,
@@ -324,6 +325,7 @@ interface SearchInput {
 interface ScrollInput {
   dataEntity: string
   fields: string[]
+  where?: string
   schema?: string
   sort?: string
   size?: number


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds the param `where` to the scrollDocuments method of the MD client. Looking in the docs and making some tests on postman, shows that the scroll method should have the `where` param to filter the data just as the search method 

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
