### PR TITLE
refactor(metrics): drop metric/status log export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.51.0",
+  "version": "6.51.1-beta",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/api",
-  "version": "6.51.1-beta",
+  "version": "6.51.1",
   "description": "VTEX I/O API client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/service/worker/runtime/statusTrack.ts
+++ b/src/service/worker/runtime/statusTrack.ts
@@ -1,6 +1,6 @@
 import cluster from 'cluster'
 
-import { ACCOUNT, APP, LINKED, PRODUCTION, WORKSPACE } from '../../../constants'
+import { LINKED } from '../../../constants'
 import { ServiceContext } from './typings'
 
 export type StatusTrack = () => EnvMetric[]
@@ -33,23 +33,12 @@ export const statusTrackHandler = async (ctx: ServiceContext) => {
 }
 
 export const trackStatus = () => {
-  global.metrics.statusTrack().forEach(status => {
-    logStatus(status)
-  })
+  // Flushing resets the metric accumulators, the CPU usage baseline and the
+  // incoming request stats, so it must keep running even though nothing
+  // consumes the returned metrics anymore.
+  global.metrics.statusTrack()
 }
 
 export const broadcastStatusTrack = () => Object.values(cluster.workers).forEach(
   worker => worker?.send(STATUS_TRACK)
 )
-
-const logStatus = (status: EnvMetric) => console.log(JSON.stringify({
-  __VTEX_IO_LOG: true,
-  account: ACCOUNT,
-  app: APP.ID,
-  isLink: LINKED,
-  pid: process.pid,
-  production: PRODUCTION,
-  status,
-  type: 'metric/status',
-  workspace: WORKSPACE,
-}))


### PR DESCRIPTION
Backport of #676 to the `6.x` major.

## Summary

- Removes the `metric/status` log line (`logStatus`) that `trackStatus()` wrote to stdout, along with the `ACCOUNT`, `APP`, `PRODUCTION` and `WORKSPACE` imports that became unused.
- Keeps the `global.metrics.statusTrack()` call even though its return value is now discarded. It delegates to `flushMetrics()`, which resets the metric accumulators, updates the CPU usage baseline and clears the incoming request stats — dropping the call would let the accumulators grow unbounded and turn the CPU/request metrics into cumulative values instead of deltas.
- The status-track flow itself is untouched: the `/_status` handler and the master/worker broadcast behave as before.

Difference from #676: on `6.x`, `trackStatus()` has no `HttpAgentSingleton.updateHttpAgentMetrics()` call, so after removing the log it contains only the `statusTrack()` flush.

## Test plan

- [x] `yarn build` (tsc) — clean
- [x] `yarn lint` — 228 errors, identical to the untouched `6.x` baseline; none in `statusTrack.ts`. These come from noisy rules in `cache.ts`/`axios.d.ts` that were only downgraded to warnings on the 7.x line (4d28566a).
- [x] `yarn test` — 2 failing suites (`rateLimit.test.ts`, `axiosTracing.test.ts`) and 25 passing tests, identical to the untouched `6.x` baseline. Both failures are `@opentelemetry/exporter-logs-otlp-http` module resolution errors, unrelated to this change.

Made with [Cursor](https://cursor.com)