### PR TITLE
Add  prometheus app name to runtime metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add app (VTEX_APP_VENDOR.VTEX_APP_NAME) to prom-client default metric labels
+
+### Changed
+- Upgrade prom-client to ^14.0.1
 
 ## [6.45.12] - 2022-04-14
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mime-types": "^2.1.12",
     "opentracing": "^0.14.4",
     "p-limit": "^2.2.0",
-    "prom-client": "^12.0.0",
+    "prom-client": "^14.0.1",
     "qs": "^6.5.1",
     "querystring": "^0.2.0",
     "ramda": "^0.26.0",

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -24,7 +24,7 @@ export const addMetricsLoggerMiddleware = () => {
 
 export const prometheusLoggerMiddleware = () => {
   register.setDefaultLabels({
-    app: `${process.env.VTEX_APP_VENDOR}.${process.env.VTEX_APP_NAME}`
+    app: `${process.env.VTEX_APP_VENDOR}.${process.env.VTEX_APP_NAME}`,
   })
   collectDefaultMetrics()
   const eventLoopLagMeasurer = new EventLoopLagMeasurer()

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -23,6 +23,9 @@ export const addMetricsLoggerMiddleware = () => {
 }
 
 export const prometheusLoggerMiddleware = () => {
+  register.setDefaultLabels({
+    app: process.env.VTEX_APP_NAME
+  })
   collectDefaultMetrics()
   const eventLoopLagMeasurer = new EventLoopLagMeasurer()
   eventLoopLagMeasurer.start()

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -24,7 +24,7 @@ export const addMetricsLoggerMiddleware = () => {
 
 export const prometheusLoggerMiddleware = () => {
   register.setDefaultLabels({
-    app: process.env.VTEX_APP_NAME
+    app: `${process.env.VTEX_APP_VENDOR}.${process.env.VTEX_APP_NAME}`
   })
   collectDefaultMetrics()
   const eventLoopLagMeasurer = new EventLoopLagMeasurer()

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -42,7 +42,7 @@ export const prometheusLoggerMiddleware = () => {
 
     await eventLoopLagMeasurer.updateInstrumentsAndReset()
     ctx.set('Content-Type', register.contentType)
-    ctx.body = register.metrics()
+    ctx.body = await register.metrics()
     ctx.status = 200
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3803,10 +3803,10 @@ process@^0.10.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.10.1.tgz#842457cc51cfed72dc775afeeafb8c6034372725"
   integrity sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=
 
-prom-client@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
-  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
+prom-client@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.0.1.tgz#bdd9583e02ec95429677c0e013712d42ef1f86a8"
+  integrity sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==
   dependencies:
     tdigest "^0.1.1"
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

1 - Upgrade prom-client to newest version
2 - Add  prometheus app name to runtime metrics

<!--- Describe your changes in detail. -->

#### What problem is this solving?

Enable runtime http metrics aggregation by app

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

1 - `yarn link` Inside node-vtex-api src dir
2 - `yarn link @vtex/api` at any app node dir of any IO node app, example: `vtex.messages`
3 - `vtex link` IO app
4 - see metrics at grafana or by forwarding linked pod to your localhost and accessing `http://localhost:5050/metrics`

#### Screenshots or example usage

*Metrics usage example*
<img width="1428" alt="Captura de Tela 2022-06-30 às 19 32 09" src="https://user-images.githubusercontent.com/1594322/176789594-4638f164-3002-4d14-b82c-75cc77744ff0.png">

*Port forwarding & metrics exposure usage example*
<img width="686" alt="Captura de Tela 2022-06-30 às 19 03 01" src="https://user-images.githubusercontent.com/1594322/176790018-4526af47-6109-42af-b103-cdbd81e5b09e.png">

<img width="1308" alt="Captura de Tela 2022-06-30 às 19 02 30" src="https://user-images.githubusercontent.com/1594322/176790035-1ec31e1d-7dd7-4b9c-976b-4da956a76887.png">


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
