### PR TITLE
Fix/prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Metrics to prometheus
 
 ## [6.45.16] - 2023-07-03
 ### Changed

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -22,7 +22,7 @@ export const addMetricsLoggerMiddleware = () => {
   }
 }
 
-export const prometheusLoggerMiddleware = () => {
+export const prometheusLoggerMiddleware = async () => {
   collectDefaultMetrics()
   const eventLoopLagMeasurer = new EventLoopLagMeasurer()
   eventLoopLagMeasurer.start()
@@ -39,7 +39,7 @@ export const prometheusLoggerMiddleware = () => {
 
     await eventLoopLagMeasurer.updateInstrumentsAndReset()
     ctx.set('Content-Type', register.contentType)
-    ctx.body = register.metrics()
+    ctx.body = await register.metrics()
     ctx.status = 200
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
The [metrics to prometheus](https://grafana.vtex.systems/d/2aCNF4MGkas/regular-node-apps-http-metrics?orgId=1&var-prometheus_datasources=Prometheus-developer-journey&var-cluster=All&var-deployment_namespace=vendor-vtex&var-app_name=vtex.render-server&var-route_handler=All&from=now-7d&to=now&refresh=10s) has been down since the update of prom-client.

Investigating the differences between [v12](https://www.npmjs.com/package/prom-client/v/12.0.0) and [v14](https://www.npmjs.com/package/prom-client/v/14.2.0), the metrics from registry are now a promise, and before it was a string.


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
