### PR TITLE
Always stringify logs to console

### DIFF
--- a/src/service/logger/logger.ts
+++ b/src/service/logger/logger.ts
@@ -124,6 +124,6 @@ export class Logger {
       }
     }
 
-    console.log(typeof inflatedLog === 'string' ? JSON.stringify(inflatedLog) : inflatedLog)
+    console.log(JSON.stringify(inflatedLog))
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change how we write logs to the standard output

#### What problem is this solving?

Userland logs that cannot appear in the o11y tools

#### How should this be manually tested?

Use the onsite demo to make logged requests:
https://onsite--vtexgame1.myvtex.com/onsite-demo
Check opensearch's index `io_3p_logs` for logs in the format `receivedTitle`

#### Screenshots or example usage

None

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
