### PR TITLE
Add diagnostics-semconv to standardize some attributes and headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/koa": "^2.11.0",
     "@types/koa-compose": "^3.2.3",
     "@vtex/diagnostics-nodejs": "0.1.0-beta.8",
+    "@vtex/diagnostics-semconv": "0.1.0-beta.8",
     "@vtex/node-error-report": "^0.0.3",
     "@wry/equality": "^0.1.9",
     "agentkeepalive": "^4.0.2",

--- a/src/HttpClient/HttpClient.ts
+++ b/src/HttpClient/HttpClient.ts
@@ -3,16 +3,9 @@ import { createHash } from 'crypto'
 import { IncomingMessage } from 'http'
 import compose from 'koa-compose'
 import pLimit from 'p-limit'
-
 import {
-  BINDING_HEADER,
+  HeaderKeys,
   BODY_HASH,
-  FORWARDED_HOST_HEADER,
-  LOCALE_HEADER,
-  PRODUCT_HEADER,
-  SEGMENT_HEADER,
-  SESSION_HEADER,
-  TENANT_HEADER,
 } from '../constants'
 import { Logger } from '../service/logger'
 import { IOContext } from '../service/worker/runtime/typings'
@@ -89,14 +82,14 @@ export class HttpClient {
       ...defaultHeaders,
       'Accept-Encoding': 'gzip',
       'User-Agent': userAgent,
-      ...host ? { [FORWARDED_HOST_HEADER]: host } : null,
-      ...tenant ? { [TENANT_HEADER]: formatTenantHeaderValue(tenant) } : null,
-      ...binding ? { [BINDING_HEADER]: formatBindingHeaderValue(binding) } : null,
-      ...locale ? { [LOCALE_HEADER]: locale } : null,
-      ...operationId ? { 'x-vtex-operation-id': operationId } : null,
-      ...product ? { [PRODUCT_HEADER]: product } : null,
-      ...segmentToken ? { [SEGMENT_HEADER]: segmentToken } : null,
-      ...sessionToken ? { [SESSION_HEADER]: sessionToken } : null,
+      ...host ? { [HeaderKeys.FORWARDED_HOST]: host } : null,
+      ...tenant ? { [HeaderKeys.TENANT]: formatTenantHeaderValue(tenant) } : null,
+      ...binding ? { [HeaderKeys.BINDING]: formatBindingHeaderValue(binding) } : null,
+      ...locale ? { [HeaderKeys.LOCALE]: locale } : null,
+      ...operationId ? { [HeaderKeys.OPERATION_ID]: operationId } : null,
+      ...product ? { [HeaderKeys.PRODUCT]: product } : null,
+      ...segmentToken ? { [HeaderKeys.SEGMENT]: segmentToken } : null,
+      ...sessionToken ? { [HeaderKeys.SESSION]: sessionToken } : null,
     }
 
     if (authType && authToken) {
@@ -139,16 +132,16 @@ export class HttpClient {
         return typeof v !== 'object' || v === null || Array.isArray(v) ? v :
                   Object.fromEntries(Object.entries(v).sort(([ka], [kb]) =>
                     ka < kb ? -1 : ka > kb ? 1 : 0))
-      } 
-      catch(error) { 
+      }
+      catch(error) {
         // I don't believe this will ever happen, but just in case
         // Also, I didn't include error as I am unsure if it would have sensitive information
         this.logger.warn({message: 'Error while sorting object for cache key'})
         return v
       }
     }
-      
-    
+
+
     const bodyHash = createHash('md5').update(JSON.stringify(data, deterministicReplacer)).digest('hex')
     const cacheableConfig = this.getConfig(url, {
       ...config,

--- a/src/HttpClient/middlewares/cache.ts
+++ b/src/HttpClient/middlewares/cache.ts
@@ -2,7 +2,7 @@ import { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { Span } from 'opentracing'
 
 import { CacheLayer } from '../../caches/CacheLayer'
-import { LOCALE_HEADER, SEGMENT_HEADER, SESSION_HEADER } from '../../constants'
+import { HeaderKeys } from '../../constants'
 import { IOContext } from '../../service/worker/runtime/typings'
 import { ErrorReport } from '../../tracing'
 import { HttpLogEvents } from '../../tracing/LogEvents'
@@ -15,7 +15,7 @@ const cacheableStatusCodes = [200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 
 
 export const cacheKey = (config: AxiosRequestConfig) => {
   const {baseURL = '', url = '', params, headers} = config
-  const locale = headers[LOCALE_HEADER]
+  const locale = headers[HeaderKeys.LOCALE]
 
   const encodedBaseURL = baseURL.replace(/\//g, '\\')
   const encodedURL = url.replace(/\//g, '\\')
@@ -97,7 +97,7 @@ export const cacheMiddleware = ({ type, storage, asyncSet }: CacheOptions) => {
     const { rootSpan: span, tracer, logger } = ctx.tracing ?? {}
 
     const key = cacheKey(ctx.config)
-    const segmentToken = ctx.config.headers[SEGMENT_HEADER]
+    const segmentToken = ctx.config.headers[HeaderKeys.SEGMENT]
     const keyWithSegment = key + segmentToken
 
     span?.log({
@@ -201,11 +201,11 @@ export const cacheMiddleware = ({ type, storage, asyncSet }: CacheOptions) => {
     }
 
     const shouldCache = maxAge || etag
-    const varySession = ctx.response.headers.vary && ctx.response.headers.vary.includes(SESSION_HEADER)
+    const varySession = ctx.response.headers.vary && ctx.response.headers.vary.includes(HeaderKeys.SESSION)
     if (shouldCache && !varySession) {
       const {responseType, responseEncoding: configResponseEncoding} = ctx.config
       const currentAge = revalidated ? 0 : age
-      const varySegment = ctx.response.headers.vary && ctx.response.headers.vary.includes(SEGMENT_HEADER)
+      const varySegment = ctx.response.headers.vary && ctx.response.headers.vary.includes(HeaderKeys.SEGMENT)
       const setKey = varySegment ? keyWithSegment : key
       const responseEncoding = configResponseEncoding || (responseType === 'arraybuffer' ? 'base64' : undefined)
       const cacheableData = type === CacheType.Disk && responseType === 'arraybuffer'

--- a/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/spanSetup.ts
+++ b/src/HttpClient/middlewares/request/setupAxios/interceptors/tracing/spanSetup.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import buildFullPath from 'axios/lib/core/buildFullPath'
 import { Span } from 'opentracing'
-import { ROUTER_CACHE_HEADER } from '../../../../../../constants'
+import { HeaderKeys } from '../../../../../../constants'
 import { CustomHttpTags, OpentracingTags } from '../../../../../../tracing/Tags'
 import { cloneAndSanitizeHeaders } from '../../../../../../tracing/utils'
 
@@ -11,7 +11,6 @@ export const injectRequestInfoOnSpan = (span: Span | undefined, http: AxiosInsta
     [OpentracingTags.HTTP_METHOD]: config.method,
     [OpentracingTags.HTTP_URL]: buildFullPath(config.baseURL, http.getUri(config)),
   })
-
   span?.log({ 'request-headers': cloneAndSanitizeHeaders(config.headers) })
 }
 
@@ -24,7 +23,8 @@ export const injectResponseInfoOnSpan = (span: Span | undefined, response: Axios
 
   span?.log({ 'response-headers': cloneAndSanitizeHeaders(response.headers) })
   span?.setTag(OpentracingTags.HTTP_STATUS_CODE, response.status)
-  if (response.headers[ROUTER_CACHE_HEADER]) {
-    span?.setTag(CustomHttpTags.HTTP_ROUTER_CACHE_RESULT, response.headers[ROUTER_CACHE_HEADER])
+
+  if (response.headers[HeaderKeys.ROUTER_CACHE]) {
+    span?.setTag(CustomHttpTags.HTTP_ROUTER_CACHE_RESULT, response.headers[HeaderKeys.ROUTER_CACHE])
   }
 }

--- a/src/clients/janus/Segment.ts
+++ b/src/clients/janus/Segment.ts
@@ -1,7 +1,6 @@
 import parseCookie from 'cookie'
 import { prop } from 'ramda'
-
-import { PRODUCT_HEADER } from '../../constants'
+import { HeaderKeys } from '../../constants'
 import { inflightUrlWithQuery, RequestTracingConfig } from '../../HttpClient'
 import { JanusClient } from './JanusClient'
 
@@ -87,7 +86,7 @@ export class Segment extends JanusClient {
       forceMaxAge: SEGMENT_MAX_AGE_S,
       headers: {
         'Content-Type': 'application/json',
-        [PRODUCT_HEADER]: product || '',
+        [HeaderKeys.PRODUCT]: product || '',
       },
       inflightKey: inflightUrlWithQuery,
       metric,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,13 @@
 import { versionToMajor } from './utils/app'
+import {
+  ATTR_VTEX_OPERATION_ID,
+  ATTR_VTEX_ACCOUNT_NAME,
+  ATTR_VTEX_IO_WORKSPACE_NAME,
+  ATTR_VTEX_IO_WORKSPACE_TYPE,
+  ATTR_VTEX_IO_APP_ID,
+  ATTR_VTEX_IO_APP_AUTHOR_TYPE
+} from '@vtex/diagnostics-semconv'
+
 // tslint:disable-next-line
 const pkg = require('../package.json')
 
@@ -7,36 +16,57 @@ export const DEFAULT_WORKSPACE = 'master'
 export const IS_IO = process.env.VTEX_IO
 export const PID = process.pid
 
-export const CACHE_CONTROL_HEADER = 'cache-control'
-export const SEGMENT_HEADER = 'x-vtex-segment'
-export const SESSION_HEADER = 'x-vtex-session'
-export const PRODUCT_HEADER = 'x-vtex-product'
-export const LOCALE_HEADER = 'x-vtex-locale'
-export const FORWARDED_HOST_HEADER = 'x-forwarded-host'
-export const TENANT_HEADER = 'x-vtex-tenant'
-export const BINDING_HEADER = 'x-vtex-binding'
-export const META_HEADER = 'x-vtex-meta'
-export const META_HEADER_BUCKET = 'x-vtex-meta-bucket'
-export const ETAG_HEADER = 'etag'
-export const ACCOUNT_HEADER = 'x-vtex-account'
-export const CREDENTIAL_HEADER = 'x-vtex-credential'
-export const REQUEST_ID_HEADER = 'x-request-id'
-export const ROUTER_CACHE_HEADER = 'x-router-cache'
-export const OPERATION_ID_HEADER = 'x-vtex-operation-id'
-export const PLATFORM_HEADER = 'x-vtex-platform'
-export const WORKSPACE_IS_PRODUCTION_HEADER = 'x-vtex-workspace-is-production'
-export const WORKSPACE_HEADER = 'x-vtex-workspace'
-export const EVENT_KEY_HEADER = 'x-event-key'
-export const EVENT_SENDER_HEADER = 'x-event-sender'
-export const EVENT_SUBJECT_HEADER = 'x-event-subject'
-export const EVENT_HANDLER_ID_HEADER = 'x-event-handler-id'
-export const COLOSSUS_ROUTE_DECLARER_HEADER = 'x-colossus-route-declarer'
-export const COLOSSUS_ROUTE_ID_HEADER = 'x-colossus-route-id'
-export const COLOSSUS_PARAMS_HEADER = 'x-colossus-params'
-export const TRACE_ID_HEADER = 'x-trace-id'
-export const PROVIDER_HEADER = 'x-vtex-provider'
+export const HeaderKeys = {
+  CACHE_CONTROL: 'cache-control',
+  SEGMENT: 'x-vtex-segment',
+  SESSION: 'x-vtex-session',
+  PRODUCT: 'x-vtex-product',
+  LOCALE: 'x-vtex-locale',
+  FORWARDED_HOST: 'x-forwarded-host',
+  FORWARDED_FOR: 'x-forwarded-for',
+  TENANT: 'x-vtex-tenant',
+  BINDING: 'x-vtex-binding',
+  META: 'x-vtex-meta',
+  META_BUCKET: 'x-vtex-meta-bucket',
+  ETAG: 'etag',
+  ACCOUNT: 'x-vtex-account',
+  CREDENTIAL: 'x-vtex-credential',
+  REQUEST_ID: 'x-request-id',
+  ROUTER_CACHE: 'x-router-cache',
+  OPERATION_ID: 'x-vtex-operation-id',
+  PLATFORM: 'x-vtex-platform',
+  WORKSPACE_IS_PRODUCTION: 'x-vtex-workspace-is-production',
+  WORKSPACE: 'x-vtex-workspace',
+  EVENT_KEY: 'x-event-key',
+  EVENT_SENDER: 'x-event-sender',
+  EVENT_SUBJECT: 'x-event-subject',
+  EVENT_HANDLER_ID: 'x-event-handler-id',
+  COLOSSUS_ROUTE_DECLARER: 'x-colossus-route-declarer',
+  COLOSSUS_ROUTE_ID: 'x-colossus-route-id',
+  COLOSSUS_PARAMS: 'x-colossus-params',
+  TRACE_ID: 'x-trace-id',
+  PROVIDER: 'x-vtex-provider',
+  USER_AGENT: 'user-agent',
+  VTEX_USER_AGENT: 'x-vtex-user-agent',
+  VTEX_IO_CALLER: 'x-vtex-io-caller',
+  VTEX_APP_SERVICE: 'x-vtex-app-service',
+  VTEX_APP_KEY: 'x-vtex-app-key',
+  VTEX_RETRY_COUNT: 'x-vtex-retry-count'
+}
 
-export type VaryHeaders = typeof SEGMENT_HEADER | typeof SESSION_HEADER | typeof PRODUCT_HEADER | typeof LOCALE_HEADER
+export const AttributeKeys = {
+  // VTEX Semantic Attributes
+  VTEX_OPERATION_ID: ATTR_VTEX_OPERATION_ID,
+  VTEX_ACCOUNT_NAME: ATTR_VTEX_ACCOUNT_NAME,
+
+  // VTEX IO Semantic Attributes
+  VTEX_IO_WORKSPACE_NAME: ATTR_VTEX_IO_WORKSPACE_NAME,
+  VTEX_IO_WORKSPACE_TYPE: ATTR_VTEX_IO_WORKSPACE_TYPE,
+  VTEX_IO_APP_ID: ATTR_VTEX_IO_APP_ID,
+  VTEX_IO_APP_AUTHOR_TYPE: ATTR_VTEX_IO_APP_AUTHOR_TYPE,
+}
+
+export type VaryHeaders = typeof HeaderKeys.SEGMENT | typeof HeaderKeys.SESSION | typeof HeaderKeys.PRODUCT | typeof HeaderKeys.LOCALE
 
 export const BODY_HASH = '__graphqlBodyHash'
 

--- a/src/service/logger/logger.ts
+++ b/src/service/logger/logger.ts
@@ -1,4 +1,4 @@
-import { APP, LOG_CLIENT_INIT_TIMEOUT_MS } from '../../constants'
+import { APP, LOG_CLIENT_INIT_TIMEOUT_MS, AttributeKeys } from '../../constants'
 import { cleanError } from '../../utils/error'
 import { cleanLog } from '../../utils/log'
 import { LogClient } from '@vtex/diagnostics-nodejs/dist/types';
@@ -82,13 +82,14 @@ export class Logger {
     const inflatedLog = {
       __VTEX_IO_LOG: true,
       level,
-      app,
-      account: this.account,
-      workspace: this.workspace,
-      production: this.production,
-      data,
-      operationId: this.operationId,
+      [AttributeKeys.VTEX_IO_APP_ID]: app,
+      [AttributeKeys.VTEX_ACCOUNT_NAME]: this.account,
+      [AttributeKeys.VTEX_IO_WORKSPACE_NAME]: this.workspace,
+      [AttributeKeys.VTEX_IO_WORKSPACE_TYPE]: this.production ? 'production' : 'development',
+      [AttributeKeys.VTEX_IO_APP_AUTHOR_TYPE]: APP.IS_THIRD_PARTY() ? '3p' : '1p',
+      [AttributeKeys.VTEX_OPERATION_ID]: this.operationId,
       requestId: this.requestId,
+      data,
       ... (this.tracingState?.isTraceSampled ? { traceId: this.tracingState.traceId } : null),
     }
 

--- a/src/service/tracing/tracingMiddlewares.ts
+++ b/src/service/tracing/tracingMiddlewares.ts
@@ -1,6 +1,6 @@
 import { FORMAT_HTTP_HEADERS, SpanContext, Tracer } from 'opentracing'
 import { finished as onStreamFinished } from 'stream'
-import { ACCOUNT_HEADER, REQUEST_ID_HEADER, TRACE_ID_HEADER, WORKSPACE_HEADER } from '../../constants'
+import { HeaderKeys } from '../../constants'
 import { ErrorReport, getTraceInfo } from '../../tracing'
 import { RuntimeLogEvents } from '../../tracing/LogEvents'
 import { RuntimeLogFields } from '../../tracing/LogFields'
@@ -52,14 +52,14 @@ export const addTracingMiddleware = (tracer: Tracer) => {
           [OpentracingTags.HTTP_METHOD]: ctx.request.method,
           [OpentracingTags.HTTP_STATUS_CODE]: ctx.response.status,
           [CustomHttpTags.HTTP_PATH]: ctx.request.path,
-          [VTEXIncomingRequestTags.VTEX_REQUEST_ID]: ctx.get(REQUEST_ID_HEADER),
-          [VTEXIncomingRequestTags.VTEX_WORKSPACE]: ctx.get(WORKSPACE_HEADER),
-          [VTEXIncomingRequestTags.VTEX_ACCOUNT]: ctx.get(ACCOUNT_HEADER),
+          [VTEXIncomingRequestTags.VTEX_REQUEST_ID]: ctx.get(HeaderKeys.REQUEST_ID),
+          [VTEXIncomingRequestTags.VTEX_WORKSPACE]: ctx.get(HeaderKeys.WORKSPACE),
+          [VTEXIncomingRequestTags.VTEX_ACCOUNT]: ctx.get(HeaderKeys.ACCOUNT),
         })
 
         currentSpan?.log(cloneAndSanitizeHeaders(ctx.request.headers, 'req.headers.'))
         currentSpan?.log(cloneAndSanitizeHeaders(ctx.response.headers, 'res.headers.'))
-        ctx.set(TRACE_ID_HEADER, traceInfo.traceId!)
+        ctx.set(HeaderKeys.TRACE_ID, traceInfo.traceId!)
       }
 
       const onResFinished = () => {

--- a/src/service/worker/runtime/builtIn/middlewares.ts
+++ b/src/service/worker/runtime/builtIn/middlewares.ts
@@ -1,6 +1,5 @@
 import { collectDefaultMetrics, register } from 'prom-client'
-import { COLOSSUS_ROUTE_ID_HEADER } from '../../../../constants'
-
+import { HeaderKeys } from '../../../../constants'
 import { MetricsLogger } from '../../../logger/metricsLogger'
 import { EventLoopLagMeasurer } from '../../../tracing/metrics/measurers/EventLoopLagMeasurer'
 import { ServiceContext } from '../typings'
@@ -32,7 +31,7 @@ export const prometheusLoggerMiddleware = () => {
       return next()
     }
 
-    const routeId = ctx.get(COLOSSUS_ROUTE_ID_HEADER)
+    const routeId = ctx.get(HeaderKeys.COLOSSUS_ROUTE_ID)
     if (routeId) {
       return next()
     }

--- a/src/service/worker/runtime/events/middlewares/context.ts
+++ b/src/service/worker/runtime/events/middlewares/context.ts
@@ -1,9 +1,6 @@
 import { IOClients } from '../../../../../clients/IOClients'
 import {
-  EVENT_HANDLER_ID_HEADER,
-  EVENT_KEY_HEADER,
-  EVENT_SENDER_HEADER,
-  EVENT_SUBJECT_HEADER,
+  HeaderKeys,
 } from '../../../../../constants'
 import { ParamsContext, RecorderState, ServiceContext } from '../../typings'
 import { prepareHandlerCtx } from '../../utils/context'
@@ -13,12 +10,12 @@ export async function eventContextMiddleware <T extends IOClients, U extends Rec
   ctx.vtex = {
     ...prepareHandlerCtx(header, ctx.tracing),
     eventInfo: {
-      key: header[EVENT_KEY_HEADER],
-      sender: header[EVENT_SENDER_HEADER],
-      subject: header[EVENT_SUBJECT_HEADER],
+      key: header[HeaderKeys.EVENT_KEY],
+      sender: header[HeaderKeys.EVENT_SENDER],
+      subject: header[HeaderKeys.EVENT_SUBJECT],
     },
     route: {
-      id: header[EVENT_HANDLER_ID_HEADER],
+      id: header[HeaderKeys.EVENT_HANDLER_ID],
       params: {},
       type: 'event',
     },

--- a/src/service/worker/runtime/events/router.ts
+++ b/src/service/worker/runtime/events/router.ts
@@ -1,11 +1,11 @@
-import { EVENT_HANDLER_ID_HEADER } from '../../../../constants'
+import { HeaderKeys } from '../../../../constants'
 import { LogLevel } from '../../../logger'
 import { RouteHandler, ServiceContext } from '../typings'
 import { logOnceToDevConsole } from './../../../logger/console'
 
 export const routerFromEventHandlers = (events: Record<string, RouteHandler> | null) => {
   return async (ctx: ServiceContext, next: () => Promise<void>) => {
-    const handlerId = ctx.get(EVENT_HANDLER_ID_HEADER)
+    const handlerId = ctx.get(HeaderKeys.EVENT_HANDLER_ID)
 
     if (!handlerId || !events) {
       return next()

--- a/src/service/worker/runtime/graphql/middlewares/updateSchema.ts
+++ b/src/service/worker/runtime/graphql/middlewares/updateSchema.ts
@@ -1,5 +1,5 @@
 import { IOClients } from '../../../../../clients'
-import { PROVIDER_HEADER } from '../../../../../constants'
+import { HeaderKeys } from '../../../../../constants'
 import { majorEqualAndGreaterThan, parseAppId } from '../../../../../utils'
 import { GraphQLOptions, ParamsContext, RecorderState } from '../../typings'
 import { makeSchema } from '../schema/index'
@@ -17,7 +17,7 @@ export const updateSchema = <T extends IOClients, U extends RecorderState, V ext
       app,
     } = ctx
 
-    if (!ctx.headers[PROVIDER_HEADER]) {
+    if (!ctx.headers[HeaderKeys.PROVIDER]) {
       await next()
       return
     }
@@ -27,18 +27,18 @@ export const updateSchema = <T extends IOClients, U extends RecorderState, V ext
       executableSchema.hasProvider &&
       (!executableSchema.provider ||
         majorEqualAndGreaterThan(
-          parseAppId(ctx.headers[PROVIDER_HEADER]).version,
+          parseAppId(ctx.headers[HeaderKeys.PROVIDER]).version,
           parseAppId(executableSchema.provider).version
         ))
     ) {
       try {
-        const newSchema = (await apps.getAppFile(ctx.headers[PROVIDER_HEADER], 'public/schema.graphql')).data.toString(
+        const newSchema = (await apps.getAppFile(ctx.headers[HeaderKeys.PROVIDER], 'public/schema.graphql')).data.toString(
           'utf-8'
         )
         graphql.schema = newSchema
         const newRunnableSchema = makeSchema(graphql)
         executableSchema.schema = newRunnableSchema.schema
-        executableSchema.provider = ctx.headers[PROVIDER_HEADER]
+        executableSchema.provider = ctx.headers[HeaderKeys.PROVIDER]
       } catch (error) {
         logger.error({ error, message: 'Update schema failed', app })
       }

--- a/src/service/worker/runtime/http/middlewares/authTokens.ts
+++ b/src/service/worker/runtime/http/middlewares/authTokens.ts
@@ -1,5 +1,4 @@
 import { IOClients } from '../../../../../clients/IOClients'
-import { CREDENTIAL_HEADER } from '../../../../../constants'
 import { ParamsContext, RecorderState, ServiceContext } from '../../typings'
 
 const JANUS_ENV_COOKIE_KEY = 'vtex-commerce-env'

--- a/src/service/worker/runtime/http/middlewares/context.ts
+++ b/src/service/worker/runtime/http/middlewares/context.ts
@@ -1,10 +1,7 @@
 import { parse as qsParse } from 'querystring'
 
 import { IOClients } from '../../../../../clients/IOClients'
-import {
-  COLOSSUS_PARAMS_HEADER,
-  COLOSSUS_ROUTE_DECLARER_HEADER,
-} from '../../../../../constants'
+import { HeaderKeys } from '../../../../../constants'
 import { prepareHandlerCtx } from '../../utils/context'
 import {
   ParamsContext,
@@ -56,9 +53,9 @@ export const createPubContextMiddleware = (
       ...prepareHandlerCtx(header, ctx.tracing),
       ...(smartcache && { recorder: ctx.state.recorder }),
       route: {
-        declarer: header[COLOSSUS_ROUTE_DECLARER_HEADER],
+        declarer: header[HeaderKeys.COLOSSUS_ROUTE_DECLARER],
         id: routeId,
-        params: qsParse(header[COLOSSUS_PARAMS_HEADER]),
+        params: qsParse(header[HeaderKeys.COLOSSUS_PARAMS]),
         type: 'public',
       },
     }

--- a/src/service/worker/runtime/http/middlewares/vary.ts
+++ b/src/service/worker/runtime/http/middlewares/vary.ts
@@ -1,9 +1,7 @@
 import { IOClients } from '../../../../../clients/IOClients'
 import {
-  LOCALE_HEADER,
-  SEGMENT_HEADER,
-  SESSION_HEADER,
-  VaryHeaders,
+  HeaderKeys,
+  VaryHeaders
 } from '../../../../../constants'
 import { ParamsContext, RecorderState, ServiceContext } from '../../typings'
 
@@ -17,17 +15,17 @@ const cachingStrategies: CachingStrategy[] = [
   {
     forbidden: [],
     path: '/_v/private/',
-    vary: [SEGMENT_HEADER, SESSION_HEADER],
+    vary: [HeaderKeys.SEGMENT, HeaderKeys.SESSION],
   },
   {
-    forbidden: [SEGMENT_HEADER, SESSION_HEADER],
+    forbidden: [HeaderKeys.SEGMENT, HeaderKeys.SESSION],
     path: '/_v/public/',
     vary: [],
   },
   {
-    forbidden: [SESSION_HEADER],
+    forbidden: [HeaderKeys.SESSION],
     path: '/_v/segment/',
-    vary: [SEGMENT_HEADER],
+    vary: [HeaderKeys.SEGMENT],
   },
 ]
 
@@ -39,14 +37,11 @@ const shouldVaryByHeader = <T extends IOClients, U extends RecorderState, V exte
   if (strategy && strategy.vary.includes(header)) {
     return true
   }
-
   if (process.env.DETERMINISTIC_VARY) {
     return false
   }
-
   return !!ctx.get(header)
 }
-
 
 export async function vary <
   T extends IOClients,
@@ -62,19 +57,20 @@ export async function vary <
     })
   }
 
-
   // We don't need to vary non GET requests, since they are never cached
   if (method.toUpperCase() !== 'GET') {
     await next()
     return
   }
 
-  ctx.vary(LOCALE_HEADER)
-  if (shouldVaryByHeader(ctx, SEGMENT_HEADER, strategy)) {
-    ctx.vary(SEGMENT_HEADER)
+  ctx.vary(HeaderKeys.LOCALE)
+
+  if (shouldVaryByHeader(ctx, HeaderKeys.SEGMENT, strategy)) {
+    ctx.vary(HeaderKeys.SEGMENT)
   }
-  if (shouldVaryByHeader(ctx, SESSION_HEADER, strategy)) {
-    ctx.vary(SESSION_HEADER)
+
+  if (shouldVaryByHeader(ctx, HeaderKeys.SESSION, strategy)) {
+    ctx.vary(HeaderKeys.SESSION)
   }
 
   await next()

--- a/src/service/worker/runtime/http/router.ts
+++ b/src/service/worker/runtime/http/router.ts
@@ -1,12 +1,11 @@
-import { COLOSSUS_ROUTE_ID_HEADER } from '../../../../constants'
+import { HeaderKeys } from '../../../../constants'
 import { LogLevel } from '../../../logger'
 import { HttpRoute, ServiceContext } from '../typings'
 import { logOnceToDevConsole } from './../../../logger/console'
 
 export const routerFromPublicHttpHandlers = (routes: Record<string, HttpRoute>) => {
   return async (ctx: ServiceContext, next: () => Promise<void>) => {
-    const routeId = ctx.get(COLOSSUS_ROUTE_ID_HEADER)
-
+    const routeId = ctx.get(HeaderKeys.COLOSSUS_ROUTE_ID)
     if (!routeId) {
       return next()
     }

--- a/src/service/worker/runtime/utils/context.ts
+++ b/src/service/worker/runtime/utils/context.ts
@@ -1,22 +1,8 @@
 import { Context } from 'koa'
 import uuid from 'uuid/v4'
-
 import {
-  ACCOUNT_HEADER,
-  BINDING_HEADER,
-  CREDENTIAL_HEADER,
-  FORWARDED_HOST_HEADER,
-  LOCALE_HEADER,
-  OPERATION_ID_HEADER,
-  PLATFORM_HEADER,
-  PRODUCT_HEADER,
+  HeaderKeys,
   REGION,
-  REQUEST_ID_HEADER,
-  SEGMENT_HEADER,
-  SESSION_HEADER,
-  TENANT_HEADER,
-  WORKSPACE_HEADER,
-  WORKSPACE_IS_PRODUCTION_HEADER,
 } from '../../../../constants'
 import { UserLandTracer } from '../../../../tracing/UserLandTracer'
 import { parseTenantHeaderValue } from '../../../../utils/tenant'
@@ -32,23 +18,23 @@ const getPlatform = (account: string): string => {
 
 export const prepareHandlerCtx = (header: Context['request']['header'], tracingContext?: TracingContext): HandlerContext => {
   const partialContext = {
-    account: header[ACCOUNT_HEADER],
-    authToken: header[CREDENTIAL_HEADER],
-    binding: header[BINDING_HEADER] ? parseBindingHeaderValue(header[BINDING_HEADER]) : undefined,
-    host: header[FORWARDED_HOST_HEADER],
-    locale: header[LOCALE_HEADER],
-    operationId: header[OPERATION_ID_HEADER] || uuid(),
-    platform: header[PLATFORM_HEADER] || getPlatform(header[ACCOUNT_HEADER]),
-    product: header[PRODUCT_HEADER],
-    production: header[WORKSPACE_IS_PRODUCTION_HEADER]?.toLowerCase() === 'true' || false,
+    account: header[HeaderKeys.ACCOUNT],
+    authToken: header[HeaderKeys.CREDENTIAL],
+    binding: header[HeaderKeys.BINDING] ? parseBindingHeaderValue(header[HeaderKeys.BINDING]) : undefined,
+    host: header[HeaderKeys.FORWARDED_HOST],
+    locale: header[HeaderKeys.LOCALE],
+    operationId: header[HeaderKeys.OPERATION_ID] || uuid(),
+    platform: header[HeaderKeys.PLATFORM] || getPlatform(header[HeaderKeys.ACCOUNT]),
+    product: header[HeaderKeys.PRODUCT],
+    production: header[HeaderKeys.WORKSPACE_IS_PRODUCTION]?.toLowerCase() === 'true' || false,
     region: REGION,
-    requestId: header[REQUEST_ID_HEADER],
-    segmentToken: header[SEGMENT_HEADER],
-    sessionToken: header[SESSION_HEADER],
-    tenant: header[TENANT_HEADER] ? parseTenantHeaderValue(header[TENANT_HEADER]) : undefined,
+    requestId: header[HeaderKeys.REQUEST_ID],
+    segmentToken: header[HeaderKeys.SEGMENT],
+    sessionToken: header[HeaderKeys.SESSION],
+    tenant: header[HeaderKeys.TENANT] ? parseTenantHeaderValue(header[HeaderKeys.TENANT]) : undefined,
     tracer: new UserLandTracer(tracingContext?.tracer!, tracingContext?.currentSpan),
     userAgent: process.env.VTEX_APP_ID || '',
-    workspace: header[WORKSPACE_HEADER],
+    workspace: header[HeaderKeys.WORKSPACE],
   }
 
   return {

--- a/src/service/worker/runtime/utils/recorder.ts
+++ b/src/service/worker/runtime/utils/recorder.ts
@@ -1,9 +1,8 @@
 import { Context } from 'koa'
 import { trim } from 'ramda'
+import { HeaderKeys } from './../../../../constants'
 
-import { META_HEADER, META_HEADER_BUCKET } from './../../../../constants'
-
-const HEADERS = [META_HEADER, META_HEADER_BUCKET]
+const HEADERS = [HeaderKeys.META, HeaderKeys.META_BUCKET]
 
 export class Recorder {
   // tslint:disable-next-line: variable-name


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
This pull request introduces a major refactor to centralize HTTP header constants into a new `HeaderKeys` object within the `src/constants.ts` file. This change improves maintainability and reduces redundancy by replacing individual header constants with a single structured object. Additionally, it introduces a new `AttributeKeys` object for semantic attributes and updates the logger to use these attributes.

##### Dependency Additions
* Added a new dependency, `@vtex/diagnostics-semconv`, to support semantic conventions for diagnostics and tracing attributes.

##### Logger Enhancements
* Updated the `Logger` class to use the new `AttributeKeys` object for semantic attributes, such as `VTEX_OPERATION_ID` and `VTEX_ACCOUNT_NAME`, instead of plain object properties. This ensures better alignment with the diagnostics library.

##### Cleanup and Refactoring
* Removed unused imports and constants that were replaced by the centralized `HeaderKeys` object, further simplifying the codebase.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Introduces `@vtex/diagnostics-semconv` library to support VTEX semantic conventions, in a reduced scope with respect to telemetry signals and emphasizing the context of logs. Future updates will include updates to the instrumentation using the diagnostics library, as well as the use of the semantic conventions of these signals.

#### How should this be manually tested?
The changes do not include new features or major behavior changes, so to test the changes simply build from this branch.

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
