### PR TITLE
Fix metrics being restricted by tracing restrictions

### DIFF
--- a/src/service/metrics/requestMetricsMiddleware.ts
+++ b/src/service/metrics/requestMetricsMiddleware.ts
@@ -1,0 +1,70 @@
+import { finished as onStreamFinished } from 'stream'
+import { hrToMillisFloat } from '../../utils'
+import { ServiceContext } from '../worker/runtime/typings'
+import {
+  createConcurrentRequestsInstrument,
+  createRequestsResponseSizesInstrument,
+  createRequestsTimingsInstrument,
+  createTotalAbortedRequestsInstrument,
+  createTotalRequestsInstrument,
+  RequestsMetricLabels,
+} from '../tracing/metrics/instruments'
+
+
+export const addRequestMetricsMiddleware = () => {
+  const concurrentRequests = createConcurrentRequestsInstrument()
+  const requestTimings = createRequestsTimingsInstrument()
+  const totalRequests = createTotalRequestsInstrument()
+  const responseSizes = createRequestsResponseSizesInstrument()
+  const abortedRequests = createTotalAbortedRequestsInstrument()
+
+  return async function addRequestMetrics(ctx: ServiceContext, next: () => Promise<void>) {
+    const start = process.hrtime()
+    concurrentRequests.inc(1)
+
+    ctx.req.once('aborted', () =>
+      abortedRequests.inc({ [RequestsMetricLabels.REQUEST_HANDLER]: ctx.requestHandlerName }, 1)
+    )
+
+    let responseClosed = false
+    ctx.res.once('close', () => (responseClosed = true))
+
+    try {
+      await next()
+    } finally {
+      const responseLength = ctx.response.length
+      if (responseLength) {
+        responseSizes.observe(
+          { [RequestsMetricLabels.REQUEST_HANDLER]: ctx.requestHandlerName },
+          responseLength
+        )
+      }
+
+      totalRequests.inc(
+        {
+          [RequestsMetricLabels.REQUEST_HANDLER]: ctx.requestHandlerName,
+          [RequestsMetricLabels.STATUS_CODE]: ctx.response.status,
+        },
+        1
+      )
+
+      const onResFinished = () => {
+        requestTimings.observe(
+          {
+            [RequestsMetricLabels.REQUEST_HANDLER]: ctx.requestHandlerName,
+          },
+          hrToMillisFloat(process.hrtime(start))
+        )
+        
+        concurrentRequests.dec(1)
+      }
+
+      if (responseClosed) {
+        onResFinished()
+      } else {
+        onStreamFinished(ctx.res, onResFinished)
+      }
+    }
+  }
+}
+

--- a/src/service/metrics/requestMetricsMiddleware.ts
+++ b/src/service/metrics/requestMetricsMiddleware.ts
@@ -1,6 +1,5 @@
 import { finished as onStreamFinished } from 'stream'
 import { hrToMillisFloat } from '../../utils'
-import { ServiceContext } from '../worker/runtime/typings'
 import {
   createConcurrentRequestsInstrument,
   createRequestsResponseSizesInstrument,
@@ -9,6 +8,7 @@ import {
   createTotalRequestsInstrument,
   RequestsMetricLabels,
 } from '../tracing/metrics/instruments'
+import { ServiceContext } from '../worker/runtime/typings'
 
 
 export const addRequestMetricsMiddleware = () => {
@@ -55,7 +55,7 @@ export const addRequestMetricsMiddleware = () => {
           },
           hrToMillisFloat(process.hrtime(start))
         )
-        
+
         concurrentRequests.dec(1)
       }
 

--- a/src/service/worker/index.ts
+++ b/src/service/worker/index.ts
@@ -14,6 +14,7 @@ import { logOnceToDevConsole } from '../logger/console'
 import { LogLevel } from '../logger/logger'
 import { TracerSingleton } from '../tracing/TracerSingleton'
 import { addTracingMiddleware } from '../tracing/tracingMiddlewares'
+import { addRequestMetricsMiddleware } from '../metrics/requestMetricsMiddleware'
 import { addProcessListeners, logger } from './listeners'
 import {
   healthcheckHandler,
@@ -221,6 +222,7 @@ export const startWorker = (serviceJSON: ServiceJSON) => {
     .use(error)
     .use(prometheusLoggerMiddleware())
     .use(addTracingMiddleware(tracer))
+    .use(addRequestMetricsMiddleware())
     .use(addMetricsLoggerMiddleware())
     .use(concurrentRateLimiter(serviceJSON?.rateLimitPerReplica?.concurrent))
     .use(compress())

--- a/src/service/worker/index.ts
+++ b/src/service/worker/index.ts
@@ -12,9 +12,9 @@ import { MetricsAccumulator } from '../../metrics/MetricsAccumulator'
 import { getService } from '../loaders'
 import { logOnceToDevConsole } from '../logger/console'
 import { LogLevel } from '../logger/logger'
+import { addRequestMetricsMiddleware } from '../metrics/requestMetricsMiddleware'
 import { TracerSingleton } from '../tracing/TracerSingleton'
 import { addTracingMiddleware } from '../tracing/tracingMiddlewares'
-import { addRequestMetricsMiddleware } from '../metrics/requestMetricsMiddleware'
 import { addProcessListeners, logger } from './listeners'
 import {
   healthcheckHandler,

--- a/src/service/worker/runtime/typings.ts
+++ b/src/service/worker/runtime/typings.ts
@@ -37,6 +37,7 @@ export interface Context<T extends IOClients> {
   timings: Record<string, [number, number]>
   metrics: Record<string, [number, number]>
   previousTimerStart: [number, number]
+  requestHandlerName?: string
   serverTiming?: ServerTiming
   tracing?: TracingContext
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Stop restricting request metrics according to the tracing sampling logic. Metrics should always be logged.

#### What problem is this solving?
Some request metrics were not being logged as frequently as desired after some tracing restrictions were added. That's because their code was tightly mixed with the tracing code, and so this happened by mistake.

To solve this, I've split the tracing middleware into two: one just for tracing and another just for those metrics. The tracing check is only done on the first.

#### How should this be manually tested?
I've navigated through [this workspace](https://mairametrics--hmchile.myvtex.com/) that includes the change and:
- Verified that the store works as before, with no errors.
- Verified that the metrics are being logged regardless of tracing being enabled (checked via console.logs).
- Verified that the traces are not being logged when disabled (checked via console.log and the jaeger-debug-id header).
- Verified that the traces are being logged when enabled (checked via console.log and the jaeger-debug-id header).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
