### PR TITLE
fix(ci): publish releases under an explicit dist-tag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -87,9 +87,23 @@ jobs:
           set -euo pipefail
 
           TARBALL=$(ls -1 *.tgz | head -n 1)
-          TAG_FLAG=""
-          if [ "${{ github.event.inputs.environment }}" = "beta" ]; then
-            TAG_FLAG="--tag beta"
+          VERSION="${{ github.event.inputs.version }}"
+          ENVIRONMENT="${{ github.event.inputs.environment }}"
+
+          if [ "${ENVIRONMENT}" = "beta" ]; then
+            TAG="beta"
+          else
+            # The version input carries the git tag name, so it may be prefixed with "v".
+            MAJOR="${VERSION%%.*}"
+            MAJOR="${MAJOR#v}"
+            # npm refuses to implicitly move "latest" backwards, so majors below the
+            # current one publish under their own dist-tag instead.
+            if [ "${MAJOR}" -ge 7 ]; then
+              TAG="latest"
+            else
+              TAG="v${MAJOR}-latest"
+            fi
           fi
-          echo "Publishing ${TARBALL} to npmjs..."
-          npm publish "${TARBALL}" --provenance --access public ${TAG_FLAG}
+
+          echo "Publishing ${TARBALL} to npmjs with tag ${TAG}..."
+          npm publish "${TARBALL}" --provenance --access public --tag "${TAG}"


### PR DESCRIPTION
## Problem

The `v6.51.1` release never reached npm. The publish workflow ran ([run 31034142378](https://github.com/vtex/node-vtex-api/actions/runs/31034142378)), pulled `vtex-api-6.51.1.tgz` from CodeArtifact, and then failed on the last step:

```
npm error Cannot implicitly apply the "latest" tag because previously published version 7.4.2
is higher than the new version 6.51.1. You must specify a tag using --tag.
```

The publish step only passed `--tag` for the `beta` environment:

```bash
TAG_FLAG=""
if [ "${{ github.event.inputs.environment }}" = "beta" ]; then
  TAG_FLAG="--tag beta"
fi
npm publish "${TARBALL}" --provenance --access public ${TAG_FLAG}
```

For `production` it passed no tag at all, so npm tried to move `latest` from 7.4.2 down to 6.51.1 and refused. This is why `v6.51.1-beta` published fine while `v6.51.1` did not — the beta path always had an explicit tag, so it never exercised the bug. It is also why the 7.x line has never hit this: for `v7.4.2` the implicit `latest` is correct, since it is the highest published version.

Note that `lint` and `ci:test` failing on `6.x` are unrelated to this. Those come from the `node-ci-v2` pipeline, which `.vtex/deployment.yaml` triggers on branch pushes; tag pushes run `npm-publish-v1`, which only executes `ci:build`.

## Change

The publish step now always resolves an explicit dist-tag: `beta` for the beta environment, `latest` for major >= 7, and `v{major}-latest` otherwise. The leading `v` from the git tag name is stripped before the comparison, so both `v6.51.1` and `6.51.1` resolve identically.

This is a port of the logic in `ee2b88c7` ("fixing ci by adding custom latest tags"), which only ever lived on `julio/fix-npm-publish-ci` and was never merged into `6.x` or `master`. One difference: that version did not strip the `v`, so `MAJOR` became `v6`, the numeric comparison errored out, and the tag came out as `vv6-latest` — which is why that odd dist-tag currently holds `6.51.0` on npm.

## Follow-ups

- `master` carries the same old script. It works today only because 7.x is the highest major, so the same fix should be ported there for consistency.
- Existing npm dist-tags for this package are `v1-latest`, `v3-latest` and the accidental `vv6-latest`. With this change the v6 line publishes to `v6-latest`. Whoever tracks `vv6-latest` would stay on 6.51.0, so that tag should either be re-pointed (`npm dist-tag add @vtex/api@6.51.1 vv6-latest`) or deprecated.

## Test plan

- [x] YAML parses (6 steps in the `publish` job)
- [x] Tag resolution verified for `v6.51.1`/`6.51.1` -> `v6-latest`, `v7.4.2`/`7.4.2` -> `latest`, `v10.0.0` -> `latest`, and any version with `environment=beta` -> `beta`
- [ ] Cut a new tag off `6.x` after merge and confirm the publish lands on `v6-latest`

Made with [Cursor](https://cursor.com)