### PR TITLE
Remove unecessary worker signal logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed unnecessary worker signal logs
 
 ## [6.45.14] - 2023-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.45.15] - 2023-02-01
 ### Changed
 - Removed unnecessary worker signal logs
 
@@ -1755,6 +1757,7 @@ instead
 - `HttpClient` now adds `'Accept-Encoding': 'gzip'` header by default.
 
 
-[Unreleased]: https://github.com/vtex/node-vtex-api/compare/v6.45.14...HEAD
+[Unreleased]: https://github.com/vtex/node-vtex-api/compare/v6.45.15...HEAD
+[6.45.15]: https://github.com/vtex/node-vtex-api/compare/v6.45.14...v6.45.15
 [6.45.14]: https://github.com/vtex/node-vtex-api/compare/v6.45.13...v6.45.14
 [6.45.13]: https://github.com/vtex/node-vtex-api/compare/v6.45.12...v6.45.13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.45.14",
+  "version": "6.45.15",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/master.ts
+++ b/src/service/master.ts
@@ -54,11 +54,6 @@ const GRACEFULLY_SHUTDOWN_TIMEOUT_S = 30
 const SIGINT_TIMEOUT_S = 1
 
 const handleSignal = (timeout: number): NodeJS.SignalsListener => (signal) => {
-  // Log the Master Process received a signal
-  const message = `Master process ${process.pid} received signal ${signal}`
-  console.warn(message)
-  logger.warn({ message, signal })
-
   // For each worker, let's try to kill it gracefully
   Object.values(cluster.workers).forEach((worker) => worker?.kill(signal))
 

--- a/src/service/worker/listeners.ts
+++ b/src/service/worker/listeners.ts
@@ -6,11 +6,7 @@ import { Logger } from '../logger'
 export const logger = new Logger({account: 'unhandled', workspace: 'unhandled', requestId: 'unhandled', operationId: 'unhandled', production: process.env.VTEX_PRODUCTION === 'true'})
 let watched: NodeJS.Process
 
-// Remove the any typings once we move to nodejs 10.x
 const handleSignal: NodeJS.SignalsListener = signal => {
-  const message = `Worker ${process.pid} received signal ${signal}`
-  console.warn(message)
-  logger.warn({message, signal})
   process.exit((constants.signals as any)[signal])
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove unnecessary worker signal logs

<!--- Describe your changes in detail. -->

#### What problem is this solving?

Worker signal logs with SIGTERM are flooding logs visualization. Those logs could happen anytime by scale to zero policy enforcement or just by evicting pods to move for new nodes when clusters are scaling.
<img width="1558" alt="Captura de Tela 2023-02-01 às 10 06 48" src="https://user-images.githubusercontent.com/1594322/216051489-be612b06-7212-46aa-8c41-182e33f52110.png">



<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
