### PR TITLE
Chore/bump prom client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.45.16] - 2023-07-03
 ### Changed
 - Bump `prom-client` version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump `prom-client` version
 
 ## [6.45.15] - 2023-02-01
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.45.15",
+  "version": "6.45.16",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mime-types": "^2.1.12",
     "opentracing": "^0.14.4",
     "p-limit": "^2.2.0",
-    "prom-client": "^12.0.0",
+    "prom-client": "^14.2.0",
     "qs": "^6.5.1",
     "querystring": "^0.2.0",
     "ramda": "^0.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3803,10 +3803,10 @@ process@^0.10.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.10.1.tgz#842457cc51cfed72dc775afeeafb8c6034372725"
   integrity sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=
 
-prom-client@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
-  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
   dependencies:
     tdigest "^0.1.1"
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This version bumps the `prom-client` version to remove a deprecation warning in the CLI when linking a project to the node builder using node 16.

#### What problem is this solving?
It removes the following deprecation warning from CLI when linking an application.
![Screenshot 2023-07-03 at 4 12 48 PM](https://github.com/vtex/node-vtex-api/assets/38737958/2e7371fe-b9d7-4fe8-ac65-8870642e96ba)


#### How should this be manually tested?
- Create a new workspace in `vtexgame1` account;
- Run `yarn link` in the `node-vtex-api`;
- Open a project using the node builder and update the version to `7.x`;
- In the same project, cd to `/node` and run `yarn link @vtex/api`;
- Link the project to the workspace. You should not see the warning above.

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
