### PR TITLE
Public graphql directive

### DIFF
--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/Public.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/Public.ts
@@ -1,0 +1,9 @@
+import { SchemaDirectiveVisitor } from "graphql-tools"
+
+export class Public extends SchemaDirectiveVisitor {
+}
+
+export const publicDirectiveTypeDefs = `
+directive @public(
+) on FIELD_DEFINITION
+`

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/Public.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/Public.ts
@@ -1,9 +1,14 @@
+import { defaultFieldResolver, GraphQLField } from "graphql";
 import { SchemaDirectiveVisitor } from "graphql-tools"
 
 export class Public extends SchemaDirectiveVisitor {
+  visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field;
+
+    field.resolve = async function (...args) {
+      return resolve.apply(this, args);
+    };
+  }
 }
 
-export const publicDirectiveTypeDefs = `
-directive @public(
-) on FIELD_DEFINITION
-`
+export const publicDirectiveTypeDefs = `directive @public on FIELD_DEFINITION`

--- a/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
+++ b/src/service/worker/runtime/graphql/schema/schemaDirectives/index.ts
@@ -2,6 +2,7 @@ import { Auth, authDirectiveTypeDefs } from './Auth'
 import { CacheControl, cacheControlDirectiveTypeDefs } from './CacheControl'
 import { Deprecated, deprecatedDirectiveTypeDefs } from './Deprecated'
 import { Metric, metricDirectiveTypeDefs } from './Metric'
+import { Public, publicDirectiveTypeDefs } from './Public'
 import { SanitizeDirective, sanitizeDirectiveTypeDefs } from './Sanitize'
 import { SettingsDirective, settingsDirectiveTypeDefs } from './Settings'
 import { SmartCacheDirective, smartCacheDirectiveTypeDefs } from './SmartCacheDirective'
@@ -20,6 +21,7 @@ export const nativeSchemaDirectives = {
   smartcache: SmartCacheDirective,
   translatableV2: TranslatableV2,
   translateTo: TranslateTo,
+  public: Public
 }
 
 export const nativeSchemaDirectivesTypeDefs = [
@@ -32,4 +34,5 @@ export const nativeSchemaDirectivesTypeDefs = [
   smartCacheDirectiveTypeDefs,
   translatableV2DirectiveTypeDefs,
   translateToDirectiveTypeDefs,
+  publicDirectiveTypeDefs
 ].join('\n\n')


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create a new graphql directive in order to allow define a query or mutation as public.

#### What problem is this solving?
This directive was created to solve a security vulnerability caused by we don't have a way to sinalize that the route is public. So basically if there is no Auth directive, the default is consider the field as public.

#### How should this be manually tested?
- Link node-vtex-api with yarn
- Link node-vtex-api into a graphql app
- Try to use the public directive

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
