### PR TITLE
fix: separate console and diagnostics client logging formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "7.2.2",
+  "version": "7.2.3-beta.0",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/logger/logger.ts
+++ b/src/service/logger/logger.ts
@@ -79,17 +79,21 @@ export class Logger {
     cleanLog(data)
 
     /* tslint:disable:object-literal-sort-keys */
-    const inflatedLog = {
+    const commonLogFields = {
       __VTEX_IO_LOG: true,
       level,
+      operationId: this.operationId,
+      requestId: this.requestId,
+      ... (this.tracingState?.isTraceSampled ? { traceId: this.tracingState.traceId } : null),
+    }
+
+    const inflatedLog = {
       app,
       account: this.account,
       workspace: this.workspace,
       production: this.production,
-      operationId: this.operationId,
-      requestId: this.requestId,
       data,
-      ... (this.tracingState?.isTraceSampled ? { traceId: this.tracingState.traceId } : null),
+      ...commonLogFields,
     }
 
     // Mark third-party apps logs to send to skidder
@@ -103,17 +107,12 @@ export class Logger {
     console.log(JSON.stringify(inflatedLog))
 
     const diagnosticsLog = {
-      __VTEX_IO_LOG: true,
-      level,
       [AttributeKeys.VTEX_IO_APP_ID]: app,
       [AttributeKeys.VTEX_ACCOUNT_NAME]: this.account,
       [AttributeKeys.VTEX_IO_WORKSPACE_NAME]: this.workspace,
       [AttributeKeys.VTEX_IO_WORKSPACE_TYPE]: this.production ? 'production' : 'development',
       [AttributeKeys.VTEX_IO_APP_AUTHOR_TYPE]: APP.IS_THIRD_PARTY() ? '3p' : '1p',
-      operationId: this.operationId,
-      requestId: this.requestId,
-      data,
-      ... (this.tracingState?.isTraceSampled ? { traceId: this.tracingState.traceId } : null),
+      ...commonLogFields,
     }
 
     if (this.logClient) {

--- a/src/service/logger/logger.ts
+++ b/src/service/logger/logger.ts
@@ -82,11 +82,10 @@ export class Logger {
     const inflatedLog = {
       __VTEX_IO_LOG: true,
       level,
-      [AttributeKeys.VTEX_IO_APP_ID]: app,
-      [AttributeKeys.VTEX_ACCOUNT_NAME]: this.account,
-      [AttributeKeys.VTEX_IO_WORKSPACE_NAME]: this.workspace,
-      [AttributeKeys.VTEX_IO_WORKSPACE_TYPE]: this.production ? 'production' : 'development',
-      [AttributeKeys.VTEX_IO_APP_AUTHOR_TYPE]: APP.IS_THIRD_PARTY() ? '3p' : '1p',
+      app,
+      account: this.account,
+      workspace: this.workspace,
+      production: this.production,
       operationId: this.operationId,
       requestId: this.requestId,
       data,
@@ -101,30 +100,45 @@ export class Logger {
       });
     }
 
+    console.log(JSON.stringify(inflatedLog))
+
+    const diagnosticsLog = {
+      __VTEX_IO_LOG: true,
+      level,
+      [AttributeKeys.VTEX_IO_APP_ID]: app,
+      [AttributeKeys.VTEX_ACCOUNT_NAME]: this.account,
+      [AttributeKeys.VTEX_IO_WORKSPACE_NAME]: this.workspace,
+      [AttributeKeys.VTEX_IO_WORKSPACE_TYPE]: this.production ? 'production' : 'development',
+      [AttributeKeys.VTEX_IO_APP_AUTHOR_TYPE]: APP.IS_THIRD_PARTY() ? '3p' : '1p',
+      operationId: this.operationId,
+      requestId: this.requestId,
+      data,
+      ... (this.tracingState?.isTraceSampled ? { traceId: this.tracingState.traceId } : null),
+    }
+
     if (this.logClient) {
       try {
         let logMessage = typeof data === 'string' ? data : JSON.stringify(data)
         switch (level) {
           case LogLevel.Debug:
-            this.logClient.debug(logMessage, inflatedLog);
+            this.logClient.debug(logMessage, diagnosticsLog);
             break;
           case LogLevel.Info:
-            this.logClient.info(logMessage, inflatedLog);
+            this.logClient.info(logMessage, diagnosticsLog);
             break;
           case LogLevel.Warn:
-            this.logClient.warn(logMessage, inflatedLog);
+            this.logClient.warn(logMessage, diagnosticsLog);
             break;
           case LogLevel.Error:
-            this.logClient.error(logMessage, inflatedLog);
+            this.logClient.error(logMessage, diagnosticsLog);
             break;
           default:
-            this.logClient.info(logMessage, inflatedLog);
+            this.logClient.info(logMessage, diagnosticsLog);
         }
       } catch (e) {
         console.error('Error using diagnostics client for logging:', e);
       }
     }
 
-    console.log(JSON.stringify(inflatedLog))
   }
 }

--- a/src/service/metrics/otelRequestMetricsMiddleware.ts
+++ b/src/service/metrics/otelRequestMetricsMiddleware.ts
@@ -52,7 +52,10 @@ export const addOtelRequestMetricsMiddleware = () => {
       if (responseLength && instruments) {
         instruments.responseSizes.record(
           responseLength,
-          { [RequestsMetricLabels.REQUEST_HANDLER]: ctx.requestHandlerName }
+          {
+            [RequestsMetricLabels.REQUEST_HANDLER]: ctx.requestHandlerName,
+            [RequestsMetricLabels.STATUS_CODE]: ctx.response.status,
+          }
         )
       }
 
@@ -72,6 +75,7 @@ export const addOtelRequestMetricsMiddleware = () => {
             hrToMillisFloat(process.hrtime(start)),
             {
               [RequestsMetricLabels.REQUEST_HANDLER]: ctx.requestHandlerName,
+              [RequestsMetricLabels.STATUS_CODE]: ctx.response.status,
             }
           )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->
This PR fixes wrong mapping for some attributes, leading to fluent-bit being unable to create some attributes on OpenSearch, even though logs objects were being sent.

#### What problem is this solving?
#579 introduced a small bug in log attribute mapping. Attributes like "account," "workspace," and "appId" were present in the object exported to stdout but weren't being mapped correctly in the OpenSearch attributes view. An [example](https://developer.logs.vtex.com/_dashboards/goto/ad14fec4769c3029155f3083fad2407d?security_tenant=global) is the image below, where we see a gap in the number of logs when filtering by one of the attributes with the affected mapping (you can also see that the issue was reversed after the rollback).

<img width="1355" height="348" alt="image" src="https://github.com/user-attachments/assets/a0e80c91-8daf-4ea6-9828-0cae73bbbb17" />

This issue was resolved by separating the object exported to stdout and logged to OpenSearch from the object logged by the diagnostics library client.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
