### PR TITLE
Add a whitelist of headers to add in trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.49.5] - 2025-07-21
+### Changed
+- Defining a list of headers to be added as trace span information
+
 ## [6.49.4] - 2025-07-02
 ### Fixed
 - Userland logs that wouldn't be collected

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.49.4",
+  "version": "6.49.5",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.49.2",
+  "version": "6.49.3-beta.4",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/tracing/utils.test.ts
+++ b/src/tracing/utils.test.ts
@@ -1,51 +1,88 @@
-import { SENSITIVE_STR } from '@vtex/node-error-report'
-import { cloneAndSanitizeHeaders } from './utils'
+import { authFields, sanitizeAuth } from '@vtex/node-error-report'
+import { cloneAndSanitizeHeaders, INTERESTING_HEADERS } from './utils'
 
 describe('cloneAndSanitizeHeaders', () => {
   const headers = {
-    a: 'b',
-    authorization: '1337',
+    'content-type': 'application/json',
+    'authorization': 'Bearer secret-token',
+    'x-request-id': '12345',
+    'x-vtex-custom': 'vtex-value',
+    'random-header': 'should-be-filtered',
+    'cookie': 'sessionId=abc123',
   }
 
   test('Original object is not modified', () => {
+    const originalHeaders = { ...headers }
     cloneAndSanitizeHeaders(headers)
-    expect(headers).toEqual({
-      a: 'b',
-      authorization: '1337',
-    })
+    expect(headers).toEqual(originalHeaders)
   })
 
-  test('Sensitive information is redacted', () => {
-    expect(cloneAndSanitizeHeaders(headers)).toEqual({
-      a: 'b',
-      authorization: SENSITIVE_STR,
-    })
+  test('Only includes whitelisted headers and x-vtex-* headers', () => {
+    const result = cloneAndSanitizeHeaders(headers)
+
+    // Should include whitelisted headers
+    expect(result).toHaveProperty('content-type', 'application/json')
+    expect(result).toHaveProperty('x-request-id', '12345')
+
+    // Should include x-vtex-* headers
+    expect(result).toHaveProperty('x-vtex-custom', 'vtex-value')
+
+    // Should NOT include non-whitelisted headers
+    expect(result).not.toHaveProperty('random-header')
+  })
+
+  test('Sensitive information is sanitized using authFields', () => {
+    const result = cloneAndSanitizeHeaders(headers)
+
+    // Check if authorization is sanitized (if it's in authFields)
+    if (authFields.includes('authorization')) {
+      expect(result.authorization).toBe(sanitizeAuth('Bearer secret-token'))
+    }
+
+    // Check if cookie is sanitized (if it's in authFields)
+    if (authFields.includes('cookie')) {
+      expect(result.cookie).toBe(sanitizeAuth('sessionId=abc123'))
+    }
   })
 
   test('Prefix is added if specified', () => {
-    expect(cloneAndSanitizeHeaders(headers, 'test.')).toEqual({
-      'test.a': 'b',
-      'test.authorization': SENSITIVE_STR,
+    const testHeaders = {
+      'content-type': 'application/json',
+      'x-vtex-test': 'value',
+    }
+
+    const result = cloneAndSanitizeHeaders(testHeaders, 'req.')
+
+    expect(result).toEqual({
+      'req.content-type': 'application/json',
+      'req.x-vtex-test': 'value',
     })
   })
 
-  test('It works if the header is an axios header object', () => {
-    const axiosHeader = {
-      common: {
-        Accept: 'application/json, text/plain, */*',
-      },
-      delete: {},
-      get: {},
-      head: {},
-      post: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      ...headers,
+  test('Handles case-insensitive header matching', () => {
+    const mixedCaseHeaders = {
+      'Content-Type': 'application/json',
+      'X-REQUEST-ID': '67890',
+      'X-VTEX-Store': 'mystore',
+      'AUTHORIZATION': 'Bearer token',
     }
 
-    expect(cloneAndSanitizeHeaders(axiosHeader)).toEqual({
-      a: 'b',
-      authorization: SENSITIVE_STR,
+    const result = cloneAndSanitizeHeaders(mixedCaseHeaders)
+    
+    // Should include headers regardless of case
+    expect(result).toHaveProperty('Content-Type', 'application/json')
+    expect(result).toHaveProperty('X-REQUEST-ID', '67890')
+    expect(result).toHaveProperty('X-VTEX-Store', 'mystore')
+    expect(result).toHaveProperty('AUTHORIZATION')
+  })
+
+  test('Handles empty headers object', () => {
+    const result = cloneAndSanitizeHeaders({})
+    expect(result).toEqual({})
+  })
+
+  test('Handles axios header object structure', () => {
+    const axiosHeaders = {
       common: {
         Accept: 'application/json, text/plain, */*',
       },
@@ -55,6 +92,61 @@ describe('cloneAndSanitizeHeaders', () => {
       post: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
+      'authorization': 'Bearer token',
+      'x-vtex-account': 'testaccount',
+      'user-agent': 'axios/1.0.0',
+    }
+
+    const result = cloneAndSanitizeHeaders(axiosHeaders)
+
+    // Should include whitelisted simple headers
+    expect(result).toHaveProperty('user-agent', 'axios/1.0.0')
+    expect(result).toHaveProperty('x-vtex-account', 'testaccount')
+
+    // Should include authorization (will be sanitized if in authFields)
+    expect(result).toHaveProperty('authorization')
+
+    // Should NOT include axios config objects since they're not whitelisted
+    expect(result).not.toHaveProperty('common')
+    expect(result).not.toHaveProperty('delete')
+    expect(result).not.toHaveProperty('get')
+    expect(result).not.toHaveProperty('head')
+    expect(result).not.toHaveProperty('post')
+  })
+
+  test('Filters out non-whitelisted headers completely', () => {
+    const headersWithNoise = {
+      'content-type': 'application/json',  // whitelisted
+      'x-vtex-store': 'mystore',          // x-vtex-* allowed
+      'x-custom-header': 'custom',        // not whitelisted, not x-vtex-*
+      'server': 'nginx',                  // not whitelisted
+      'x-powered-by': 'Express',          // not whitelisted
+      'host': 'api.vtex.com',             // whitelisted
+    }
+
+    const result = cloneAndSanitizeHeaders(headersWithNoise)
+
+    expect(Object.keys(result)).toEqual(['content-type', 'x-vtex-store', 'host'])
+    expect(result).not.toHaveProperty('x-custom-header')
+    expect(result).not.toHaveProperty('server')
+    expect(result).not.toHaveProperty('x-powered-by')
+  })
+
+  test('All INTERESTING_HEADERS are properly whitelisted', () => {
+    // Create a headers object with all interesting headers
+    const allInterestingHeaders: Record<string, string> = {}
+    INTERESTING_HEADERS.forEach(header => {
+      allInterestingHeaders[header] = `value-for-${header}`
     })
+
+    const result = cloneAndSanitizeHeaders(allInterestingHeaders)
+
+    // All interesting headers should be included
+    INTERESTING_HEADERS.forEach(header => {
+      expect(result).toHaveProperty(header)
+    })
+
+    // Should have exactly the same number of headers
+    expect(Object.keys(result)).toHaveLength(INTERESTING_HEADERS.length)
   })
 })

--- a/src/tracing/utils.ts
+++ b/src/tracing/utils.ts
@@ -44,6 +44,7 @@ export const INTERESTING_HEADERS = [
   // VTEX/E-commerce Specific (x-vtex-* headers are handled automatically)
   'x-router-cache',
   'x-powered-by-vtex-cache',
+  'jaeger-debug-id',
   
   // API & Service Headers
   'x-api-version',

--- a/src/tracing/utils.ts
+++ b/src/tracing/utils.ts
@@ -54,6 +54,9 @@ export const INTERESTING_HEADERS = [
   'cookie',
 ]
 
+// Create the set once for performance
+const INTERESTING_HEADERS_SET = new Set(INTERESTING_HEADERS.map(h => h.toLowerCase()))
+
 export function getTraceInfo(span?: Span): TraceInfo {
   const spanContext = span?.context()
   return {
@@ -73,14 +76,11 @@ export const cloneAndSanitizeHeaders = (headersObj: Record<string, any>, resultF
   const ret: Record<string, string> = {}
   const entries = Object.entries(headersObj)
   
-  // Create a set of lowercase header names for case-insensitive matching
-  const interestingHeadersSet = new Set(INTERESTING_HEADERS.map(h => h.toLowerCase()))
-  
   for (const [key, val] of entries) {
     const lowerKey = key.toLowerCase()
     
     // Only include headers that are in our whitelist or start with x-vtex-
-    if (!interestingHeadersSet.has(lowerKey) && !lowerKey.startsWith('x-vtex-')) {
+    if (!INTERESTING_HEADERS_SET.has(lowerKey) && !lowerKey.startsWith('x-vtex-')) {
       continue
     }
     

--- a/src/tracing/utils.ts
+++ b/src/tracing/utils.ts
@@ -42,6 +42,8 @@ export const INTERESTING_HEADERS = [
   'x-forwarded-port',
   
   // VTEX/E-commerce Specific (x-vtex-* headers are handled automatically)
+  'x-router-cache',
+  'x-powered-by-vtex-cache',
   
   // API & Service Headers
   'x-api-version',

--- a/src/tracing/utils.ts
+++ b/src/tracing/utils.ts
@@ -6,6 +6,54 @@ export interface TraceInfo {
   isSampled: boolean
 }
 
+/**
+ * Headers that are interesting for tracing and debugging purposes
+ */
+export const INTERESTING_HEADERS = [
+  // Request/Response Identification & Routing
+  'x-request-id',
+  'x-correlation-id',
+  'x-trace-id',
+  'x-span-id',
+  'x-forwarded-for',
+  'x-real-ip',
+  'host',
+  'referer',
+  
+  // Content & Encoding
+  'content-type',
+  'content-length',
+  'content-encoding',
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  
+  // Caching & Performance
+  'cache-control',
+  'etag',
+  'if-none-match',
+  'expires',
+  'last-modified',
+  
+  // Client Information
+  'user-agent',
+  'x-forwarded-proto',
+  'x-forwarded-host',
+  'x-forwarded-port',
+  
+  // VTEX/E-commerce Specific (x-vtex-* headers are handled automatically)
+  
+  // API & Service Headers
+  'x-api-version',
+  'x-service-name',
+  'x-timeout',
+  'retry-after',
+  
+  // Security (will be sanitized)
+  'authorization',
+  'cookie',
+]
+
 export function getTraceInfo(span?: Span): TraceInfo {
   const spanContext = span?.context()
   return {
@@ -16,6 +64,7 @@ export function getTraceInfo(span?: Span): TraceInfo {
 
 /**
  * Do a shallow copy of a headers object and redacts sensitive information.
+ * Only includes headers that are in the INTERESTING_HEADERS whitelist.
  *
  * @param headersObj The headers object
  * @param resultFieldsPrefix The prefix that will be added to each field on the result object
@@ -23,7 +72,18 @@ export function getTraceInfo(span?: Span): TraceInfo {
 export const cloneAndSanitizeHeaders = (headersObj: Record<string, any>, resultFieldsPrefix: string = '') => {
   const ret: Record<string, string> = {}
   const entries = Object.entries(headersObj)
+  
+  // Create a set of lowercase header names for case-insensitive matching
+  const interestingHeadersSet = new Set(INTERESTING_HEADERS.map(h => h.toLowerCase()))
+  
   for (const [key, val] of entries) {
+    const lowerKey = key.toLowerCase()
+    
+    // Only include headers that are in our whitelist or start with x-vtex-
+    if (!interestingHeadersSet.has(lowerKey) && !lowerKey.startsWith('x-vtex-')) {
+      continue
+    }
+    
     // Most of the time val is a string, but there are some cases, for example when we do a axios interceptor,
     // that a header field can contain an object, for example:
     // ```


### PR DESCRIPTION
# Description

As of now, when adding traces in the VTEX IO node apps, we include all the headers from the request and responses, as we can see in the previous version of `cloneAndSanitizeHeaders`, this makes us to add too many information for our spans reaching limits of columns in our databases.

So this pull request adds a whitelist of headers that will be added to the span that actually brings meaningful o11y.

# Testing
- [x] Release a beta version
- [x] Upload to a testing cluster
- [x] Update image of the runtime with the beta version
- [x] Call apps forcing the trace and check if spans are created