### PR TITLE
Fix MasterData scrollDocuments incorrect return type

### DIFF
--- a/src/clients/external/Masterdata.ts
+++ b/src/clients/external/Masterdata.ts
@@ -217,7 +217,7 @@ export class MasterData extends ExternalClient {
   ) {
     const metric = 'masterdata-scrollDocuments'
     return this.http
-      .getRaw<ScrollResponse<T>>(routes.scroll(dataEntity), {
+      .getRaw<T>(routes.scroll(dataEntity), {
         cacheable: CacheType.None,
         metric,
         params: {
@@ -335,9 +335,4 @@ interface ScrollInput {
 interface DeleteInput {
   dataEntity: string
   id: string
-}
-
-interface ScrollResponse<T> {
-  data: T[]
-  mdToken: string
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Improve the clients usability for TypeScript.

#### What problem is this solving?

Fix broken return types for `MasterData` client's `scrollDocuments` method.

This is the return type of scrollDocuments as is today:

```typescript
interface Response<T> {
    mdToken: string
    data: T
}
```

However, according to the function signature and reinforced by the LSP, it shows an incorrect type and causes inaccurate type errors:

```typescript
interface Response<T> {
    mdToken: string
    data: {
        mdToken: string
        data: T
    }
}
```

This PR fixes it so that the return type shows the correct output as the first snippet.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
