### PR TITLE
Simplifies logic of LRUDiskCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [6.45.15] - 2023-02-01
 ### Changed
+
+- Simplifies logic of LRUDiskCache.
+
+## [6.45.15] - 2023-02-01
+
+### Changed
+
 - Removed unnecessary worker signal logs
 
 ## [6.45.14] - 2023-02-01
@@ -23,7 +29,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Do not return empty content if no conflict is found.
 
 ## [6.45.13] - 2022-12-12
+
 ### Changed
+
 - Deterministic cache for getWithBody
 - Remove socket metrics per origin
 
@@ -1755,7 +1763,6 @@ instead
 ### Changed
 
 - `HttpClient` now adds `'Accept-Encoding': 'gzip'` header by default.
-
 
 [Unreleased]: https://github.com/vtex/node-vtex-api/compare/v6.45.15...HEAD
 [6.45.15]: https://github.com/vtex/node-vtex-api/compare/v6.45.14...v6.45.15


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR changes the LRUDiskCache implementations to use the dispose function of the LRU implementation to clear the disk cache instead of implementing it on get and set functions.

#### What problem is this solving?

After adding some LRUDiskCache to our code, we saw that its metrics were not working correctly. By checking the implementation, I suspect that when any key needs to be removed from the cache, none of the keys will be retrieved due to [this logic](https://github.com/vtex/node-vtex-api/blob/b8dbfaded4d2f75d74dd98355d6f6cffaa8f71f5/src/caches/LRUDiskCache.ts#L62-L69). The key to be deleted is not being verified before removal.

#### How should this be manually tested?
I think the only way to test this properly is installing it in some accounts and check the behavior.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
