### PR TITLE
Allow passing request config to VBase's getJSON method

### DIFF
--- a/src/clients/infra/VBase.ts
+++ b/src/clients/infra/VBase.ts
@@ -11,6 +11,7 @@ import {
   inflightUrlWithQuery,
   InstanceOptions,
   IOResponse,
+  RequestConfig,
   RequestTracingConfig,
 } from '../../HttpClient'
 import {
@@ -83,8 +84,15 @@ export class VBase extends InfraClient {
     }})
   }
 
-  public getJSON = <T>(bucket: string, path: string, nullIfNotFound?: boolean, conflictsResolver?: ConflictsResolver<T>, tracingConfig?: RequestTracingConfig) => {
-    return this.getRawJSON<T>(bucket, path, nullIfNotFound, conflictsResolver, tracingConfig)
+  public getJSON = <T>(
+    bucket: string,
+    path: string,
+    nullIfNotFound?: boolean,
+    conflictsResolver?: ConflictsResolver<T>,
+    tracingConfig?: RequestTracingConfig,
+    requestConfig?: RequestConfig
+  ) => {
+    return this.getRawJSON<T>(bucket, path, nullIfNotFound, conflictsResolver, tracingConfig, requestConfig)
       .then(response => response.data)
   }
 
@@ -93,7 +101,8 @@ export class VBase extends InfraClient {
     path: string,
     nullIfNotFound?: boolean,
     conflictsResolver?: ConflictsResolver<T>,
-    tracingConfig?: RequestTracingConfig
+    tracingConfig?: RequestTracingConfig,
+    requestConfig?: RequestConfig
   ) => {
     const headers = conflictsResolver ? { 'X-Vtex-Detect-Conflicts': true } : {}
     const inflightKey = inflightURL
@@ -108,6 +117,7 @@ export class VBase extends InfraClient {
           requestSpanNameSuffix: metric,
           ...tracingConfig?.tracing,
         },
+        ...requestConfig
       } as IgnoreNotFoundRequestConfig)
       .catch(async (error: AxiosError<T>) => {
         const { response } = error


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow passing request options when calling VBase's getJSON method.

#### What problem is this solving?

Today it isn't possible to send custom per-request options for VBase's getJSON method, so we can't use the `forceMaxAge` option per request, for example. This extra param will also allow passing a new request config that will added in a subsequent PR.

#### How should this be manually tested?

- Build the codebase and verify that there were no errors.
- Link this npm package into an app, within a linked workspace, and make sure that vbase calls are working as before.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
