### PR TITLE
Add handler name http runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+- Add handler name for runtime http handlers
+
 ## [6.46.1] - 2024-01-31
 
 ### Fixed

--- a/src/service/worker/runtime/builtIn/handlers.ts
+++ b/src/service/worker/runtime/builtIn/handlers.ts
@@ -4,7 +4,8 @@ export const whoAmIHandler = ({
   events,
   routes,
 }: ServiceJSON) => (ctx: ServiceContext) => {
-  ctx.tracing?.currentSpan?.setOperationName('builtin:whoami')
+  ctx.requestHandlerName = 'builtin:whoami'
+  ctx.tracing?.currentSpan?.setOperationName(ctx.requestHandlerName)
   ctx.status = 200
   ctx.body = {
     events,
@@ -17,7 +18,8 @@ export const healthcheckHandler = ({
   events,
   routes,
 }: ServiceJSON) => (ctx: ServiceContext) => {
-  ctx.tracing?.currentSpan?.setOperationName('builtin:healthcheck')
+  ctx.requestHandlerName = 'builtin:healthcheck'
+  ctx.tracing?.currentSpan?.setOperationName(ctx.requestHandlerName)
   ctx.status = 200
   ctx.body = {
     events,
@@ -26,7 +28,8 @@ export const healthcheckHandler = ({
 }
 
 export const metricsLoggerHandler = (ctx: ServiceContext) => {
-  ctx.tracing?.currentSpan?.setOperationName('builtin:metrics-logger')
+  ctx.requestHandlerName = 'builtin:metrics-logger'
+  ctx.tracing?.currentSpan?.setOperationName(ctx.requestHandlerName)
   ctx.status = 200
   ctx.body = ctx.metricsLogger.getSummaries()
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds labels to the request handlers for the routes added by the node sdk to all applications -`/healthcheck`, `/_metrics` and  `/:account/:workspace/_whoami`. Currently, the handler `undefined` is TOP 5 handler in the metrics for `runtime_http_requests_total` - [ref](https://grafana.vtex.systems/goto/1SM0WDfSR?orgId=1):

<img width="1427" alt="Screenshot 2024-04-23 at 5 34 59 PM" src="https://github.com/vtex/node-vtex-api/assets/38737958/81ba64e2-8e94-40d7-9bef-24159b8b744d">

_one thing that doens't make sense to me is the scale in this dashboard - I might have queried it wrong, but the intention here is to show the relevance of the undefined events_

#### What problem is this solving?
The handler name is added to the metrics based on `ctx.requestHandlerName` - [ref](https://github.com/vtex/node-vtex-api/blob/8defd37eb11b9e507d87cfb41fc58c27b4275c97/src/service/metrics/requestMetricsMiddleware.ts#L26-L54). The `requestHandlerName` is added by the [nameSpanOperation Middleware](https://github.com/vtex/node-vtex-api/blob/8defd37eb11b9e507d87cfb41fc58c27b4275c97/src/service/tracing/tracingMiddlewares.ts#L78-L84), and it's applied to the `appHttpHandlers`, `appEventHandlers` and `appGraphQLHandlers` not to the `runtimeHttpHandlers` - [here](https://github.com/vtex/node-vtex-api/blob/8defd37eb11b9e507d87cfb41fc58c27b4275c97/src/service/worker/index.ts#L239-L242).

- For the `appHttpHandlers`, it's is applied for both private and public routes, it's added [here](https://github.com/vtex/node-vtex-api/blob/8defd37eb11b9e507d87cfb41fc58c27b4275c97/src/service/worker/runtime/http/index.ts#L37) and [here](https://github.com/vtex/node-vtex-api/blob/8defd37eb11b9e507d87cfb41fc58c27b4275c97/src/service/worker/runtime/http/index.ts#L64);
- For the `appEventHandlers`, it's applied [here](https://github.com/vtex/node-vtex-api/blob/8defd37eb11b9e507d87cfb41fc58c27b4275c97/src/service/worker/runtime/events/index.ts#L32);
- For the `appGraphQLHandlers`, it's applied [here](https://github.com/vtex/node-vtex-api/blob/8defd37eb11b9e507d87cfb41fc58c27b4275c97/src/service/worker/runtime/graphql/index.ts#L27).

By adding the `requestHandlerName` to the context in the routes created by `runtimeHttpHandlers` we should be able to better filter the http metrics for applications.
