### PR TITLE
Release v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [7.0.0] - 2025-07-25
+### Changed
+- Version created to keep track of Runtime 7-compatible implementation of this lib
+
 ## [6.49.6] - 2025-07-25
 ### Changed
 - Bump `@vtex/diagnostics-nodejs` version
@@ -1872,7 +1876,7 @@ instead
 - `HttpClient` now adds `'Accept-Encoding': 'gzip'` header by default.
 
 
-[Unreleased]: https://github.com/vtex/node-vtex-api/compare/v6.48.1-beta.4...HEAD
+[7.0.0]: https://github.com/vtex/node-vtex-api/compare/v7.0.0...v6.49.6
 [6.45.15]: https://github.com/vtex/node-vtex-api/compare/v6.45.14...v6.45.15
 [6.45.14]: https://github.com/vtex/node-vtex-api/compare/v6.45.13...v6.45.14
 [6.45.13]: https://github.com/vtex/node-vtex-api/compare/v6.45.12...v6.45.13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.49.6",
+  "version": "7.0.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Tag the `@vtex/api` version with Axios vuln fix with the 7.x major.

#### What problem is this solving?

This organizes releases between VTEX IO NodeJS runtimes since the fix introduced a breaking change in runtime 6.x

#### How should this be manually tested?

No need

#### Screenshots or example usage

None

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
