### PR TITLE
Add resolveAll to the ConflicstResolver module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- resolveAll to `MineWinsConflictsResolver` to handle an array of conflicts.
+
 ## [6.47.0] - 2024-06-11
 ### Added
 - Add option to save asynchronous cache

--- a/src/utils/MineWinsConflictsResolver.ts
+++ b/src/utils/MineWinsConflictsResolver.ts
@@ -49,18 +49,17 @@ export class MineWinsConflictsResolver<T> implements ConflictsResolver<T> {
   }
 
   public async resolveAll() {
-    return await this.client.getConflicts<AxiosResponse<VBaseConflictData[]>>(this.bucket).then((data) => {
-      const { data: conflicts }: { data: VBaseConflictData[] } = data
+    const conflictsResponse = await this.client.getConflicts<AxiosResponse<VBaseConflictData[]>>(this.bucket)
+    const { data: conflicts }: { data: VBaseConflictData[] } = conflictsResponse
 
-      const resolved = conflicts.map((conflict) => {
-        conflict.base.parsedContent = this.parseConflict(conflict.base)
-        conflict.master.parsedContent = this.parseConflict(conflict.master)
-        conflict.mine.parsedContent = this.parseConflict(conflict.mine)
-        return this.resolveConflictMineWins(conflict)
-      })
-
-      return resolved as any
+    const resolvedConflicts = conflicts.map((conflict) => {
+      conflict.base.parsedContent = this.parseConflict(conflict.base)
+      conflict.master.parsedContent = this.parseConflict(conflict.master)
+      conflict.mine.parsedContent = this.parseConflict(conflict.mine)
+      return this.resolveConflictMineWins(conflict)
     })
+
+    return resolvedConflicts
   }
 
   protected mergeMineWins(base: Configuration, master: Configuration, mine: Configuration) {

--- a/src/utils/MineWinsConflictsResolver.ts
+++ b/src/utils/MineWinsConflictsResolver.ts
@@ -48,6 +48,21 @@ export class MineWinsConflictsResolver<T> implements ConflictsResolver<T> {
     })
   }
 
+  public async resolveAll() {
+    return await this.client.getConflicts<AxiosResponse<VBaseConflictData[]>>(this.bucket).then((data) => {
+      const { data: conflicts }: { data: VBaseConflictData[] } = data
+
+      const resolved = conflicts.map((conflict) => {
+        conflict.base.parsedContent = this.parseConflict(conflict.base)
+        conflict.master.parsedContent = this.parseConflict(conflict.master)
+        conflict.mine.parsedContent = this.parseConflict(conflict.mine)
+        return this.resolveConflictMineWins(conflict)
+      })
+
+      return resolved as any
+    })
+  }
+
   protected mergeMineWins(base: Configuration, master: Configuration, mine: Configuration) {
     if (isArray(master)) {
       return this.mergeMineWinsArray((base || []) as ConfigurationData[], master, (mine || []) as ConfigurationData[])


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Enable to resolve all pending conflicts in the same operation.

#### What problem is this solving?

[Slack thread](https://vtex.slack.com/archives/C05CBNSEP0B/p1727825595441399)

#### How should this be manually tested?
- You can test it yarn linking all dependencies([cli-plugin-workspace](https://github.com/vtex/cli-plugin-workspace/pull/14), this module, and the [toolbelt](https://github.com/vtex/toolbelt/pull/1235)), and running with the alias:
vtex-test promote After that, listing to conflicts should return an empty array.

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
