### PR TITLE
Increase messages timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Return type for the saveJSON method of VBase client
 
+### Changed
+- Increase timeout for messagesGraphQL client
+
 ## [6.46.0] - 2023-10-25
 ### Added
 - Add disk cache steps and retry count to tracing

--- a/src/service/loaders.ts
+++ b/src/service/loaders.ts
@@ -44,9 +44,9 @@ const defaultClients: ClientsConfig = {
       timeout: 1000,
     },
     messagesGraphQL: {
-      concurrency: 10,
+      concurrency: 12,
       retries: 2,
-      timeout: 1000,
+      timeout: 2000,
     },
   },
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

We have seen some timeout errors in the admin coming from `translateWithDependencies` method. We are increasing the timeout to the MessageGraphQL to accommodate the P99 duration time for this method - [here](https://ui.honeycomb.io/vtex/datasets/vtex/result/6GR5x8MjSry). We are also increasing the number of concurrent request to messages, since the app is running below 50% of CPU usage on average.  
