### PR TITLE
chore: enable SonarQube coverage and PR decoration

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -8,10 +8,13 @@
           nodeVersion: "22-bookworm"
           packageManager: yarn
           skipInstall: false
+          sonarProjectName: node-vtex-api
           nodeCommands:
             - lint
             - ci:test
         when:
+          - event: pull_request
+            source: branch
           - event: push
             source: branch
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format-lint": "yarn format && yarn lint",
     "prepublishOnly": "bash ./scripts/publishLock.sh",
     "ci:build": "yarn build && yarn gen",
-    "ci:test": "yarn test --ci",
+    "ci:test": "yarn test --ci --coverage",
     "ci:prettier-check": "prettier --check --config ./.prettierrc \"src/**/*.ts\" \"src/**/*.js\""
   },
   "jest": {


### PR DESCRIPTION
## Summary
- Add `sonarProjectName: node-vtex-api` so the SonarQube scan reports results to the dashboard
- Add `--coverage` flag to `ci:test` so Jest generates an lcov report for SonarQube
- Add `pull_request` event trigger for SonarQube PR decoration (quality gate comments on PRs)

## Context
Part of the SonarQube rollout — Phase 2 (Tier 1 coverage quick wins).

## Test plan
- [ ] Verify `node-ci-v2` pipeline runs on this PR at http://dkcicd.vtex.systems/
- [ ] Verify the sonar scan step runs successfully
- [ ] Check http://sonarqube.vtex.systems/dashboard?id=node-vtex-api for the project appearing
- [ ] Verify PR decoration (SonarQube comment on this PR)
- [ ] Verify coverage > 0%