### PR TITLE
Make the computed hash that is appended to request behave determinist…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.45.13-beta.3",
+  "version": "6.45.13-beta.6",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.45.13-beta.2",
+  "version": "6.45.13-beta.3",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.45.12",
+  "version": "6.45.13-beta.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -14,6 +14,7 @@ import {
   SESSION_HEADER,
   TENANT_HEADER,
 } from '../constants'
+import { Logger } from '../service/logger'
 import { IOContext } from '../service/worker/runtime/typings'
 import { formatBindingHeaderValue } from '../utils/binding'
 import { formatTenantHeaderValue } from '../utils/tenant'
@@ -27,7 +28,6 @@ import { recorderMiddleware } from './middlewares/recorder'
 import { defaultsMiddleware, requestMiddleware, routerCacheMiddleware } from './middlewares/request'
 import { createHttpClientTracingMiddleware } from './middlewares/tracing'
 import { InstanceOptions, IOResponse, MiddlewareContext, RequestConfig } from './typings'
-import { Logger } from '../service/logger'
 
 const DEFAULT_TIMEOUT_MS = 1000
 const noTransforms = [(data: any) => data]

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -123,7 +123,12 @@ export class HttpClient {
   }
 
   public getWithBody = <T = any>(url: string, data?: any, config: RequestConfig = {}): Promise<T> => {
-    const bodyHash = createHash('md5').update(JSON.stringify(data)).digest('hex')
+    const deterministicReplacer = (_ : any, v : any) =>
+      typeof v !== 'object' || v === null || Array.isArray(v) ? v :
+        Object.fromEntries(Object.entries(v).sort(([ka], [kb]) =>
+          ka < kb ? -1 : ka > kb ? 1 : 0));
+
+    const bodyHash = createHash('md5').update(JSON.stringify(data, deterministicReplacer)).digest('hex')
     const cacheableConfig = this.getConfig(url, {
       ...config,
       data,

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -126,7 +126,7 @@ export class HttpClient {
     const deterministicReplacer = (_ : any, v : any) =>
       typeof v !== 'object' || v === null || Array.isArray(v) ? v :
         Object.fromEntries(Object.entries(v).sort(([ka], [kb]) =>
-          ka < kb ? -1 : ka > kb ? 1 : 0));
+          ka < kb ? -1 : ka > kb ? 1 : 0))
 
     const bodyHash = createHash('md5').update(JSON.stringify(data, deterministicReplacer)).digest('hex')
     const cacheableConfig = this.getConfig(url, {


### PR DESCRIPTION
#### What is the purpose of this pull request?
I've observed cache hit ratios that suggested that there may be an issue with the keys used for caching. Upon digging further into it I noted that the cache key for a page that was unchanged was computing different hashes for the calls to render services. Those difference were the order in which items appeared in the json.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
By applying a consistent order to the json which is used to generate a hash we can guarantee that the hash will be computed to the same value each time. This will improve efficiency and performance.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
I was able to observe consistent hashing by `yarn link`ing the api into one of the render services and then `yarn link`ing that.

#### Screenshots or example usage
Example of the inconsistencies without applying a sort:
```
settings: {
  'vtex.google-search-console':(},
  'vtex.google-tag-manager':(},
  'vtex.google-shopping': (}
}
```
vs
```
settings: {
  'vtex.google-search-console':(},
  'vtex.google-shopping': (},
  'vtex.google-tag-manager':(}
}
```
#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
