### PR TITLE
Fix/save json return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Return type for the saveJSON method of VBase client
+
 ## [6.46.0] - 2023-10-25
 ### Added
 - Add disk cache steps and retry count to tracing

--- a/src/clients/infra/VBase.ts
+++ b/src/clients/infra/VBase.ts
@@ -16,7 +16,7 @@ import {
 import {
   IgnoreNotFoundRequestConfig,
 } from '../../HttpClient/middlewares/notFound'
-import { BucketMetadata, FileListItem } from '../../responses'
+import { BucketMetadata, FileListItem, VBaseSaveResponse } from '../../responses'
 import { IOContext } from '../../service/worker/runtime/typings'
 import { InfraClient } from './InfraClient'
 
@@ -118,7 +118,7 @@ export class VBase extends InfraClient {
             return { ...response, data: conflictsMergedData } as IOResponse<T>
           } catch (resolverError) {
             const typedResolverError = resolverError as { status?: number; message: string }
-            
+
             if (typedResolverError?.status === 404) {
               return this.http.getRaw<T>(routes.File(bucket, path), {
                 'X-Vtex-Detect-Conflicts': false,
@@ -165,7 +165,7 @@ export class VBase extends InfraClient {
       headers['If-Match'] = ifMatch
     }
     const metric = 'vbase-save-json'
-    return this.http.put(routes.File(bucket, path), data, {headers, metric, tracing: {
+    return this.http.put<VBaseSaveResponse>(routes.File(bucket, path), data, {headers, metric, tracing: {
       requestSpanNameSuffix: metric,
       ...tracingConfig?.tracing,
     }})

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -86,3 +86,5 @@ export interface HousekeeperStatesAndUpdates {
   state: HouseKeeperState
   updates: HouseKeeperUpdates
 }
+
+export type VBaseSaveResponse = FileListItem[]


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?
The return type from the VBase saveJSON method is currently `Promise<void>`. This PR changes it the correct type to `Promise<Array<{path: string; hash: string}>>`.

The VBase service that answers this request is [this one](https://github.com/vtex/vbase/blob/f872f26a91c772493a6c9263c5ee8e5a2ed30b6c/src/vbase/Applications/VBase.WebApp/Controllers/FilesController.cs#L60-L77), and the return type is defined [here](https://github.com/vtex/vbase/blob/f872f26a91c772493a6c9263c5ee8e5a2ed30b6c/src/vbase/Applications/VBase.WebApp/Results/FileCreatedResult.cs#L17).



