### PR TITLE
fix updateSchema criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Update the schema every time the provider version is different instead of when it is higher. 
+
 ## [6.45.12] - 2022-04-14
 
 ### Fixed

--- a/src/service/worker/runtime/graphql/middlewares/updateSchema.ts
+++ b/src/service/worker/runtime/graphql/middlewares/updateSchema.ts
@@ -1,6 +1,6 @@
 import { IOClients } from '../../../../../clients'
 import { PROVIDER_HEADER } from '../../../../../constants'
-import { majorEqualAndGreaterThan, parseAppId } from '../../../../../utils'
+import { isDifferentVersion, parseAppId } from '../../../../../utils'
 import { GraphQLOptions, ParamsContext, RecorderState } from '../../typings'
 import { makeSchema } from '../schema/index'
 import { ExecutableSchema } from '../typings'
@@ -26,10 +26,7 @@ export const updateSchema = <T extends IOClients, U extends RecorderState, V ext
     if (
       executableSchema.hasProvider &&
       (!executableSchema.provider ||
-        majorEqualAndGreaterThan(
-          parseAppId(ctx.headers[PROVIDER_HEADER]).version,
-          parseAppId(executableSchema.provider).version
-        ))
+        isDifferentVersion(parseAppId(ctx.headers[PROVIDER_HEADER]), parseAppId(executableSchema.provider)))
     ) {
       try {
         const newSchema = (await apps.getAppFile(ctx.headers[PROVIDER_HEADER], 'public/schema.graphql')).data.toString(

--- a/src/utils/app.ts
+++ b/src/utils/app.ts
@@ -53,15 +53,15 @@ export const appIdToAppAtMajor = (appId: string): string => {
 }
 
 // SemVer regex from https://github.com/sindresorhus/semver-regex
-const APP_ID_REGEX = /^[\w\-]+\.[\w\-]+@(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$/
+const APP_ID_REGEX =
+  /^[\w\-]+\.[\w\-]+@(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$/
 
 export const isValidAppIdOrLocator = (appId: string): boolean => {
   return APP_ID_REGEX.test(appId)
 }
 
-export const sameMajor = (v1: string, v2: string) => versionToMajor(v1) === versionToMajor(v2)
-
-export const majorEqualAndGreaterThan = (v1: string, v2: string) => sameMajor(v1, v2) && semver.gt(v1, v2)
+export const isDifferentVersion = (v1: ParsedLocator, v2: ParsedLocator) =>
+  v1.version !== v2.version || v1.build !== v2.build
 
 export interface ParsedLocator {
   name: string


### PR DESCRIPTION
#### What is the purpose of this pull request?

Update the schema every time the provider version is different instead of when it is higher.

#### What problem is this solving?

When the app has a provider, we update the Graphql schema in runtime. The problem is that we only update it when the version is greater than the current one.

The problem is that when you link or deprecate an app, the current schema version will not be updated.

#### How should this be manually tested?

Go to the [workspace](https://hiago--storecomponents.myvtex.com/) and link any version of the `vtex.search-graphql`. You will notice that the version will be updated instantly.


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
