### PR TITLE
chore: add .specify to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ yarn-error.log
 
 # AI IDE
 .cursor/
+
+# Specify
+.specify/*
+!.specify/memory/


### PR DESCRIPTION
Appends `.specify/*` and `!.specify/memory/` to `.gitignore` to ignore the Specify tool directory while preserving the memory folder.