### PR TITLE
refactor(metrics): drop metric/status log export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "7.4.0",
+  "version": "7.4.2-beta.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -132,5 +132,6 @@
   },
   "resolutions": {
     "@grpc/grpc-js": "^1.13.4"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "7.4.2-beta.1",
+  "version": "7.4.2",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/statusTrack.ts
+++ b/src/service/worker/runtime/statusTrack.ts
@@ -1,6 +1,6 @@
 import cluster from 'cluster'
 
-import { ACCOUNT, APP, LINKED, PRODUCTION, WORKSPACE } from '../../../constants'
+import { LINKED } from '../../../constants'
 import { HttpAgentSingleton } from '../../../HttpClient/middlewares/request/HttpAgentSingleton'
 import { ServiceContext } from './typings'
 
@@ -37,24 +37,12 @@ export const trackStatus = () => {
   // Update diagnostics metrics (gauges for HTTP agent stats)
   HttpAgentSingleton.updateHttpAgentMetrics()
   
-  // Legacy status tracking (console.log export)
-  global.metrics.statusTrack().forEach(status => {
-    logStatus(status)
-  })
+  // Flushing resets the metric accumulators, the CPU usage baseline and the
+  // incoming request stats, so it must keep running even though nothing
+  // consumes the returned metrics anymore.
+  global.metrics.statusTrack()
 }
 
 export const broadcastStatusTrack = () => Object.values(cluster.workers).forEach(
   worker => worker?.send(STATUS_TRACK)
 )
-
-const logStatus = (status: EnvMetric) => console.log(JSON.stringify({
-  __VTEX_IO_LOG: true,
-  account: ACCOUNT,
-  app: APP.ID,
-  isLink: LINKED,
-  pid: process.pid,
-  production: PRODUCTION,
-  status,
-  type: 'metric/status',
-  workspace: WORKSPACE,
-}))


### PR DESCRIPTION
## Summary

- Removes the `metric/status` log line (`logStatus`) that `trackStatus()` wrote to stdout, along with the `ACCOUNT`, `APP`, `PRODUCTION` and `WORKSPACE` imports that became unused.
- Keeps the `global.metrics.statusTrack()` call even though its return value is now discarded. It delegates to `flushMetrics()`, which resets the metric accumulators, updates the CPU usage baseline and clears the incoming request stats — dropping the call would let the accumulators grow unbounded and turn the CPU/request metrics into cumulative values instead of deltas.
- The status-track flow itself is untouched: `HttpAgentSingleton.updateHttpAgentMetrics()`, the `/_status` handler and the master/worker broadcast all behave as before.

Companion change in `service-runtime-base` (branch `chore/remove-metric-status-log`) removes the equivalent log emitted by the Go runtime.

## Test plan

- [x] `yarn lint` — clean (only pre-existing warnings)
- [x] `yarn build`
- [x] `yarn test` — 11 suites, 206 tests passing

Made with [Cursor](https://cursor.com)