### PR TITLE
Stop updating client cache when revalidated and still expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Stop updating client cache when revalidated and still expired
+
 ## [6.45.23] - 2023-10-04
 
 ### Fixed

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -198,7 +198,16 @@ export const cacheMiddleware = ({ type, storage }: CacheOptions) => {
         ? (data as Buffer).toString(responseEncoding)
         : data
 
-      const expiration = Date.now() + (maxAge - currentAge) * 1000
+      const now = Date.now()
+      const expiration = now + (maxAge - currentAge) * 1000
+
+      const alreadyExpired = expiration <= now
+      const reusingRevalidatedCache = cached && (ctx.response === cached.response)
+      const shouldSkipCacheUpdate = alreadyExpired && reusingRevalidatedCache
+      if (shouldSkipCacheUpdate) {
+        return
+      }
+
       await storage.set(setKey, {
         etag,
         expiration,


### PR DESCRIPTION
#### What is the purpose of this pull request?

This is removing a bunch of unnecessary disk writes, which just waste CPU.

#### What problem is this solving?

When a cached response is expired, we try sending a request using the cached etag to revalidate it. If this revalidation is successful, we use the cache contents. In that case, we also update the cache again **with the contents it already has**. That's just a waste of CPU.

This is only ever useful if the cache max age has increased, to avoid further revalidations, since we also write the new max age to the disk. But at least for pages-graphql calls it's very frequent for the content to still be expired at this point. 

This PR is making sure that we only ever update the cache if either the content has changed (meaning that we didn't use the cached contents) or the expiration time has changed.

This should free a lot of disk writes from pages-graphql (at least ~60% of disk writes for VBase calls, plus others in the same situation).

#### How should this be manually tested?

I've tested this by vtex linking pages-graphql with @vtex/api locally linked, and adding console.log to show when we skip writing to cache. The skips were done at the right time (after revalidating VBase requests, which are always expired).

I've also tested by looking at Honeycomb traces. On production you'll always see the `local-cache-saved` event for requests to VBase, even for STALE requests. Now you'll only ever see this event for MISS requests to VBase ([example trace with STALE](https://ui.honeycomb.io/vtex/datasets/vtex/result/xGhYKiApJPn/trace/nWPYfWDvwDr?fields[]=c_name&fields[]=c_service.name&fields[]=c_http.cache.disk&span=447dc3b2be8ae28b), [example trace with MISS](https://ui.honeycomb.io/vtex/datasets/vtex/result/p5Unmwgsj6n/trace/oJDszfxobHe?fields[]=c_name&fields[]=c_service.name&fields[]=c_http.cache.disk&span=1649e70a8fae547d)).

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
