### PR TITLE
Remove socket metrics per origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove socket metrics per origin
 
 ## [6.45.12] - 2022-04-14
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.45.12",
+  "version": "6.45.14-beta.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/HttpClient/middlewares/request/HttpAgentSingleton.ts
+++ b/src/HttpClient/middlewares/request/HttpAgentSingleton.ts
@@ -1,5 +1,4 @@
 import HttpAgent from 'agentkeepalive'
-import { mapObjIndexed, sum, values } from 'ramda'
 import { createHttpAgent } from '../../agents'
 
 export class HttpAgentSingleton {
@@ -12,29 +11,23 @@ export class HttpAgentSingleton {
   }
 
   public static httpAgentStats() {
-    const socketsPerOrigin = HttpAgentSingleton.countPerOrigin(HttpAgentSingleton.httpAgent.sockets)
-    const sockets = sum(values(socketsPerOrigin))
-    const freeSocketsPerOrigin = HttpAgentSingleton.countPerOrigin((HttpAgentSingleton.httpAgent as any).freeSockets)
-    const freeSockets = sum(values(freeSocketsPerOrigin))
-    const pendingRequestsPerOrigin = HttpAgentSingleton.countPerOrigin(HttpAgentSingleton.httpAgent.requests)
-    const pendingRequests = sum(values(pendingRequestsPerOrigin))
+    const sockets = HttpAgentSingleton.count(HttpAgentSingleton.httpAgent.sockets)
+    const freeSockets = HttpAgentSingleton.count((HttpAgentSingleton.httpAgent as any).freeSockets)
+    const pendingRequests = HttpAgentSingleton.count(HttpAgentSingleton.httpAgent.requests)
 
     return {
       freeSockets,
-      freeSocketsPerOrigin,
       pendingRequests,
-      pendingRequestsPerOrigin,
       sockets,
-      socketsPerOrigin,
     }
   }
   private static httpAgent: HttpAgent
 
-  private static countPerOrigin(obj: { [key: string]: any[] }) {
+  private static count(obj: { [key: string]: any[] }) {
     try {
-      return mapObjIndexed(val => val.length, obj)
+      return Object.values(obj).reduce((acc, val) => acc += val.length, 0)
     } catch (_) {
-      return {}
+      return 0
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove socket metrics per origin

<!--- Describe your changes in detail. -->

#### What problem is this solving?
Metrics fields overflow in opensearch. We are creating a new field at opensearch for every domain apps make a request, see below.

<img width="1493" alt="Captura de Tela 2022-12-05 às 10 29 57" src="https://user-images.githubusercontent.com/1594322/205649206-cad5ad37-0654-495e-a8eb-34ffc80e9494.png">

This is producing `2366` fields by now, this number can grow indefinitely.

<img width="1511" alt="Captura de Tela 2022-12-05 às 10 48 46" src="https://user-images.githubusercontent.com/1594322/205653223-4e39a9f0-73f4-40db-b8f3-805819952e30.png">


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

At this repo main dir `yarn link` && `yarn watch`

Inside the `node` dir at a node application `yarn link @vtex/api`
Comment [this line](https://github.com/vtex/node-vtex-api/blob/b920186f9049ba5c5c2ad979462b2e97b97bd017/src/service/worker/runtime/statusTrack.ts#L28) so you can see metrics on link logs

link your application and make some requests. You shall see socket metrics at the terminal.

#### Screenshots or example usage

<img width="439" alt="Captura de Tela 2022-12-05 às 10 27 49" src="https://user-images.githubusercontent.com/1594322/205648668-cabd2a67-0348-460b-8068-8727287bbe4b.png">

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
