### PR TITLE
Fix error details not being logged in the tracing's span event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Error tracing spans not logging the details.
+
 ## [6.45.20] - 2023-08-30
 ### Changed
 - Remove sampling decision from runtime

--- a/src/HttpClient/middlewares/request/setupAxios/__tests__/axiosTracingTestSuite.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/__tests__/axiosTracingTestSuite.ts
@@ -167,7 +167,7 @@ export const registerSharedTestSuite = (testSuiteConfig: TestSuiteConfig) => {
           expect((requestSpan as any)._logs[len - 1].fields[ErrorReportLogFields.ERROR_ID]).toBeDefined()
           expect((requestSpan as any)._logs[len - 1].fields[ErrorReportLogFields.ERROR_KIND]).toBeDefined()
           expect(
-            ((requestSpan as any)._logs[len - 1].fields.error.message as string).startsWith(
+            ((requestSpan as any)._logs[len - 1].fields[ErrorReportLogFields.ERROR_DETAILS].message as string).startsWith(
               testSuiteConfig.expects.error!.errorMessagePrefix
             )
           ).toBeTruthy()

--- a/src/HttpClient/middlewares/request/setupAxios/__tests__/axiosTracingTestSuite.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/__tests__/axiosTracingTestSuite.ts
@@ -167,7 +167,7 @@ export const registerSharedTestSuite = (testSuiteConfig: TestSuiteConfig) => {
           expect((requestSpan as any)._logs[len - 1].fields[ErrorReportLogFields.ERROR_ID]).toBeDefined()
           expect((requestSpan as any)._logs[len - 1].fields[ErrorReportLogFields.ERROR_KIND]).toBeDefined()
           expect(
-            ((requestSpan as any)._logs[len - 1].fields[ErrorReportLogFields.ERROR_DETAILS].message as string).startsWith(
+            ((requestSpan as any)._logs[len - 1].fields[ErrorReportLogFields.ERROR_MESSAGE] as string).startsWith(
               testSuiteConfig.expects.error!.errorMessagePrefix
             )
           ).toBeTruthy()

--- a/src/tracing/LogFields.ts
+++ b/src/tracing/LogFields.ts
@@ -15,6 +15,7 @@ export const enum ErrorReportLogFields {
    */
   ERROR_KIND = 'error.kind',
   ERROR_ID = 'error.id',
+  ERROR_DETAILS = 'error.details',
 
   /**
    * VTEX's Infra errors adds error details to the response

--- a/src/tracing/LogFields.ts
+++ b/src/tracing/LogFields.ts
@@ -18,7 +18,8 @@ export const enum ErrorReportLogFields {
   ERROR_MESSAGE = 'error.message',
   ERROR_CODE = 'error.code',
   ERROR_STACK = 'error.stack',
-  ERROR_METADATA = 'error.metadata',
+  ERROR_METADATA_REPORT_COUNT = 'error.metadata.reportCount',
+  ERROR_METADATA_METRICS_INSTANTIATION_TIME = 'error.metadata.metrics.InstantiationTime',
 
   /**
    * VTEX's Infra errors adds error details to the response

--- a/src/tracing/LogFields.ts
+++ b/src/tracing/LogFields.ts
@@ -15,7 +15,10 @@ export const enum ErrorReportLogFields {
    */
   ERROR_KIND = 'error.kind',
   ERROR_ID = 'error.id',
-  ERROR_DETAILS = 'error.details',
+  ERROR_MESSAGE = 'error.message',
+  ERROR_CODE = 'error.code',
+  ERROR_STACK = 'error.stack',
+  ERROR_METADATA = 'error.metadata',
 
   /**
    * VTEX's Infra errors adds error details to the response

--- a/src/tracing/errorReporting/ErrorReport.ts
+++ b/src/tracing/errorReporting/ErrorReport.ts
@@ -65,8 +65,8 @@ export class ErrorReport extends ErrorReportBase {
       event: 'error',
       ...indexedLogs,
       [ErrorReportLogFields.ERROR_MESSAGE]: serializableError.message,
-      [ErrorReportLogFields.ERROR_METADATA_METRICS_INSTANTIATION_TIME]: serializableError.metadata.reportCount,
-      [ErrorReportLogFields.ERROR_METADATA_REPORT_COUNT]: serializableError.metadata.metrics.instantiationTime,
+      [ErrorReportLogFields.ERROR_METADATA_METRICS_INSTANTIATION_TIME]: serializableError.metadata?.reportCount,
+      [ErrorReportLogFields.ERROR_METADATA_REPORT_COUNT]: serializableError.metadata?.metrics?.instantiationTime,
       [ErrorReportLogFields.ERROR_STACK]: serializableError.stack,
       [ErrorReportLogFields.ERROR_CODE]: serializableError.code,
     })

--- a/src/tracing/errorReporting/ErrorReport.ts
+++ b/src/tracing/errorReporting/ErrorReport.ts
@@ -65,7 +65,8 @@ export class ErrorReport extends ErrorReportBase {
       event: 'error',
       ...indexedLogs,
       [ErrorReportLogFields.ERROR_MESSAGE]: serializableError.message,
-      [ErrorReportLogFields.ERROR_METADATA]: serializableError.metadata,
+      [ErrorReportLogFields.ERROR_METADATA_METRICS_INSTANTIATION_TIME]: serializableError.metadata.reportCount,
+      [ErrorReportLogFields.ERROR_METADATA_REPORT_COUNT]: serializableError.metadata.metrics.instantiationTime,
       [ErrorReportLogFields.ERROR_STACK]: serializableError.stack,
       [ErrorReportLogFields.ERROR_CODE]: serializableError.code,
     })

--- a/src/tracing/errorReporting/ErrorReport.ts
+++ b/src/tracing/errorReporting/ErrorReport.ts
@@ -61,7 +61,14 @@ export class ErrorReport extends ErrorReportBase {
     }
 
     const serializableError = this.toObject()
-    span.log({ event: 'error', ...indexedLogs, [ErrorReportLogFields.ERROR_DETAILS]: serializableError })
+    span.log({
+      event: 'error',
+      ...indexedLogs,
+      [ErrorReportLogFields.ERROR_MESSAGE]: serializableError.message,
+      [ErrorReportLogFields.ERROR_METADATA]: serializableError.metadata,
+      [ErrorReportLogFields.ERROR_STACK]: serializableError.stack,
+      [ErrorReportLogFields.ERROR_CODE]: serializableError.code,
+    })
 
     if (logger && this.shouldLogToSplunk(span)) {
       logger.error(serializableError)

--- a/src/tracing/errorReporting/ErrorReport.ts
+++ b/src/tracing/errorReporting/ErrorReport.ts
@@ -61,7 +61,7 @@ export class ErrorReport extends ErrorReportBase {
     }
 
     const serializableError = this.toObject()
-    span.log({ event: 'error', ...indexedLogs, error: serializableError })
+    span.log({ event: 'error', ...indexedLogs, [ErrorReportLogFields.ERROR_DETAILS]: serializableError })
 
     if (logger && this.shouldLogToSplunk(span)) {
       logger.error(serializableError)


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix how the field "error" of an "error" span event is not displaying the error's details.

|[Before](https://ui.honeycomb.io/vtex/datasets/vtex/result/4gcqfkK2VnT/trace/qrDKt35zRAb?fields%5B%5D=c_name&fields%5B%5D=c_service.name&span=7343fae299df18bb)|[After](https://ui.honeycomb.io/vtex/datasets/vtex/result/wqY64s5khL9/trace/oy4qsTDkA6L?fields%5B%5D=c_name&fields%5B%5D=c_service.name&fields%5B%5D=c_service.name_and_version&span=b3d5f187c40e6b2a)|
|-|-|
|![CleanShot 2023-09-14 at 14 01 28@2x](https://github.com/vtex/node-vtex-api/assets/381395/901ca798-5df3-475b-98a4-17294860bc1e)|![CleanShot 2023-09-19 at 12 24 19](https://github.com/vtex/node-vtex-api/assets/381395/20b3ac26-a3d7-4063-b6c6-81ac65f7a6f6)|

#### What problem is this solving?

It appears this "error" field is categorized as a boolean type, so the [expected error details](https://github.com/vtex/node-error-report/blob/7971b91dcde144b44c3b8c7534bd71a80017b132/src/ErrorReportBase.ts#L108-L120) isn't being used. By renaming this field to "error.details", we expect to have it displayed on Honeycomb.

#### How should this be manually tested?

1. Visit https://filipelimaxtracing--storecomponents.myvtex.com/ where I have yarn-linked this branch to a vtex-linked `pages-graphql` and `render-server` apps.
2. To avoid being sampled, use a browser extension to include the header `jaeger-debug-id=ANY_ID_YOU_WANT_USE_TO_QUERY_HONEYCOMB`. 
3. Navigate through the store to send some traces to Honeycomb.
4. In Honeycomb's Query page, add a WHERE filter to `jaeger-debug-id = ANY_ID_YOU_WANT_USE_TO_QUERY_HONEYCOMB` to find your traces.

[Example](https://ui.honeycomb.io/vtex/datasets/vtex/result/wqY64s5khL9/trace/oy4qsTDkA6L?fields%5B%5D=c_name&fields%5B%5D=c_service.name&fields%5B%5D=c_service.name_and_version&span=b3d5f187c40e6b2a) of a trace with error span. Check the "Span events" tab on the side bar and expand the "error" event.

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
