### PR TITLE
fix: guard global.metrics in singleFlightMiddleware

### DIFF
--- a/src/HttpClient/middlewares/inflight.ts
+++ b/src/HttpClient/middlewares/inflight.ts
@@ -17,10 +17,13 @@ export const singleFlightMiddleware = async (ctx: MiddlewareContext, next: () =>
   // cancel any request
   ctx.config.cancelToken = undefined
 
-  if (!metricsAdded) {
+  // global.metrics is only initialized by startApp() in the IO service
+  // runtime. Standalone consumers of HttpClient (e.g. the toolbelt CLI)
+  // run without it, so guard the bare global reference.
+  if (!metricsAdded && typeof metrics !== 'undefined') {
     metrics.addOnFlushMetric(() => ({
       name: 'node-vtex-api-inflight-map-size',
-      size: inflight.entries.length,
+      size: inflight.size,
     }))
     metricsAdded = true
   }
@@ -41,11 +44,9 @@ export const singleFlightMiddleware = async (ctx: MiddlewareContext, next: () =>
           cacheHit: ctx.cacheHit!,
           response: ctx.response!,
         })
-      }
-      catch (err) {
+      } catch (err) {
         reject(err)
-      }
-      finally {
+      } finally {
         inflight.delete(key)
       }
     })
@@ -54,6 +55,7 @@ export const singleFlightMiddleware = async (ctx: MiddlewareContext, next: () =>
   }
 }
 
-export const inflightURL: InflightKeyGenerator = ({baseURL, url}: RequestConfig) => baseURL! + url!
+export const inflightURL: InflightKeyGenerator = ({ baseURL, url }: RequestConfig) => baseURL! + url!
 
-export const inflightUrlWithQuery: InflightKeyGenerator = ({baseURL, url, params}: RequestConfig) => baseURL! + url! + stringify(params, {arrayFormat: 'repeat', addQueryPrefix: true})
+export const inflightUrlWithQuery: InflightKeyGenerator = ({ baseURL, url, params }: RequestConfig) =>
+  baseURL! + url! + stringify(params, { arrayFormat: 'repeat', addQueryPrefix: true })

--- a/src/HttpClient/middlewares/inflight.ts
+++ b/src/HttpClient/middlewares/inflight.ts
@@ -44,9 +44,11 @@ export const singleFlightMiddleware = async (ctx: MiddlewareContext, next: () =>
           cacheHit: ctx.cacheHit!,
           response: ctx.response!,
         })
-      } catch (err) {
+      }
+      catch (err) {
         reject(err)
-      } finally {
+      }
+      finally {
         inflight.delete(key)
       }
     })
@@ -55,7 +57,6 @@ export const singleFlightMiddleware = async (ctx: MiddlewareContext, next: () =>
   }
 }
 
-export const inflightURL: InflightKeyGenerator = ({ baseURL, url }: RequestConfig) => baseURL! + url!
+export const inflightURL: InflightKeyGenerator = ({baseURL, url}: RequestConfig) => baseURL! + url!
 
-export const inflightUrlWithQuery: InflightKeyGenerator = ({ baseURL, url, params }: RequestConfig) =>
-  baseURL! + url! + stringify(params, { arrayFormat: 'repeat', addQueryPrefix: true })
+export const inflightUrlWithQuery: InflightKeyGenerator = ({baseURL, url, params}: RequestConfig) => baseURL! + url! + stringify(params, {arrayFormat: 'repeat', addQueryPrefix: true})


### PR DESCRIPTION
## What

Guards the bare `metrics` global in `singleFlightMiddleware`, and fixes the size reported by its flush metric.

## Why

Until v7, `global.metrics = new MetricsAccumulator()` was a module-load side effect of `service/Runtime.ts`, so requiring the package initialized it. In v7 that moved inside `startApp()` (`service/index.ts`), which only runs on the IO service runtime.

`singleFlightMiddleware` still references `metrics` as a bare global. Any standalone consumer of `HttpClient` — one that never boots the service runtime — therefore crashes on the first request that sets an `inflightKey`:

```
ReferenceError: metrics is not defined
    at singleFlightMiddleware (lib/HttpClient/middlewares/inflight.js:16:9)
```

This is what broke the toolbelt CLI in v4.4.2 when it bumped to `@vtex/api@7.4.0` (see [vtex/toolbelt#1276](https://github.com/vtex/toolbelt/issues/1276) and [vtex/toolbelt#1277](https://github.com/vtex/toolbelt/pull/1277)). The toolbelt PR fixes the CLI by initializing the global itself; this PR makes the library not depend on a global only its own service runtime creates, so the whole class of bug can't recur for other consumers.

Note `metricsMiddleware` already takes `metrics` as an explicit (optional) parameter and guards it — `inflight.ts` is the one place still reaching for the bare global.

## Also

```diff
-      size: inflight.entries.length,
+      size: inflight.size,
```

`entries` is a `Map` method, so `inflight.entries.length` evaluated to the function's arity (`0`) rather than the number of inflight requests. The `node-vtex-api-inflight-map-size` metric has been reporting a constant zero.

## Behavior

Inside the service runtime nothing changes: `global.metrics` is defined, the flush metric is registered as before (now with a correct size). Outside it, the middleware works and simply skips the legacy metric registration.