### PR TITLE
Remove sampling decision from runtime

### DIFF
--- a/src/service/tracing/TracerSingleton.ts
+++ b/src/service/tracing/TracerSingleton.ts
@@ -33,12 +33,6 @@ export class TracerSingleton {
       reporter: {
         agentHost: process.env.VTEX_OWN_NODE_IP,
       },
-      sampler: {
-        host: process.env.VTEX_OWN_NODE_IP,
-        param: 0.05,
-        refreshIntervalMs: 60 * 1000,
-        type: 'remote',
-      },
       serviceName,
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Node runtime is overriding jaeger-agent sampling decision. It is also creating dangling RootSpans anytime a current application doesn't receive a RootSpan from the parent request, e.g: Kuberouter.

This PR removes sampler configs enabling the default behavior, which is: 
> Remote (sampler.type=remote, which is also the default) sampler consults jaeger-agent for the appropriate sampling strategy to use in the current service. This allows controlling the sampling strategies in the services from a central configuration in Jaeger backend (see [Remote Sampling](https://www.jaegertracing.io/docs/1.46/sampling/#remote-sampling)), or even dynamically (see [Adaptive Sampling](https://www.jaegertracing.io/docs/1.46/sampling/#adaptive-sampling)).

It also only creates tracing spans when a RootSpan comes from the Router.

<!--- Describe your changes in detail. -->
<img width="1016" alt="Screenshot 2023-08-30 at 15 21 32" src="https://github.com/vtex/node-vtex-api/assets/1594322/8d622454-33e0-4b65-b871-2759473ecc55">

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
