### PR TITLE
[1.x] Fix / Sensitive fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Update sensitive fields.
+    - Remove "error".
+    - Add missing fields.
+- Fix cleanJson.
+    - Lowercase keys before comparison.
+
 ## [1.9.2] - 2022-03-08
 ### Fixed
 - Only remove sensitive fields from logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.9.3] - 2022-04-14
 ### Fixed
 - Update sensitive fields.
     - Remove "error".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -2,7 +2,7 @@ export function cleanJson(json: {[k: string]: any}, targetFields: string[]) {
     for (const key of Object.keys(json)) {
         let deleted = false
         for (const field of targetFields) {
-            if (key === field) {
+            if (key.toLowerCase() === field) {
                 delete json[key]
                 deleted = true
             }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,6 +1,10 @@
 import { cleanJson } from './json'
 
-const SENSITIVE_FIELDS = ['cookie', 'Cookie', 'vtexIdclientautcookie']
+const SENSITIVE_FIELDS = [
+    'cookie',
+    'Cookie',
+    'vtexIdclientautcookie',
+]
 
 export const removeSensitiveData = (log: any) => {
     return cleanJson(log, SENSITIVE_FIELDS)

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -5,7 +5,6 @@ const SENSITIVE_FIELDS = [
     'authorization',
     'authtoken',
     'cookie',
-    'Cookie',
     'proxy-authorization',
     'rawheaders',
     'token',

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,6 +1,6 @@
 import { cleanJson } from './json'
 
-const SENSITIVE_FIELDS = ['cookie', 'Cookie', 'vtexIdclientautcookie', 'error']
+const SENSITIVE_FIELDS = ['cookie', 'Cookie', 'vtexIdclientautcookie']
 
 export const removeSensitiveData = (log: any) => {
     return cleanJson(log, SENSITIVE_FIELDS)

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,9 +1,19 @@
 import { cleanJson } from './json'
 
 const SENSITIVE_FIELDS = [
+    'auth',
+    'authorization',
+    'authtoken',
     'cookie',
     'Cookie',
-    'vtexIdclientautcookie',
+    'proxy-authorization',
+    'rawheaders',
+    'token',
+    'x-vtex-api-appkey',
+    'x-vtex-api-apptoken',
+    'x-vtex-credential',
+    'x-vtex-session',
+    'vtexidclientautcookie',
 ]
 
 export const removeSensitiveData = (log: any) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
The main purpose of this pull request is to remove `error` from the list of sensitive fields.
Besides that, this pull request also
- adds some missing fields to the sensitive fields list;
- lowercase the keys before comparing them, in `cleanJson`.

#### What problem is this solving?
- Many apps rely on the `error` field to log information about the errors they encounter. We will have to find a different way of stopping the apps from logging user tokens in an `error` field.
- Some apps log user tokens inside fields whose key is not fully lowercase.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
