### PR TITLE
Remove `prometheusLoggerMiddleware` async typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.45.17",
+  "version": "6.45.18",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -22,7 +22,7 @@ export const addMetricsLoggerMiddleware = () => {
   }
 }
 
-export const prometheusLoggerMiddleware = async () => {
+export const prometheusLoggerMiddleware = () => {
   collectDefaultMetrics()
   const eventLoopLagMeasurer = new EventLoopLagMeasurer()
   eventLoopLagMeasurer.start()


### PR DESCRIPTION
Last PR had a build problem because of a misplaced `async` directive. Removing that solves the issue

To test:
Run `yarn build`. It should execute without errors