### PR TITLE
Allow disabling memoization for all requests of a client

### DIFF
--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -39,6 +39,7 @@ export class HttpClient {
 
   private logger: Logger
   private cacheableType: CacheType
+  private memoizable: boolean
 
   private runMiddlewares: compose.ComposedMiddleware<MiddlewareContext>
 
@@ -49,6 +50,7 @@ export class HttpClient {
       authType,
       memoryCache,
       diskCache,
+      memoizable = true,
       locale,
       name,
       metrics,
@@ -79,6 +81,7 @@ export class HttpClient {
     this.name = name || baseURL || 'unknown'
     this.logger = logger
     this.cacheableType = cacheableType
+    this.memoizable = memoizable
 
     const limit = concurrency && concurrency > 0 && pLimit(concurrency) || undefined
     const headers: Record<string, string> = {
@@ -210,7 +213,7 @@ export class HttpClient {
 
   private getConfig = (url: string, config: RequestConfig = {}): CacheableRequestConfig => ({
     cacheable: this.cacheableType,
-    memoizable: true,
+    memoizable: this.memoizable,
     ...config,
     url,
   })

--- a/src/HttpClient/typings.ts
+++ b/src/HttpClient/typings.ts
@@ -83,6 +83,7 @@ export interface InstanceOptions {
   timeout?: number
   memoryCache?: CacheLayer<string, Cached>
   diskCache?: CacheLayer<string, Cached>
+  memoizable?: boolean
   baseURL?: string
   retries?: number
   exponentialTimeoutCoefficient?: number


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adding an optional flag for HttpClient to disable memoization for all requests by default.

#### What problem is this solving?

All HttpClient classes have memoization turned on by default, and the only way to turn it off today is by request. And even that way is not helpful for Node.js apps, because the methods provided by subclasses of HttpClient don't provide the option of passing this config anyway.

This new flag for HttpClient allows apps to configure the value for `memoizable` per client, which was previously true for all of them. I set the default value of this new flag to `true` so that there will be no behavior change at all.

The reason why we wnant to be able to turn memoization off is because we've noticed that apps like pages-graphql never get hits for those, so having it enabled is a waste of memory and of garbage collector work.

#### How should this be manually tested?
Link @vtex/api to a local app and try setting this new flag to `false` for some clients. Checking honeycomb traces will show that the setting is now disabled for each outgoing request for that client.

I've tested this on pages-graphql, for example and these are the traces:
**1. Trace from master workspace, without the change** - [link](https://ui.honeycomb.io/vtex/datasets/vtex/result/uw4WB8HMii7/trace/rMzQgB1PhHs?fields%5B%5D=c_name&fields%5B%5D=c_service.name&fields%5B%5D=c_http.cache.memoization&fields%5B%5D=c_http.cache.memoization.enabled&span=ef37d4d33b380fce). You can see that the `http.cache.memoization.enabled` field is always _true_ for outgoing requests from pages-graphql.
**2. Trace from a workspace with the change, without setting the new flag** - [link](https://ui.honeycomb.io/vtex/datasets/vtex/result/t7NpzjuWmb9/trace/BfT1SRZeEC5?fields%5B%5D=c_name&fields%5B%5D=c_service.name&fields%5B%5D=c_http.cache.memoization&fields%5B%5D=c_http.cache.memoization.enabled&span=e14da7a238635d2c). You can see the same behavior as in master: the `http.cache.memoization.enabled` field is always _true_ for outgoing requests from pages-graphql.
**3. Trace from a workspace with the change, setting the new flag to false** - [link](https://ui.honeycomb.io/vtex/datasets/vtex/result/dbCYoVQakHf/trace/58aUDaJWR51?fields%5B%5D=c_name&fields%5B%5D=c_service.name&fields%5B%5D=c_http.cache.memoization&fields%5B%5D=c_http.cache.memoization.enabled&span=d3110f2f98c442a9). You can see that the `http.cache.memoization.enabled` field is always _false_ for outgoing requests from pages-graphql.

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
